### PR TITLE
fix: declare the distribution as nvidia-kvcr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = ["hatchling>=1.27,<2"]
 build-backend = "hatchling.build"
 
 [project]
-name = "kvcr"
+name = "nvidia-kvcr"
 version = "0.1.0"
 description = "Framework-neutral KV Cache Runner"
 readme = "README.md"


### PR DESCRIPTION
Fixes #4

`pyproject.toml` declared `name = "kvcr"`, while every other reference in the repository names the distribution `nvidia-kvcr`. `docs/dev-guide.md` states the contract explicitly:

> The distribution name is `nvidia-kvcr`, the Python import is `kvcr`

This one-line rename makes the metadata match. The import package stays `kvcr`, since `[tool.hatch.build.targets.wheel]` keeps packaging `src/kvcr`.

## Why it matters

The documented quick-start build fails without it — `Dockerfile.quick-start`\x27s compatibility canary looks the distribution up by name:

```
importlib.metadata.PackageNotFoundError: No package metadata was found for nvidia-kvcr
```

It also unbreaks the verification snippets at `docs/dev-guide.md` lines 164, 192 and 508, and makes the wheel filename match `docs/dev-guide.md:126`.

## Verification

With this change the quick-start image builds and its canary passes end to end:

```
ai-dynamo==1.5.0
vllm==0.27.2rc1.dev122+g8efa13b70
nvidia-kvcr==0.1.0
nixl==1.3.2
nvidia-nccl-cu13==2.30.7
```

`ruff check src tests` passes. `pytest tests/unit` is unchanged from `main` on this host (152 passed; the 15 failures are pre-existing and environmental — `SO_PEERPIDFD` needs Linux 6.5+ and this host runs 5.15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)