### PR TITLE
core: stop allocating an empty set per block record

### DIFF
--- a/src/kvcr/core.py
+++ b/src/kvcr/core.py
@@ -6,7 +6,7 @@ import functools
 import logging
 import time
 from collections.abc import Callable, Collection, Iterable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from math import ceil
 from typing import TYPE_CHECKING
 
@@ -72,16 +72,35 @@ def _noop_record_transfer(
     return None
 
 
-@dataclass
+@dataclass(slots=True)
 class _BlockRecord:
     # Locally pinned framework-owned G2 memory. This is never remote
     # KVCR residency and exists only while KVCR controls the pin.
     fw_mem: "_FwMemResidency | None" = None
     local_dram: _LocalDramResidency | None = None
     g3: _G3Residency | None = None
-    in_flight_ops: set[_OpId] = field(default_factory=set)
+    in_flight_ops: set[_OpId] | None = None
     access_count: int = 0
     last_access: float | None = None
+
+    def add_in_flight_op(self, op_id: _OpId) -> None:
+        if self.in_flight_ops is None:
+            self.in_flight_ops = {op_id}
+        else:
+            self.in_flight_ops.add(op_id)
+
+    def discard_in_flight_op(self, op_id: _OpId) -> None:
+        ops = self.in_flight_ops
+        if ops is not None:
+            ops.discard(op_id)
+            if not ops:
+                self.in_flight_ops = None
+
+    @property
+    def active_op_ids(self) -> tuple[_OpId, ...]:
+        """Snapshot of in-flight op ids, safe to iterate while mutating."""
+        ops = self.in_flight_ops
+        return () if ops is None else tuple(ops)
 
 
 class _KVCRCore:
@@ -564,14 +583,14 @@ class _KVCRCore:
         if new_operation:
             self._outstanding_operations += 1
         for key in op.keys:
-            self._block_record(key).in_flight_ops.add(op.op_id)
+            self._block_record(key).add_in_flight_op(op.op_id)
 
     def _remove_block_dependencies(self, op: _Op) -> None:
         self._outstanding_operations -= 1
         for key in op.keys:
             record = self._block_record_map.get(key)
             if record is not None:
-                record.in_flight_ops.discard(op.op_id)
+                record.discard_in_flight_op(op.op_id)
                 self._prune_block_record(key)
 
     # Cross-backend DRAM coordination.

--- a/src/kvcr/local_disk.py
+++ b/src/kvcr/local_disk.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(slots=True)
 class _G3Residency:
     slot: int
     claim_count: int = 0
@@ -486,7 +486,7 @@ class _G3:
             residency = record.g3 if record is not None else None
             if record is None or residency is None or residency.claim_count:
                 raise RuntimeError(f"invalid G3 eviction candidate {key!r}")
-            if any(op_id[0] == "fetch" for op_id in record.in_flight_ops):
+            if any(op_id[0] == "fetch" for op_id in record.in_flight_ops or ()):
                 skipped.add(key)
                 continue
             decision = self._kvcr._policy.decide_eviction(

--- a/src/kvcr/local_dram.py
+++ b/src/kvcr/local_dram.py
@@ -38,7 +38,7 @@ class _LocalDramState(Enum):
     DISCARDING = auto()
 
 
-@dataclass
+@dataclass(slots=True)
 class _LocalDramResidency:
     slot: int
     state: _LocalDramState
@@ -448,7 +448,7 @@ class _LocalDram:
             ):
                 raise RuntimeError(f"local DRAM fill state lost for {key!r}")
             residency.state = _LocalDramState.DISCARDING
-            for op_id in tuple(record.in_flight_ops):
+            for op_id in record.active_op_ids:
                 residency_op = self._pending_residency_ops.get(op_id)
                 if (
                     residency_op is not None
@@ -540,7 +540,7 @@ class _LocalDram:
                 record.local_dram = None
                 self._free_slots.append(slot)
 
-            for op_id in tuple(record.in_flight_ops):
+            for op_id in record.active_op_ids:
                 residency_op = self._pending_residency_ops.get(op_id)
                 if residency_op is not None and key in residency_op.keys:
                     if success and (

--- a/src/kvcr/remote_fw_dram.py
+++ b/src/kvcr/remote_fw_dram.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 _MEM_DESCRIPTORS_TYPE = tuple[MemDescriptor, ...]
 
 
-@dataclass
+@dataclass(slots=True)
 class _FwMemResidency:
     descriptor: MemDescriptor
     pin_handle: PinHandle

--- a/tests/unit/_kvcr_test_utils.py
+++ b/tests/unit/_kvcr_test_utils.py
@@ -117,7 +117,7 @@ def _block_op_ids(kvcr: KVCR) -> set[tuple[str, Any]]:
     return {
         op_id
         for record in kvcr._core._block_record_map.values()
-        for op_id in record.in_flight_ops
+        for op_id in record.active_op_ids
     }
 
 

--- a/tests/unit/test_kvcr.py
+++ b/tests/unit/test_kvcr.py
@@ -15,6 +15,7 @@ from _kvcr_test_utils import (
     FakeNixlAgent,
     FakePrimaryPinning,
     FakeTelemetryStats,
+    _mem_descriptor,
     _new_kvcr,
 )
 
@@ -28,6 +29,10 @@ from kvcr.config import (
     KVCRGuardConfig,
     LocalDramInfo,
 )
+from kvcr.core import _BlockRecord
+from kvcr.local_disk import _G3Residency
+from kvcr.local_dram import _LocalDramResidency, _LocalDramState
+from kvcr.remote_fw_dram import _FwMemResidency
 
 _GUARD_CONFIG = KVCRGuardConfig(
     kvcr_service_socket_path="/tmp/kvcr.sock",
@@ -289,3 +294,43 @@ def test_close_preserves_backends_when_progress_is_not_quiescent(
         with pytest.raises(RuntimeError, match=expected):
             kvcr.close()
     assert cleaned == []
+
+
+def test_block_record_holds_no_set_while_no_operation_is_in_flight() -> None:
+    """Pin the storage, not just the behaviour.
+
+    Every observable use of these helpers behaves identically if the empty set
+    is kept instead of dropped, so only an explicit check keeps the record from
+    quietly growing an allocation per resident block again.
+    """
+    record = _BlockRecord()
+    assert record.in_flight_ops is None
+    assert record.active_op_ids == ()
+
+    record.discard_in_flight_op(("target", 1))
+    assert record.in_flight_ops is None
+
+    record.add_in_flight_op(("target", 1))
+    record.add_in_flight_op(("source", 2))
+    assert record.in_flight_ops == {("target", 1), ("source", 2)}
+
+    # The snapshot is what lets a caller retire ops while iterating.
+    snapshot = record.active_op_ids
+    record.discard_in_flight_op(("target", 1))
+    assert set(snapshot) == {("target", 1), ("source", 2)}
+    assert record.in_flight_ops == {("source", 2)}
+
+    record.discard_in_flight_op(("source", 2))
+    assert record.in_flight_ops is None
+    assert record.active_op_ids == ()
+
+
+def test_resident_records_carry_no_instance_dictionary() -> None:
+    """Every record a resident block can hold, so none of them grows one back."""
+    for residency in (
+        _BlockRecord(),
+        _LocalDramResidency(0, _LocalDramState.READY),
+        _G3Residency(0),
+        _FwMemResidency(_mem_descriptor(), object()),
+    ):
+        assert not hasattr(residency, "__dict__"), type(residency).__name__


### PR DESCRIPTION
## Problem

Every `_BlockRecord` eagerly built an `in_flight_ops` set. CPython inlines an 8-entry smalltable in `PySetObject`, so an **empty** set costs ~216 bytes, flat from 0 to 4 entries. Most resident blocks have no operation in flight, making that empty set the largest single component of a record. `None` costs 16 bytes.

## Change

- `in_flight_ops` is lazily allocated (`set[_OpId] | None = None`) and reset to `None` once it drains.
- `add_in_flight_op` / `discard_in_flight_op` keep the `None` handling in one place; `active_op_ids` returns the tuple snapshot the two `local_dram` loops already built by hand, because they mutate the set while iterating it. The one reader that only asks whether a fetch is in flight scans the set directly.
- `slots=True` on `_BlockRecord`, `_LocalDramResidency`, `_G3Residency`, `_FwMemResidency`.

**Why reset to `None`:** without it, any block that ever had a fill op keeps its set for the rest of its residency — the common lifecycle, and most of the win. Cost is one `if not ops:` on the discard path.

## Memory

`tracemalloc` over a real 200k-record map, Python 3.12.3, 32-byte keys, one G2 residency each. Measured with `tracemalloc`, not `sys.getsizeof(obj.__dict__)` — that call materializes the very dict it claims to measure on 3.11+.

| | B/record | 200k records |
|---|---|---|
| before | 512.4 | 102.5 MB |
| after | **224.4** | **44.9 MB** |

**2.28x smaller.**

## Testing

- **169 unit tests pass** (167 before, plus 2 new). Ruff clean.
- **vLLM e2e**: `test_regression_transfer.py::test_router_plan_drives_worker_b_kvcr_calls` passes — two GPUs, real Dynamo KV router, real vLLM workers, real NIXL transfer.
- The invariant was asserted after every one of the 169 tests via a teardown sweep of all live objects: 1228 records inspected, 24 legitimately mid-flight, none retaining a drained set, none carrying a `__dict__`. Verification only; not part of this PR.

`slots=True` safety was verified across `src/` and `tests/`: nothing sets undeclared attributes, takes weak references, subclasses, pickles, or reads `__dict__` on these types.

## Review notes addressed

- *Include `_FwMemResidency` in the slots regression test.* Done; mutation-verified that dropping `slots=True` from it alone fails the test.
- *`active_op_ids` allocates a snapshot in the `_allocate_slot` eviction loop, which only reads it.* That loop now scans `record.in_flight_ops or ()` directly. Mutation-verified: disabling the check fails `test_waiting_g3_fetch_source_is_not_evicted` and one other G3 test.
- *Drop the explanatory comment on the field, restore the one-line `active_op_ids` docstring, and don't add a one-caller helper.* All three done, −15 lines.

## Out of scope

Inlining residency objects into `_BlockRecord` — measured at ~40 B further, and it would touch every `record.local_dram.slot` access across three modules.
