### PR TITLE
ci: lint + unit tests on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - run: ruff check src tests
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e . --group dev
+      - run: python -m pytest tests/unit -q


### PR DESCRIPTION
GitHub Actions: ruff lint + pytest tests/unit on ubuntu-latest, on every PR and main push. CPU-only per plan; GPU/e2e CI is a separate follow-up on self-hosted runners.

This PR also live-tests the DCO check and the branch ruleset on the new repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)