### PR TITLE
fix: give progress startup its own timeout budget

### DIFF
--- a/src/kvcr/progress.py
+++ b/src/kvcr/progress.py
@@ -21,6 +21,12 @@ logger = logging.getLogger(__name__)
 _IDLE_WAIT_SECONDS = 0.001
 _CLOSE_TIMEOUT_SECONDS = 5.0
 _JOIN_TIMEOUT_SECONDS = 10.0
+# Cold start is not the same kind of wait as a join: it covers NIXL agent
+# creation, backend setup, and memory registration, none of which are bounded
+# by anything KVCR controls. UCX enumerates every network device during
+# `ucp_init`, and ranks sharing a node pay that cost concurrently, so this is
+# a liveness backstop rather than a performance target.
+_STARTUP_TIMEOUT_SECONDS = 30.0
 _RELEASE_LOG_INTERVAL_SECONDS = 1.0
 _STOP = object()
 _OpId = tuple[str, Any]
@@ -106,6 +112,9 @@ class _KVCRProgress:
         )
         self._failure: BaseException | None = None
         self._stop_requested = False
+        # Written by the progress thread, read by start() on timeout, so the
+        # error names the stage that is actually slow.
+        self._startup_phase = "thread startup"
 
     @property
     def nixl_agent(self) -> Any:
@@ -254,8 +263,12 @@ class _KVCRProgress:
 
     def start(self) -> None:
         self._thread.start()
-        if not self._ready.wait(timeout=_JOIN_TIMEOUT_SECONDS):
-            raise RuntimeError("KVCR progress thread did not start")
+        if not self._ready.wait(timeout=_STARTUP_TIMEOUT_SECONDS):
+            raise RuntimeError(
+                "KVCR progress thread did not finish startup within "
+                f"{_STARTUP_TIMEOUT_SECONDS:g}s; it is still in "
+                f"{self._startup_phase!r}"
+            )
         self.raise_if_failed()
 
     def submit(self, item: object) -> None:
@@ -300,12 +313,17 @@ class _KVCRProgress:
 
     def _run(self) -> None:
         try:
+            self._startup_phase = "NIXL agent initialization"
             self._initialize_nixl()
             # Let KVCR backends initialize NIXL resources before common
             # memory registration.
+            self._startup_phase = "backend initialization"
             self._initialize(self)
+            self._startup_phase = "memory registration"
             self._register_memory_regions()
+            self._startup_phase = "agent metadata capture"
             self._capture_agent_metadata()
+            self._startup_phase = "ready"
             self._ready.set()
             while not self._stop_requested:
                 if not self._run_one_iteration():

--- a/tests/unit/test_kvcr.py
+++ b/tests/unit/test_kvcr.py
@@ -102,12 +102,19 @@ def test_startup_timeout_retains_nonquiescent_resources(
     )
     monkeypatch.setattr(kvcr_api, "_KVCRCore", create_core)
     monkeypatch.setattr(kvcr_api, "_NONQUIESCENT_STARTUP_RESOURCES", retained)
+    monkeypatch.setattr(kvcr_progress, "_STARTUP_TIMEOUT_SECONDS", 0)
+    # The agent stays blocked until the assertions below finish, so close()
+    # must not spend its full join budget waiting for a thread parked on
+    # purpose.
     monkeypatch.setattr(kvcr_progress, "_JOIN_TIMEOUT_SECONDS", 0)
     monkeypatch.setattr(kvcr_progress, "nixl_agent", create_agent)
     monkeypatch.setattr(kvcr_progress, "nixl_agent_config", lambda **kwargs: kwargs)
 
     try:
-        with pytest.raises(RuntimeError, match="progress thread did not start"):
+        with pytest.raises(
+            RuntimeError,
+            match="did not finish startup .*'NIXL agent initialization'",
+        ):
             KVCR(
                 KVCRConfig(nixl_agent_name="target", nixl_listen_port=1),
                 KVCRBindings(Mock(), Mock(), Mock()),


### PR DESCRIPTION
Fixes #5

`start()` waited `_JOIN_TIMEOUT_SECONDS` (10s) for the progress thread to become ready. That constant describes how long `close()` should wait for a thread to *join*; reusing it as a cold-start budget conflates two unrelated waits.

## Changes

- Add `_STARTUP_TIMEOUT_SECONDS` (30s) for the readiness wait, leaving `_JOIN_TIMEOUT_SECONDS` to mean what its name says.
- Track the startup stage so a genuine hang names it instead of claiming the thread never started.

No `KVCRConfig` field, deliberately — that is public API and would have to be threaded through the vLLM adapter in vllm-project/vllm#53624. This keeps the change to zero API surface.

## Measurements

Startup is not bounded by anything KVCR controls. UCX enumerates every network device inside `ucp_init`, so NIXL agent creation scales with the host, and ranks sharing a node pay that cost concurrently. `nixl_agent()` alone, measured in the quick-start image:

| configuration | `nixl_agent()` |
| --- | --- |
| bridge network (2 interfaces), 1 agent | 1.66 – 1.74s |
| host network (~220 `veth` interfaces), 1 agent | 11.8 – 14.6s |
| host network, 2 agents concurrent | 10.3 – 11.0s |
| host network, 4 agents concurrent | 22.0 – 24.2s |
| host network, 8 agents concurrent | **35.5 – 41.0s** |

Memory registration is not a factor — UCX defers it, and registering 32GB measured under 10ms.

Both vLLM data-parallel ranks failed with `RuntimeError: KVCR progress thread did not start`, ~23s before the agent actually came up. `docs/quick-start.md` requires `--network host`, which is exactly the configuration that exposes every interface.

## On the choice of 30s

30s is a deliberately conservative 3x increase over the current 10s. It covers the observed failure (23s) and the measured 1–4 rank cases.

**It does not cover 8 ranks initializing concurrently on one node**, which measured 35–41s — an ordinary shape on an 8-GPU box. That case wants either a larger budget or a configurable one. It is left for a follow-up so this change stays a minimal fix with no public API surface; reviewers who would rather raise the constant now should say so and I will adjust.

A complementary option, not included here: periodic progress logging during startup, so a slow-but-healthy start is visible rather than silent. The stage tracking added here is the hook for it.

## Test change

`test_startup_timeout_retains_nonquiescent_resources` asserted the old message and forced the timeout by patching `_JOIN_TIMEOUT_SECONDS`. It now patches the startup budget, and asserts the reported stage so the new phase tracking is covered.

It also keeps patching `_JOIN_TIMEOUT_SECONDS`. That is load-bearing: the test parks the agent on purpose, so without it `close()` spends its full join budget waiting for a thread that will not move, adding 20s to the suite.

## Verification

`ruff check src tests` passes. `pytest tests/unit` matches `main` exactly — 152 passed, 14.5s, same 15 pre-existing environmental failures (`SO_PEERPIDFD` needs Linux 6.5+, this host runs 5.15; CI runners are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
