### PR TITLE
guard: use lifecycle actor

### DIFF
--- a/src/kvcr/control_channels.py
+++ b/src/kvcr/control_channels.py
@@ -13,6 +13,7 @@ import os
 import socket
 import struct
 from array import array
+from contextlib import ExitStack
 from typing import TypeVar
 
 import msgspec
@@ -344,12 +345,20 @@ class ZmqPeerControlChannel:
         return messages
 
     def close(self) -> None:
-        for outgoing_socket in self._outgoing.values():
-            outgoing_socket.close()
-        self._outgoing.clear()
-        if self._socket is not None:
-            self._socket.close()
+        """Give up every socket, whatever any one of them does about it.
+
+        Stopping at the first failure would leave the listener behind, and with
+        it the pool's control address: bound, unreachable, and unclaimable.
+        """
+        with ExitStack() as sockets:
+            for outgoing_socket in self._outgoing.values():
+                sockets.callback(outgoing_socket.close)
+            if self._socket is not None:
+                sockets.callback(self._socket.close)
+            if self._listener is not None:
+                sockets.callback(self._listener.close)
+            # Given up before any of them is asked, so a close that raises is
+            # not one a second close has to attempt again.
+            self._outgoing = {}
             self._socket = None
-        if self._listener is not None:
-            self._listener.close()
             self._listener = None

--- a/src/kvcr/control_channels.py
+++ b/src/kvcr/control_channels.py
@@ -75,17 +75,13 @@ class FramedConnection:
         self._connection.close()
 
     def send(self, message: object) -> None:
-        frame = self._encode_frame(message)
-        self._connection.sendall(frame)
+        self._connection.sendall(self._encode_frame(message))
 
     def send_with_fd(self, message: object, file_descriptor: int) -> None:
         """Send one frame carrying one descriptor on its first byte."""
         frame = self._encode_frame(message)
         sent = socket.send_fds(self._connection, [frame], [file_descriptor])
-        if sent == 0:
-            raise EOFError
-        if sent < len(frame):
-            self._connection.sendall(frame[sent:])
+        self._connection.sendall(frame[sent:])
 
     @staticmethod
     def _encode_frame(message: object) -> bytes:
@@ -112,16 +108,15 @@ class FramedConnection:
         if not header:
             raise EOFError
 
-        descriptors: list[int] = []
+        descriptors = array("i")
         try:
             unexpected_ancillary = False
             for level, kind, data in ancillary:
                 if level != socket.SOL_SOCKET or kind != socket.SCM_RIGHTS:
                     unexpected_ancillary = True
                     continue
-                received = array("i")
-                received.frombytes(data[: len(data) - len(data) % received.itemsize])
-                descriptors.extend(received)
+                size = len(data) - len(data) % descriptors.itemsize
+                descriptors.frombytes(data[:size])
             if flags & socket.MSG_CTRUNC:
                 raise KVCRMsgFramingError("truncated ancillary data")
             if unexpected_ancillary:
@@ -134,16 +129,14 @@ class FramedConnection:
                 except EOFError as error:
                     raise KVCRMsgFramingError("truncated frame") from error
             message = self._receive_after_header(header, decoder)
-            return message, descriptors.pop() if descriptors else None
+            return message, descriptors[0] if descriptors else None
         except BaseException:
             for file_descriptor in descriptors:
                 os.close(file_descriptor)
             raise
 
     def _receive_after_header(
-        self,
-        header: bytes,
-        decoder: msgspec.msgpack.Decoder[_T],
+        self, header: bytes, decoder: msgspec.msgpack.Decoder[_T]
     ) -> _T:
         (length,) = _FRAME_HEADER.unpack(header)
         if length == 0 or length > _MAX_FRAME_BYTES:
@@ -194,40 +187,15 @@ class ZmqPeerControlChannel:
         self._bind_host = bind_host
         self._bind_port = bind_port
         self._advertise_host = advertise_host
-        self._adopt_listener(
-            None,
-            f"tcp://{bind_host}:{bind_port}",
-            f"tcp://{advertise_host}:{bind_port}",
-        )
-
-    def _ensure_listener(self) -> socket.socket:
-        """Bind the configured port the first time a listener is needed."""
-        listener = self._listener
-        if listener is not None:
-            return listener
-        listener = socket.create_server((self._bind_host, self._bind_port))
-        self._listener = listener
-        return listener
-
-    def _adopt_listener(
-        self,
-        listener: socket.socket | None,
-        bind_endpoint: str,
-        endpoint: str | None,
-    ) -> None:
-        """Take ownership of a bound listener and reset per-channel socket state."""
-        self.endpoint = endpoint
-        self._bind_endpoint = bind_endpoint
-        self._listener = listener
+        self.endpoint = f"tcp://{advertise_host}:{bind_port}"
+        self._bind_endpoint = f"tcp://{bind_host}:{bind_port}"
+        self._listener = None
         self._ctx = None
         self._socket = None
         self._outgoing = {}
 
     @classmethod
-    def from_shared_listener(
-        cls,
-        listener: socket.socket,
-    ) -> "ZmqPeerControlChannel":
+    def from_shared_listener(cls, listener: socket.socket) -> "ZmqPeerControlChannel":
         """Take ownership of a pre-bound TCP listener received by the service."""
         if listener.family != socket.AF_INET:
             raise ValueError("KVCR control listener must use TCP")
@@ -235,18 +203,12 @@ class ZmqPeerControlChannel:
             raise ValueError("KVCR control listener must be a stream socket")
         if listener.getsockopt(socket.SOL_SOCKET, socket.SO_ACCEPTCONN) != 1:
             raise ValueError("KVCR control listener must already be listening")
-        address = listener.getsockname()
-        host, port = address[0], int(address[1])
-
-        # Constructed normally: __new__ alone left _bind_host and _bind_port unset.
-        channel = cls(host, port, host)
+        host, port = listener.getsockname()[:2]
+        channel = cls(host, int(port), host)
+        channel.adopt_listener(listener.detach())
         # The service cannot reconstruct the primary's advertised host; the
         # Guard replies using routes reflected in incoming requests.
-        channel._adopt_listener(
-            socket.socket(fileno=listener.detach()),
-            f"tcp://{host}:{port}",
-            None,
-        )
+        channel.endpoint = None
         return channel
 
     def control_bind_address(self) -> tuple[str, int]:
@@ -264,33 +226,25 @@ class ZmqPeerControlChannel:
         listener = socket.socket(fileno=listener_fd)
         try:
             host, port = listener.getsockname()[:2]
-            port = int(port)
         except BaseException:
             # Detached, not closed: the hold owns this descriptor until the
             # adoption returns, and closes it on release; closing here would
             # have the release double-close it.
             listener.detach()
             raise
-        self._adopt_listener(
-            listener,
-            f"tcp://{host}:{port}",
-            f"tcp://{self._advertise_host}:{port}",
-        )
+        self._listener = listener
+        self._bind_endpoint = f"tcp://{host}:{int(port)}"
+        self.endpoint = f"tcp://{self._advertise_host}:{int(port)}"
 
     def initialize(self) -> None:
-        listener = self._ensure_listener()
+        if self._listener is None:
+            self._listener = socket.create_server((self._bind_host, self._bind_port))
         self._ctx = zmq.Context.instance()
         self._socket = self._ctx.socket(zmq.PULL)
         self._socket.linger = 0
-        adopted_fd = os.dup(listener.fileno())
+        adopted_fd = os.dup(self._listener.fileno())
         try:
             self._socket.setsockopt(zmq.USE_FD, adopted_fd)
-        except BaseException:
-            os.close(adopted_fd)
-            self._socket.close()
-            self._socket = None
-            raise
-        try:
             self._socket.bind(self._bind_endpoint)
         except BaseException:
             # libzmq takes the descriptor at bind, so one that failed to bind
@@ -347,18 +301,13 @@ class ZmqPeerControlChannel:
     def close(self) -> None:
         """Give up every socket, whatever any one of them does about it.
 
-        Stopping at the first failure would leave the listener behind, and with
-        it the pool's control address: bound, unreachable, and unclaimable.
+        A first-failure stop leaves the pool's control address bound, unclaimable.
         """
         with ExitStack() as sockets:
-            for outgoing_socket in self._outgoing.values():
-                sockets.callback(outgoing_socket.close)
-            if self._socket is not None:
-                sockets.callback(self._socket.close)
-            if self._listener is not None:
-                sockets.callback(self._listener.close)
-            # Given up before any of them is asked, so a close that raises is
-            # not one a second close has to attempt again.
+            for target in (*self._outgoing.values(), self._socket, self._listener):
+                if target is not None:
+                    sockets.callback(target.close)
+            # Dropped before any close runs: a raising close is not retried.
             self._outgoing = {}
             self._socket = None
             self._listener = None

--- a/src/kvcr/guard.py
+++ b/src/kvcr/guard.py
@@ -8,14 +8,21 @@ violated one would surface as an AttributeError on None -- a worse message,
 never a different outcome.
 """
 
+import concurrent.futures
+import enum
 import errno
 import logging
+import os
 import queue
+import select
+import socket
 import threading
+import time
 import uuid
 from collections.abc import Callable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass, field
+from typing import Any
 
 from .api import KVCRBindings
 from .config import (
@@ -23,11 +30,16 @@ from .config import (
     KVCRConfig,
     LocalDramInfo,
 )
-from .control_channels import ZmqPeerControlChannel
+from .control_channels import KVCRServiceError, ZmqPeerControlChannel
 from .core import _BlockRecord, _KVCRCore
-from .guard_protocol import _TierConfig
+from .guard_protocol import PidfdLiveness, _TierConfig
 from .local_disk import _G3Residency
-from .memory import KVCRPoolAttachment, KVCRPoolSpec, _compute_pool_geometry
+from .memory import (
+    KVCRPoolAttachment,
+    KVCRPoolSpec,
+    _compute_pool_geometry,
+    _KVCRPoolOwner,
+)
 from .recovery_journal import (
     RecoveryJournal,
     RecoveryJournalError,
@@ -54,11 +66,48 @@ _RECOVERY_CAPACITY_ERRORS = (errno.ENOSPC, errno.EDQUOT)
 
 @dataclass
 class _Command:
+    """One request on the pool's mailbox, and the future its answer arrives on."""
+
     operation: str
-    control: ZmqPeerControlChannel | None = None
-    tier_config: "_TierConfig | None" = None
-    done: threading.Event = field(default_factory=threading.Event)
-    error: BaseException | None = None
+    args: tuple[Any, ...] = ()
+    future: "concurrent.futures.Future[Any]" = field(
+        default_factory=concurrent.futures.Future
+    )
+
+
+class _Phase(enum.Enum):
+    """Where a pool is in its life.
+
+    The first six are stable: states a pool can rest in, each naming exactly
+    which resources exist. The last three are transient reservations a command
+    holds while it runs, taken before the command is queued, so a conflicting
+    command on the same pool is refused now rather than parked behind work
+    that may outlive its caller's patience.
+    """
+
+    UNCONFIGURED = enum.auto()
+    IDLE = enum.auto()
+    STANDBY = enum.auto()
+    PRIMARY = enum.auto()
+    FAILED = enum.auto()
+    CLOSED = enum.auto()
+    CLAIMING = enum.auto()
+    RELEASING = enum.auto()
+    PROMOTING = enum.auto()
+
+
+class _Lease:
+    """One primary's exclusive hold on its pool.
+
+    Identity is the authority: a release acts only if it names THIS object, so
+    nothing stale -- a reused pid, a retried release, an old connection -- can
+    ever touch a newer lease.
+    """
+
+    __slots__ = ("liveness",)
+
+    def __init__(self, liveness: PidfdLiveness) -> None:
+        self.liveness = liveness
 
 
 def _without_g3(
@@ -133,9 +182,24 @@ class _Guard:
         failure_callback: Callable[..., None] | None = None,
         *,
         compatibility_digest: str,
+        pool_index: int = 0,
+        owner: _KVCRPoolOwner | None = None,
+        refusing: Callable[[], bool] = lambda: False,
     ) -> None:
         self._spec = spec
         self._compatibility_digest = compatibility_digest
+        self._pool_index = pool_index
+        # The pool itself, and the lease over it. Owned here rather than by the
+        # registry: one thread owns everything about one pool, so a claim needs
+        # no lock and no reservation against the next one -- the mailbox is the
+        # reservation.
+        self._owner = owner
+        self._refusing = refusing
+        self._lease: _Lease | None = None
+        self._listener: socket.socket | None = None
+        # The address as the claimant asked for it: getsockname() answers
+        # numerically and would reject every alias of the same address.
+        self._bind: tuple[str, int] | None = None
         # All of this belongs to whichever primary currently holds the pool.
         self._control: ZmqPeerControlChannel | None = None
         self._configured: _ConfiguredTier | None = None
@@ -152,12 +216,26 @@ class _Guard:
         self._closed = False
         self._serving = False
         self._resumable = False
+        # One small lock over the phase, its reservation, the lease and the
+        # failure -- never held across blocking work. It exists so a caller can
+        # reserve a transition before queueing it; the actor thread is still
+        # the only thing that runs one.
+        self._phase_lock = threading.Lock()
+        self._phase = _Phase.UNCONFIGURED
+        self._reserved: _Phase | None = None
+        self._closing = False
         self._failure: BaseException | None = None
         self._failure_callback = failure_callback or (lambda guard, error: None)
         self._attachment: KVCRPoolAttachment | None = None
         self._journal: RecoveryJournal | None = None
         self._mirror: _RecoveryMirror | None = None
         self._core: _KVCRCore | None = None
+        self._handlers: dict[str, Callable[..., Any]] = {
+            "claim": self._claim,
+            "release": self._stand_down,
+            "abort": self._abort,
+            "close": self._close,
+        }
 
     def start(self) -> None:
         """Attach the pool and begin the lifecycle thread, before any claim."""
@@ -170,68 +248,170 @@ class _Guard:
         self._prepare()
         self._thread.start()
 
-    def promote_after_death(self) -> None:
-        self._submit(_Command("promote"))
+    def claim(
+        self,
+        liveness: PidfdLiveness,
+        tier_config: _TierConfig,
+        control_bind: tuple[str, int],
+    ) -> "tuple[KVCRPoolSpec, int, _Lease]":
+        """Give this pool to a primary, with the endpoint its Guard answers on.
 
-    def adopt(self, control: ZmqPeerControlChannel, tier_config: _TierConfig) -> None:
-        """Take up a new primary, handing over whatever the last one left."""
-        command = _Command("adopt", control=control, tier_config=tier_config)
-        try:
-            self._submit(command)
-        except BaseException:
-            # _adopt closes this once the command reaches the thread. If it
-            # never got there, nothing else owns the pool listener's duplicate.
-            if not command.done.is_set():
-                control.close()
-            raise
+        The reservation is taken here, on the requesting thread, so a pool
+        mid-transition answers busy immediately instead of queueing this
+        claimant behind work that may outlive its patience.
+        """
+        self._reserve_claim()
+        return self._submit(_Command("claim", (liveness, tier_config, control_bind)))
 
-    def release(self) -> None:
-        """Let the current primary go, keeping what it left for the next one."""
-        self._submit(_Command("release"))
+    def release(self, lease: "_Lease") -> None:
+        """End a lease. The pool keeps its Guard, and the Guard its records.
 
-    def abort_grant(self) -> None:
+        A stale lease -- one a promotion or an earlier release already ended --
+        is a no-op. During shutdown a release is absorbed the same way: the
+        close path owns every resource a release would have touched.
+        """
+        with self._phase_lock:
+            if self._closing or lease is not self._lease:
+                return
+            if self._reserved is not None:
+                if self._reserved is _Phase.PROMOTING:
+                    # The death of this same lease got here first; it wins.
+                    return
+                raise KVCRServiceError(f"KVCR pool {self._pool_index} is busy")
+            self._reserved = _Phase.RELEASING
+        self._submit(_Command("release", (lease,)))
+
+    def abort_grant(self, lease: "_Lease") -> None:
         """Roll back a lease its claimant declared it never served.
 
         The claimant sends this only after stopping local access, so if this
         claim stood a serving Guard down, the Guard may resume; otherwise it
-        is an ordinary release. Ambiguous cases -- a grant whose delivery
-        failed mid-send -- never come here; those release, fenced.
+        is an ordinary release. Staleness is decided exactly as for a release.
         """
-        self._submit(_Command("abort"))
+        with self._phase_lock:
+            if self._closing or lease is not self._lease:
+                return
+            if self._reserved is not None:
+                if self._reserved is _Phase.PROMOTING:
+                    # The death of this same lease got here first; it wins.
+                    return
+                raise KVCRServiceError(f"KVCR pool {self._pool_index} is busy")
+            self._reserved = _Phase.RELEASING
+        self._submit(_Command("abort", (lease,)))
 
     def close(self) -> None:
-        if self._closed:
-            return
-        if not self._started or not self._thread.is_alive():
-            self._close_resources()
-            self._closed = True
-            return
-        self._submit(_Command("close"), _LIFECYCLE_TIMEOUT_SECONDS)
-        self._thread.join(_LIFECYCLE_TIMEOUT_SECONDS)
-        if self._thread.is_alive():
+        self.begin_close()
+        if self.finish_close(time.monotonic() + _LIFECYCLE_TIMEOUT_SECONDS):
             raise TimeoutError("KVCR Guard lifecycle thread did not stop")
 
-    def _submit(self, command: _Command, timeout: float | None = None) -> None:
-        """Run one command on the lifecycle thread and wait for its outcome.
+    def begin_close(self) -> None:
+        """Stop taking work and queue the teardown, without waiting for it.
 
-        State-changing commands wait untimed: a deadline cancels nothing, so a
-        promotion reported as timed out could still land against a registry that has
-        already rolled the claim back. A wedged Guard is contained by the registry's
-        own transition deadline instead.
-
-        One command at a time needs no lock here: the registry marks a pool in
-        transition for exactly as long as a command can be in flight, and it is
-        this Guard's only caller.
+        Split from the wait so shutdown reaches every pool before it waits on
+        any one of them: a wedged pool must not keep its neighbours from being
+        told to close.
         """
-        if not self._thread.is_alive():
-            raise RuntimeError("Guard lifecycle thread stopped unexpectedly")
+        with self._phase_lock:
+            already = self._closing
+            self._closing = True
+        if not self._started or not self._thread.is_alive():
+            # Inline, and retried on a later call if it raised the first time.
+            if not self._closed:
+                self._close_resources()
+                self._closed = True
+            return
+        if not already:
+            self._commands.put(_Command("close"))
+
+    def finish_close(self, deadline: float) -> bool:
+        """Wait out a begun close. True if the actor is wedged past the deadline.
+
+        A close that finished but failed raises its reason here, so shutdown
+        keeps the pool -- and its resources -- visible instead of forgetting it.
+        """
+        if not self._started or self._thread.ident is None:
+            # The thread never ran; begin_close already closed inline.
+            return False
+        # Always joined once it ran: _closed is set just before the actor's
+        # final drain, so returning on the flag alone could report a close
+        # finished while the thread still held the mailbox.
+        self._thread.join(max(0.0, deadline - time.monotonic()))
+        if self._thread.is_alive():
+            return True
+        if not self._closed and self._failure is not None:
+            raise self._failure
+        return False
+
+    def _reserve_claim(self) -> None:
+        """Take the transition slot for a claim, or refuse right now."""
+        with self._phase_lock:
+            if self._closing:
+                raise KVCRServiceError("KVCR pool registry is closed")
+            if self._failure is not None:
+                raise self._failure
+            if self._reserved is not None:
+                raise KVCRServiceError(f"KVCR pool {self._pool_index} is busy")
+            if self._phase is _Phase.PRIMARY:
+                lease = self._lease
+                assert lease is not None
+                poller = select.poll()
+                poller.register(lease.liveness.fileno(), select.POLLIN)
+                if not poller.poll(0):
+                    raise KVCRServiceError(
+                        f"KVCR pool {self._pool_index} is held by another worker"
+                    )
+                # Dead but not yet promoted: the actor is the sole authority.
+                raise KVCRServiceError(f"KVCR pool {self._pool_index} is busy")
+            if self._phase in (_Phase.FAILED, _Phase.CLOSED):
+                raise KVCRServiceError("KVCR pool registry is closed")
+            self._reserved = _Phase.CLAIMING
+
+    def _submit(self, command: _Command) -> Any:
+        """Run one command on the actor thread and wait for its outcome.
+
+        The wait is unbounded but not unguarded: a reservation was taken before
+        anything was queued, so every later caller is refused with busy instead
+        of piling up here -- and an actor that exits mid-wait answers this
+        command with a typed error instead of leaving its caller waiting.
+        """
         self._commands.put(command)
-        if not command.done.wait(timeout):
-            raise TimeoutError(f"KVCR Guard {command.operation} timed out")
-        if command.error is not None:
-            raise command.error
+        while True:
+            try:
+                return command.future.result(timeout=0.1)
+            except TimeoutError:
+                if command.future.done():
+                    # The handler itself raised a TimeoutError; that is the
+                    # answer, not a wait that has not finished.
+                    raise
+                if not self._thread.is_alive():
+                    if command.future.done():
+                        # Completed in the gap between the wait and this check.
+                        continue
+                    # The drain on the actor's way out answers everything
+                    # queued; this covers a command that raced the drain.
+                    raise KVCRServiceError("KVCR pool registry is closed") from None
 
     def _run(self) -> None:
+        try:
+            self._serve_commands()
+        except BaseException as error:  # noqa: BLE001 - the loop itself failed
+            self._record_background_failure(error)
+        finally:
+            # Whatever ended this thread -- CLOSED, FAILED, or a defect in the
+            # loop -- nothing queued may be left waiting on an answer that is
+            # never coming.
+            with self._phase_lock:
+                self._closing = True
+            while True:
+                try:
+                    abandoned = self._commands.get_nowait()
+                except queue.Empty:
+                    break
+                abandoned.future.set_exception(
+                    KVCRServiceError("KVCR pool registry is closed")
+                )
+
+    def _serve_commands(self) -> None:
         draining = False
         while True:
             try:
@@ -246,32 +426,236 @@ class _Guard:
                     timeout = _POLL_SECONDS if busy and not self._failure else None
                     command = self._commands.get(timeout=timeout)
             except queue.Empty:
+                self._observe_holder()
                 draining = self._poll()
                 continue
+            failed: BaseException | None = None
             try:
-                if command.operation == "promote":
-                    self._promote()
-                elif command.operation == "adopt":
-                    assert command.control is not None
-                    assert command.tier_config is not None
-                    self._adopt(command.control, command.tier_config)
-                elif command.operation == "release":
-                    self._release()
-                elif command.operation == "abort":
-                    self._abort()
-                elif command.operation == "close":
-                    self._close_resources()
-                    self._closed = True
-                else:
+                handler = self._handlers.get(command.operation)
+                if handler is None:
                     raise AssertionError(f"unknown Guard command: {command.operation}")
+                result = handler(*command.args)
             except BaseException as error:  # noqa: BLE001 - returned to caller
-                command.error = error
-                if command.operation == "promote":
-                    self._failure = error
-            finally:
-                command.done.set()
-            if command.operation == "close" and command.error is None:
+                failed = error
+                with self._phase_lock:
+                    # The one rollback point: success commits a stable phase
+                    # itself; failure gives the reservation back here.
+                    self._reserved = None
+                command.future.set_exception(error)
+            else:
+                with self._phase_lock:
+                    self._reserved = None
+                command.future.set_result(result)
+            if command.operation == "close":
+                if failed is not None:
+                    # A close that failed cannot be retried into success; the
+                    # actor ends either way and finish_close raises the reason.
+                    with self._phase_lock:
+                        self._failure = failed
+                        self._phase = _Phase.FAILED
                 return
+
+    def _observe_holder(self) -> None:
+        """Notice the current primary dying. The actor is the only watcher.
+
+        The pidfd is polled here, between commands and on the same thread that
+        runs them, so a death and every command are totally ordered: there is
+        no watcher thread to race, misreport a shutdown, or outlive the pool.
+        """
+        with self._phase_lock:
+            if (
+                self._phase is not _Phase.PRIMARY
+                or self._reserved is not None
+                or self._closing
+            ):
+                return
+            lease = self._lease
+        assert lease is not None
+        poller = select.poll()
+        poller.register(lease.liveness.fileno(), select.POLLIN)
+        events = poller.poll(0)
+        if not events:
+            return
+        flags = events[0][1]
+        with self._phase_lock:
+            if self._lease is not lease or self._reserved is not None or self._closing:
+                # A close that began while this poll was in flight owns the
+                # teardown; promoting now would race it for the same resources.
+                return
+            self._reserved = _Phase.PROMOTING
+        try:
+            if not flags & select.POLLIN:
+                # The descriptor broke while its process may still be alive:
+                # promotion here could seat a second server over a live mapping.
+                raise OSError(f"pidfd poll returned without POLLIN: {flags:#x}")
+            self._promote_for(lease)
+        except BaseException as error:  # noqa: BLE001 - service-fatal
+            with self._phase_lock:
+                self._failure = error
+                self._phase = _Phase.FAILED
+            self._escalate(error)
+        finally:
+            with self._phase_lock:
+                self._reserved = None
+
+    def _claim(
+        self,
+        liveness: PidfdLiveness,
+        tier_config: _TierConfig,
+        control_bind: tuple[str, int],
+    ) -> "tuple[KVCRPoolSpec, int, _Lease]":
+        """Give the pool to a primary, and take up the endpoint it named.
+
+        Everything that can fail runs before the lease exists, and the lease is
+        committed under the same lock a refusal is read under: there is no
+        instant at which this pool is both granted and refused, and no failure
+        that leaves it half-granted.
+        """
+        bound_here = self._listener is None
+        listener = self._bind_listener(control_bind)
+        granted_fd = -1
+        try:
+            granted_fd = os.dup(listener.fileno())
+            # from_shared_listener detaches what it is given, so the Guard gets a
+            # duplicate and this pool keeps the original.
+            duplicate = socket.socket(fileno=os.dup(listener.fileno()))
+            try:
+                control = ZmqPeerControlChannel.from_shared_listener(duplicate)
+            except BaseException:
+                duplicate.close()
+                raise
+            self._adopt(control, tier_config)
+            lease = _Lease(liveness)
+            with self._phase_lock:
+                if not self._closing and not self._refusing():
+                    self._lease = lease
+                    self._phase = _Phase.PRIMARY
+                    return self._spec, granted_fd, lease
+            # Refused at the commit itself: a service on its way out must not
+            # grant a pool. Everything adopted goes back where a release would
+            # have put it, so the pool is left safe rather than serving.
+            self._release()
+            with self._phase_lock:
+                self._phase = _Phase.IDLE
+            raise KVCRServiceError("KVCR pool registry is closed")
+        except BaseException as error:
+            if granted_fd >= 0:
+                with suppress(OSError):
+                    os.close(granted_fd)
+            if bound_here:
+                # This claim chose the address and then failed, so keeping it
+                # would refuse the retry as an endpoint move.
+                self._unbind_listener()
+            if isinstance(error, (ValueError, RecoveryMirrorError)):
+                raise KVCRServiceError(str(error)) from error
+            raise
+
+    def _stand_down(self, lease: "_Lease") -> None:
+        """End this lease, keeping what it left for the next primary.
+
+        Staleness was already decided under the phase lock at submission; by
+        the time this runs, the lease is the current one.
+        """
+        try:
+            self._release()
+        except BaseException as error:
+            # Escalated before the pool is exposed: a Guard that failed here may
+            # have left a partial handback, and the next claimant could take it.
+            with self._phase_lock:
+                self._failure = error
+                self._phase = _Phase.FAILED
+            self._escalate(error)
+            raise
+        finally:
+            lease.liveness.close()
+            with self._phase_lock:
+                if self._lease is lease:
+                    self._lease = None
+        with self._phase_lock:
+            self._phase = _Phase.IDLE
+
+    def _abort(self, lease: "_Lease") -> None:
+        """Undo a grant that never arrived: resume serving, or release.
+
+        Resuming is safe exactly because the claimant could not decode the
+        grant -- it can never map the pool this Guard re-serves. The mirror
+        still holds what the handback wrote, and the journal was reset with
+        nothing published since, so promotion serves the same state back.
+        """
+        if self._resumable and not self._serving and self._mirror is not None:
+            try:
+                self._promote_for(lease)
+            except BaseException as error:
+                with self._phase_lock:
+                    self._failure = error
+                    self._phase = _Phase.FAILED
+                self._escalate(error)
+                raise
+            return
+        self._stand_down(lease)
+
+    def _promote_for(self, lease: "_Lease") -> None:
+        """Take the pool over from the primary that just died."""
+        try:
+            self._promote()
+        finally:
+            lease.liveness.close()
+            with self._phase_lock:
+                if self._lease is lease:
+                    self._lease = None
+        with self._phase_lock:
+            self._phase = _Phase.STANDBY
+
+    def _bind_listener(self, control_bind: tuple[str, int]) -> socket.socket:
+        """The address this pool answers on, bound once and never moved.
+
+        A Guard inherits the endpoint its primary used, so a claim naming a
+        different one is refused rather than migrated.
+        """
+        if self._listener is not None:
+            if self._bind != control_bind:
+                assert self._bind is not None
+                raise KVCRServiceError(
+                    f"KVCR pool {self._pool_index} answers on "
+                    f"{self._bind[0]}:{self._bind[1]} and cannot be moved to "
+                    f"{control_bind[0]}:{control_bind[1]}"
+                )
+            return self._listener
+        try:
+            listener = socket.create_server(control_bind)
+        except OSError as error:
+            raise KVCRServiceError(
+                f"KVCR pool {self._pool_index} control listener "
+                f"{control_bind[0]}:{control_bind[1]} is unavailable: {error}"
+            ) from error
+        self._listener = listener
+        self._bind = control_bind
+        return listener
+
+    def _unbind_listener(self) -> None:
+        listener, self._listener = self._listener, None
+        self._bind = None
+        if listener is None:
+            return
+        try:
+            listener.close()
+        except BaseException as error:  # noqa: BLE001 - escalated, not swallowed
+            # An address that will not close is one the service can neither
+            # reach nor hand out, so nothing may claim this pool again.
+            self._escalate(error)
+
+    def _escalate(self, error: BaseException) -> None:
+        logger.critical("KVCR pool %d Guard failed", self._pool_index)
+        try:
+            self._failure_callback(self, error)
+        except BaseException:  # noqa: BLE001 - retain the original failure
+            logger.exception("Failed to notify KVCR-Service of Guard failure")
+
+    def _close(self) -> None:
+        self._close_resources()
+        self._closed = True
+        with self._phase_lock:
+            self._phase = _Phase.CLOSED
 
     def _prepare(self) -> None:
         """Everything that depends only on the pool, and so needs no claim."""
@@ -462,7 +846,9 @@ class _Guard:
         self._mirror = None
 
     def _record_background_failure(self, error: BaseException) -> None:
-        self._failure = error
+        with self._phase_lock:
+            self._failure = error
+            self._phase = _Phase.FAILED
         logger.exception("KVCR Guard background polling failed")
         # Shut what this answered on so the address stops accepting what nothing
         # will read. Best effort; the process exit closes what this could not.
@@ -477,17 +863,6 @@ class _Guard:
             self._failure_callback(self, error)
         except BaseException:  # noqa: BLE001 - retain the original failure
             logger.exception("Failed to notify KVCR-Service of Guard failure")
-
-    def _abort(self) -> None:
-        """Undo a grant that never arrived: resume serving, or release.
-
-        Resuming is safe exactly because the claimant could not decode the
-        grant -- it can never map the pool this Guard re-serves.
-        """
-        if self._resumable and not self._serving and self._mirror is not None:
-            self._promote()
-            return
-        self._release()
 
     def _promote(self) -> None:
         """Take the pool over from the dead primary, warm if anything survived."""
@@ -629,8 +1004,6 @@ class _Guard:
         try:
             if self._core is not None:
                 self._core.close()
-        # BaseException: even an interrupt must not skip giving the pool back
-        # once the core is quiescent.
         except BaseException:
             assert self._core is not None
             if not self._core.is_quiescent():
@@ -641,9 +1014,58 @@ class _Guard:
                 "KVCR Guard core close failed after reaching quiescence",
                 exc_info=True,
             )
-        try:
-            if self._control is not None:
-                self._control.close()
-        finally:
-            if self._attachment is not None:
-                self._attachment.close()
+        # Everything else the pool has, whatever any one of them does about it:
+        # the first refusal is the one that explains the rest.
+        failure: BaseException | None = None
+        for give_back in (
+            self._close_control,
+            self._close_attachment,
+            self._close_lease,
+            self._close_listener,
+            self._close_owner,
+        ):
+            try:
+                give_back()
+            except BaseException as error:  # noqa: BLE001 - raised below
+                failure = failure or error
+        if failure is not None:
+            raise failure
+
+    # Each helper clears its field only once the close succeeded: a resource
+    # whose close failed stays referenced, so a kept pool can still name -- and
+    # retry -- what it leaked. Every close here is idempotent.
+
+    def _close_control(self) -> None:
+        if self._control is not None:
+            self._control.close()
+            self._control = None
+
+    def _close_attachment(self) -> None:
+        if self._attachment is not None:
+            self._attachment.close()
+            self._attachment = None
+
+    def _close_lease(self) -> None:
+        if self._lease is not None:
+            self._lease.liveness.close()
+            self._lease = None
+
+    def _close_listener(self) -> None:
+        # Unlike _unbind_listener, a failure here raises: at teardown there is
+        # no claim error to protect, and the kept pool must still name the
+        # endpoint it could not free.
+        if self._listener is not None:
+            self._listener.close()
+            self._listener = None
+            self._bind = None
+
+    def _close_owner(self) -> None:
+        if self._owner is None:
+            return
+        if self._attachment is not None:
+            # The mapping would not close, so the file must keep naming it:
+            # unlinking now would hide still-committed RAM from the next
+            # start's purge. The attachment failure above reports the pool.
+            return
+        self._owner.close()
+        self._owner = None

--- a/src/kvcr/guard.py
+++ b/src/kvcr/guard.py
@@ -1,12 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Private journal-backed Guard for one service-owned pool.
-
-Asserts in this module are Optional-narrowing only: each names a field the
-phase machine established before that line can run. Under ``python -O`` a
-violated one would surface as an AttributeError on None -- a worse message,
-never a different outcome.
-"""
+"""Private journal-backed Guard for one service-owned pool."""
 
 import concurrent.futures
 import enum
@@ -21,15 +15,10 @@ import time
 import uuid
 from collections.abc import Callable, Mapping
 from contextlib import suppress
-from dataclasses import dataclass, field
 from typing import Any
 
 from .api import KVCRBindings
-from .config import (
-    KVCRBackendConfigs,
-    KVCRConfig,
-    LocalDramInfo,
-)
+from .config import KVCRBackendConfigs, KVCRConfig, LocalDramInfo
 from .control_channels import KVCRServiceError, ZmqPeerControlChannel
 from .core import _BlockRecord, _KVCRCore
 from .guard_protocol import PidfdLiveness, _TierConfig
@@ -47,8 +36,6 @@ from .recovery_journal import (
     _recovery_frames,
     _RecoveryMirror,
     canonical_pool_terms,
-    clear_recovery_snapshot,
-    install_recovery_records,
     read_handback,
     write_recovery_snapshot,
 )
@@ -58,56 +45,14 @@ logger = logging.getLogger(__name__)
 
 # TODO: Wake the mirror on publication rather than polling. A standby still
 # drains at roughly a fifth of the rate a primary can publish.
-_POLL_SECONDS = 0.001
-_POLL_BATCH = 64
-_LIFECYCLE_TIMEOUT_SECONDS = 30.0
+_POLL_SECONDS, _POLL_BATCH = 0.001, 64
 _RECOVERY_CAPACITY_ERRORS = (errno.ENOSPC, errno.EDQUOT)
 
+# Lease identity is the pidfd object itself: a release acts only on THIS
+# object, so nothing stale (reused pid, retried release) can touch a newer lease.
+_Lease = PidfdLiveness
 
-@dataclass
-class _Command:
-    """One request on the pool's mailbox, and the future its answer arrives on."""
-
-    operation: str
-    args: tuple[Any, ...] = ()
-    future: "concurrent.futures.Future[Any]" = field(
-        default_factory=concurrent.futures.Future
-    )
-
-
-class _Phase(enum.Enum):
-    """Where a pool is in its life.
-
-    The first six are stable: states a pool can rest in, each naming exactly
-    which resources exist. The last three are transient reservations a command
-    holds while it runs, taken before the command is queued, so a conflicting
-    command on the same pool is refused now rather than parked behind work
-    that may outlive its caller's patience.
-    """
-
-    UNCONFIGURED = enum.auto()
-    IDLE = enum.auto()
-    STANDBY = enum.auto()
-    PRIMARY = enum.auto()
-    FAILED = enum.auto()
-    CLOSED = enum.auto()
-    CLAIMING = enum.auto()
-    RELEASING = enum.auto()
-    PROMOTING = enum.auto()
-
-
-class _Lease:
-    """One primary's exclusive hold on its pool.
-
-    Identity is the authority: a release acts only if it names THIS object, so
-    nothing stale -- a reused pid, a retried release, an old connection -- can
-    ever touch a newer lease.
-    """
-
-    __slots__ = ("liveness",)
-
-    def __init__(self, liveness: PidfdLiveness) -> None:
-        self.liveness = liveness
+_OPS = dict(claim="_claim", release="_stand_down", abort="_abort", close="_close")
 
 
 def _without_g3(
@@ -143,37 +88,25 @@ def _with_g3(
     return records
 
 
-@dataclass(frozen=True)
-class _ConfiguredTier:
-    """The tiers a claim chose, and the geometry this pool has under them.
+class _Command:
+    """One request on the pool's mailbox, and the future its answer arrives on."""
 
-    One record because the four are only meaningful together: a stride without
-    the rows it yields describes nothing. Deriving them together is also what
-    makes committing a configuration a single assignment, so a failure part way
-    through choosing one cannot leave a pool half-chosen.
-    """
+    def __init__(self, operation: str, args: tuple[Any, ...] = ()) -> None:
+        self.operation, self.args = operation, args
+        self.future: concurrent.futures.Future[Any] = concurrent.futures.Future()
 
-    tier_config: _TierConfig
-    effective_bytes: int
-    rows: int
 
-    @property
-    def row_stride(self) -> int:
-        return self.tier_config.row_stride
-
-    @classmethod
-    def derive(cls, spec: KVCRPoolSpec, tier_config: _TierConfig) -> "_ConfiguredTier":
-        effective_bytes, rows = _compute_pool_geometry(
-            spec.data_bytes, tier_config.row_stride
-        )
-        return cls(tier_config, effective_bytes, rows)
+# First six: stable resting states. Last three: transient reservations taken
+# before a command is queued, so a conflicting command is refused immediately.
+_Phase = enum.Enum(
+    "_Phase",
+    "UNCONFIGURED IDLE STANDBY PRIMARY FAILED CLOSED CLAIMING RELEASING PROMOTING",
+)
 
 
 class _Guard:
-    """One pool's standby, for as long as the service owns the pool.
-
-    Built with the pool and outliving every primary that holds it, so a claim is
-    something this is told about rather than something that creates it.
+    """One pool's standby, alive as long as the service owns the pool.
+    Outlives every primary: a claim is reported to it, not what creates it.
     """
 
     def __init__(
@@ -189,104 +122,73 @@ class _Guard:
         self._spec = spec
         self._compatibility_digest = compatibility_digest
         self._pool_index = pool_index
-        # The pool itself, and the lease over it. Owned here rather than by the
-        # registry: one thread owns everything about one pool, so a claim needs
-        # no lock and no reservation against the next one -- the mailbox is the
-        # reservation.
+        # Owned here, not by the registry: one thread owns one pool, so a
+        # claim needs no lock -- the mailbox is the reservation.
         self._owner = owner
         self._refusing = refusing
-        self._lease: _Lease | None = None
-        self._listener: socket.socket | None = None
-        # The address as the claimant asked for it: getsockname() answers
-        # numerically and would reject every alias of the same address.
+        self._lease = self._listener = None
+        # As the claimant asked: getsockname() is numeric and rejects aliases.
         self._bind: tuple[str, int] | None = None
-        # All of this belongs to whichever primary currently holds the pool.
+        # Owned by the current primary.
         self._control: ZmqPeerControlChannel | None = None
-        self._configured: _ConfiguredTier | None = None
-        # The G3 half of what was recovered. A Guard does not serve it, but the
-        # primary that takes the pool back does, so it is kept rather than dropped.
+        self._configured: _TierConfig | None = None
+        self._attachment = self._journal = self._mirror = self._core = None
+        # Recovered half a Guard cannot serve; kept for the next primary, which can.
         self._g3_records: dict[BlockKey, _G3Residency] = {}
         self._commands: queue.Queue[_Command] = queue.Queue()
         self._thread = threading.Thread(
-            target=self._run,
-            name=f"kvcr-guard-{spec.pool_id}",
-            daemon=True,
+            target=self._run, name=f"kvcr-guard-{spec.pool_id}", daemon=True
         )
-        self._started = False
-        self._closed = False
-        self._serving = False
-        self._resumable = False
-        # One small lock over the phase, its reservation, the lease and the
-        # failure -- never held across blocking work. It exists so a caller can
-        # reserve a transition before queueing it; the actor thread is still
-        # the only thing that runs one.
+        self._started = self._closed = self._serving = self._resumable = False
+        # Guards phase, reservation, lease, and failure; never held across
+        # blocking work. Callers reserve transitions; only the actor runs them.
         self._phase_lock = threading.Lock()
         self._phase = _Phase.UNCONFIGURED
         self._reserved: _Phase | None = None
         self._closing = False
         self._failure: BaseException | None = None
         self._failure_callback = failure_callback or (lambda guard, error: None)
-        self._attachment: KVCRPoolAttachment | None = None
-        self._journal: RecoveryJournal | None = None
-        self._mirror: _RecoveryMirror | None = None
-        self._core: _KVCRCore | None = None
-        self._handlers: dict[str, Callable[..., Any]] = {
-            "claim": self._claim,
-            "release": self._stand_down,
-            "abort": self._abort,
-            "close": self._close,
-        }
+
+    def _fail(self, error: BaseException) -> None:
+        with self._phase_lock:
+            self._failure = error
+            self._phase = _Phase.FAILED
+        self._escalate(error)
 
     def start(self) -> None:
         """Attach the pool and begin the lifecycle thread, before any claim."""
         if self._started:
             raise RuntimeError("Guard preparation was already attempted")
         self._started = True
-        # On this thread: attaching a pool is not thread-affine, no command can
-        # exist yet, and a caller that sees the failure directly never has to
-        # decide what to tear down behind a thread still opening it.
+        # Attaching is not thread-affine; done here so a failure surfaces
+        # directly, with nothing to tear down.
         self._prepare()
         self._thread.start()
 
     def claim(
-        self,
-        liveness: PidfdLiveness,
-        tier_config: _TierConfig,
-        control_bind: tuple[str, int],
+        self, liveness: PidfdLiveness, tier_config: _TierConfig, bind: tuple[str, int]
     ) -> "tuple[KVCRPoolSpec, int, _Lease]":
         """Give this pool to a primary, with the endpoint its Guard answers on.
-
-        The reservation is taken here, on the requesting thread, so a pool
-        mid-transition answers busy immediately instead of queueing this
-        claimant behind work that may outlive its patience.
+        Reserved on the requesting thread: a mid-transition pool answers busy
+        immediately instead of queueing the claimant.
         """
         self._reserve_claim()
-        return self._submit(_Command("claim", (liveness, tier_config, control_bind)))
+        return self._submit(_Command("claim", (liveness, tier_config, bind)))
 
     def release(self, lease: "_Lease") -> None:
-        """End a lease. The pool keeps its Guard, and the Guard its records.
-
-        A stale lease -- one a promotion or an earlier release already ended --
-        is a no-op. During shutdown a release is absorbed the same way: the
-        close path owns every resource a release would have touched.
-        """
-        with self._phase_lock:
-            if self._closing or lease is not self._lease:
-                return
-            if self._reserved is not None:
-                if self._reserved is _Phase.PROMOTING:
-                    # The death of this same lease got here first; it wins.
-                    return
-                raise KVCRServiceError(f"KVCR pool {self._pool_index} is busy")
-            self._reserved = _Phase.RELEASING
-        self._submit(_Command("release", (lease,)))
+        """End a lease. The pool keeps its Guard, and the Guard its records."""
+        self._end_lease(lease, "release")
 
     def abort_grant(self, lease: "_Lease") -> None:
         """Roll back a lease its claimant declared it never served.
+        Sent only after the claimant stopped local access, so a stood-down
+        serving Guard may resume; otherwise an ordinary release.
+        """
+        self._end_lease(lease, "abort")
 
-        The claimant sends this only after stopping local access, so if this
-        claim stood a serving Guard down, the Guard may resume; otherwise it
-        is an ordinary release. Staleness is decided exactly as for a release.
+    def _end_lease(self, lease: "_Lease", operation: str) -> None:
+        """Queue a release or abort; a stale lease is a no-op. Absorbed during
+        shutdown too: the close path owns every resource this touches.
         """
         with self._phase_lock:
             if self._closing or lease is not self._lease:
@@ -297,19 +199,16 @@ class _Guard:
                     return
                 raise KVCRServiceError(f"KVCR pool {self._pool_index} is busy")
             self._reserved = _Phase.RELEASING
-        self._submit(_Command("abort", (lease,)))
+        self._submit(_Command(operation, (lease,)))
 
     def close(self) -> None:
         self.begin_close()
-        if self.finish_close(time.monotonic() + _LIFECYCLE_TIMEOUT_SECONDS):
+        if self.finish_close(time.monotonic() + 30.0):
             raise TimeoutError("KVCR Guard lifecycle thread did not stop")
 
     def begin_close(self) -> None:
-        """Stop taking work and queue the teardown, without waiting for it.
-
-        Split from the wait so shutdown reaches every pool before it waits on
-        any one of them: a wedged pool must not keep its neighbours from being
-        told to close.
+        """Stop taking work and queue the teardown without waiting: a wedged
+        pool must not keep its neighbours from being told to close.
         """
         with self._phase_lock:
             already = self._closing
@@ -324,17 +223,14 @@ class _Guard:
             self._commands.put(_Command("close"))
 
     def finish_close(self, deadline: float) -> bool:
-        """Wait out a begun close. True if the actor is wedged past the deadline.
-
-        A close that finished but failed raises its reason here, so shutdown
-        keeps the pool -- and its resources -- visible instead of forgetting it.
+        """Wait out a begun close; True if the actor is wedged past the
+        deadline. A close that finished but failed raises its reason here.
         """
         if not self._started or self._thread.ident is None:
             # The thread never ran; begin_close already closed inline.
             return False
-        # Always joined once it ran: _closed is set just before the actor's
-        # final drain, so returning on the flag alone could report a close
-        # finished while the thread still held the mailbox.
+        # Always join: _closed is set before the actor's final drain, so the
+        # flag alone could report done while the thread still holds the mailbox.
         self._thread.join(max(0.0, deadline - time.monotonic()))
         if self._thread.is_alive():
             return True
@@ -352,10 +248,8 @@ class _Guard:
             if self._reserved is not None:
                 raise KVCRServiceError(f"KVCR pool {self._pool_index} is busy")
             if self._phase is _Phase.PRIMARY:
-                lease = self._lease
-                assert lease is not None
                 poller = select.poll()
-                poller.register(lease.liveness.fileno(), select.POLLIN)
+                poller.register(self._lease.fileno(), select.POLLIN)
                 if not poller.poll(0):
                     raise KVCRServiceError(
                         f"KVCR pool {self._pool_index} is held by another worker"
@@ -368,27 +262,27 @@ class _Guard:
 
     def _submit(self, command: _Command) -> Any:
         """Run one command on the actor thread and wait for its outcome.
-
-        The wait is unbounded but not unguarded: a reservation was taken before
-        anything was queued, so every later caller is refused with busy instead
-        of piling up here -- and an actor that exits mid-wait answers this
-        command with a typed error instead of leaving its caller waiting.
+        The unbounded wait is guarded: the reservation refuses later callers,
+        and an actor exiting mid-wait answers with a typed error.
         """
         self._commands.put(command)
         while True:
             try:
+                # futures.TimeoutError != the builtin before 3.11; 3.10 is the floor.
                 return command.future.result(timeout=0.1)
-            except TimeoutError:
+            except concurrent.futures.TimeoutError as error:
                 if command.future.done():
-                    # The handler itself raised a TimeoutError; that is the
-                    # answer, not a wait that has not finished.
-                    raise
+                    if command.future.exception() is error:
+                        # The handler raised this TimeoutError; it is the answer.
+                        raise
+                    # Answered in the gap after the timeout; re-read, or a
+                    # committed lease would be reported as a timeout.
+                    continue
                 if not self._thread.is_alive():
                     if command.future.done():
                         # Completed in the gap between the wait and this check.
                         continue
-                    # The drain on the actor's way out answers everything
-                    # queued; this covers a command that raced the drain.
+                    # The exit drain answers everything queued; this covers a racer.
                     raise KVCRServiceError("KVCR pool registry is closed") from None
 
     def _run(self) -> None:
@@ -397,19 +291,14 @@ class _Guard:
         except BaseException as error:  # noqa: BLE001 - the loop itself failed
             self._record_background_failure(error)
         finally:
-            # Whatever ended this thread -- CLOSED, FAILED, or a defect in the
-            # loop -- nothing queued may be left waiting on an answer that is
-            # never coming.
+            # However this thread ended, nothing queued may wait forever.
             with self._phase_lock:
                 self._closing = True
-            while True:
-                try:
-                    abandoned = self._commands.get_nowait()
-                except queue.Empty:
-                    break
-                abandoned.future.set_exception(
-                    KVCRServiceError("KVCR pool registry is closed")
-                )
+            with suppress(queue.Empty):
+                while True:
+                    self._commands.get_nowait().future.set_exception(
+                        KVCRServiceError("KVCR pool registry is closed")
+                    )
 
     def _serve_commands(self) -> None:
         draining = False
@@ -431,15 +320,11 @@ class _Guard:
                 continue
             failed: BaseException | None = None
             try:
-                handler = self._handlers.get(command.operation)
-                if handler is None:
-                    raise AssertionError(f"unknown Guard command: {command.operation}")
-                result = handler(*command.args)
+                result = getattr(self, _OPS[command.operation])(*command.args)
             except BaseException as error:  # noqa: BLE001 - returned to caller
                 failed = error
                 with self._phase_lock:
-                    # The one rollback point: success commits a stable phase
-                    # itself; failure gives the reservation back here.
+                    # The one rollback point: success commits a stable phase itself.
                     self._reserved = None
                 command.future.set_exception(error)
             else:
@@ -448,19 +333,15 @@ class _Guard:
                 command.future.set_result(result)
             if command.operation == "close":
                 if failed is not None:
-                    # A close that failed cannot be retried into success; the
-                    # actor ends either way and finish_close raises the reason.
+                    # A failed close is final; finish_close raises the reason.
                     with self._phase_lock:
                         self._failure = failed
                         self._phase = _Phase.FAILED
                 return
 
     def _observe_holder(self) -> None:
-        """Notice the current primary dying. The actor is the only watcher.
-
-        The pidfd is polled here, between commands and on the same thread that
-        runs them, so a death and every command are totally ordered: there is
-        no watcher thread to race, misreport a shutdown, or outlive the pool.
+        """Notice the current primary dying. Polled between commands on the
+        actor thread, so a death and every command are totally ordered.
         """
         with self._phase_lock:
             if (
@@ -470,54 +351,41 @@ class _Guard:
             ):
                 return
             lease = self._lease
-        assert lease is not None
         poller = select.poll()
-        poller.register(lease.liveness.fileno(), select.POLLIN)
-        events = poller.poll(0)
-        if not events:
+        poller.register(lease.fileno(), select.POLLIN)
+        if not (events := poller.poll(0)):
             return
         flags = events[0][1]
         with self._phase_lock:
             if self._lease is not lease or self._reserved is not None or self._closing:
-                # A close that began while this poll was in flight owns the
-                # teardown; promoting now would race it for the same resources.
+                # An in-flight close owns the teardown; promoting would race it.
                 return
             self._reserved = _Phase.PROMOTING
         try:
             if not flags & select.POLLIN:
-                # The descriptor broke while its process may still be alive:
-                # promotion here could seat a second server over a live mapping.
+                # The process may still be alive: promoting could seat a
+                # second server over a live mapping.
                 raise OSError(f"pidfd poll returned without POLLIN: {flags:#x}")
             self._promote_for(lease)
         except BaseException as error:  # noqa: BLE001 - service-fatal
-            with self._phase_lock:
-                self._failure = error
-                self._phase = _Phase.FAILED
-            self._escalate(error)
+            self._fail(error)
         finally:
             with self._phase_lock:
                 self._reserved = None
 
     def _claim(
-        self,
-        liveness: PidfdLiveness,
-        tier_config: _TierConfig,
-        control_bind: tuple[str, int],
+        self, liveness: PidfdLiveness, tier_config: _TierConfig, bind: tuple[str, int]
     ) -> "tuple[KVCRPoolSpec, int, _Lease]":
         """Give the pool to a primary, and take up the endpoint it named.
-
-        Everything that can fail runs before the lease exists, and the lease is
-        committed under the same lock a refusal is read under: there is no
-        instant at which this pool is both granted and refused, and no failure
-        that leaves it half-granted.
+        All fallible work runs before the lease exists, and commit and refusal
+        share one lock: a lease is never half-granted.
         """
         bound_here = self._listener is None
-        listener = self._bind_listener(control_bind)
+        listener = self._bind_listener(bind)
         granted_fd = -1
         try:
             granted_fd = os.dup(listener.fileno())
-            # from_shared_listener detaches what it is given, so the Guard gets a
-            # duplicate and this pool keeps the original.
+            # from_shared_listener detaches its argument; give it a duplicate.
             duplicate = socket.socket(fileno=os.dup(listener.fileno()))
             try:
                 control = ZmqPeerControlChannel.from_shared_listener(duplicate)
@@ -525,15 +393,13 @@ class _Guard:
                 duplicate.close()
                 raise
             self._adopt(control, tier_config)
-            lease = _Lease(liveness)
             with self._phase_lock:
                 if not self._closing and not self._refusing():
-                    self._lease = lease
+                    self._lease = liveness
                     self._phase = _Phase.PRIMARY
-                    return self._spec, granted_fd, lease
-            # Refused at the commit itself: a service on its way out must not
-            # grant a pool. Everything adopted goes back where a release would
-            # have put it, so the pool is left safe rather than serving.
+                    return self._spec, granted_fd, liveness
+            # Refused at the commit: a closing service must not grant a pool.
+            # Everything adopted goes back as a release would have put it.
             self._release()
             with self._phase_lock:
                 self._phase = _Phase.IDLE
@@ -543,8 +409,7 @@ class _Guard:
                 with suppress(OSError):
                     os.close(granted_fd)
             if bound_here:
-                # This claim chose the address and then failed, so keeping it
-                # would refuse the retry as an endpoint move.
+                # Keeping an address this claim chose would refuse a retry as a move.
                 self._unbind_listener()
             if isinstance(error, (ValueError, RecoveryMirrorError)):
                 raise KVCRServiceError(str(error)) from error
@@ -552,22 +417,16 @@ class _Guard:
 
     def _stand_down(self, lease: "_Lease") -> None:
         """End this lease, keeping what it left for the next primary.
-
-        Staleness was already decided under the phase lock at submission; by
-        the time this runs, the lease is the current one.
+        Staleness was decided at submission; here the lease is current.
         """
         try:
             self._release()
         except BaseException as error:
-            # Escalated before the pool is exposed: a Guard that failed here may
-            # have left a partial handback, and the next claimant could take it.
-            with self._phase_lock:
-                self._failure = error
-                self._phase = _Phase.FAILED
-            self._escalate(error)
+            # Escalated before the pool is exposed: a partial handback may remain.
+            self._fail(error)
             raise
         finally:
-            lease.liveness.close()
+            lease.close()
             with self._phase_lock:
                 if self._lease is lease:
                     self._lease = None
@@ -575,21 +434,15 @@ class _Guard:
             self._phase = _Phase.IDLE
 
     def _abort(self, lease: "_Lease") -> None:
-        """Undo a grant that never arrived: resume serving, or release.
-
-        Resuming is safe exactly because the claimant could not decode the
-        grant -- it can never map the pool this Guard re-serves. The mirror
-        still holds what the handback wrote, and the journal was reset with
-        nothing published since, so promotion serves the same state back.
+        """Undo a grant its claimant declared unserved: resume, or release.
+        Resume is safe: the claimant stopped local access for good, the mirror
+        holds the handback, the journal is reset -- promotion serves it back.
         """
         if self._resumable and not self._serving and self._mirror is not None:
             try:
                 self._promote_for(lease)
             except BaseException as error:
-                with self._phase_lock:
-                    self._failure = error
-                    self._phase = _Phase.FAILED
-                self._escalate(error)
+                self._fail(error)
                 raise
             return
         self._stand_down(lease)
@@ -599,7 +452,7 @@ class _Guard:
         try:
             self._promote()
         finally:
-            lease.liveness.close()
+            lease.close()
             with self._phase_lock:
                 if self._lease is lease:
                     self._lease = None
@@ -607,14 +460,11 @@ class _Guard:
             self._phase = _Phase.STANDBY
 
     def _bind_listener(self, control_bind: tuple[str, int]) -> socket.socket:
-        """The address this pool answers on, bound once and never moved.
-
-        A Guard inherits the endpoint its primary used, so a claim naming a
-        different one is refused rather than migrated.
+        """Bind this pool's address, once and never moved: a claim naming a
+        different endpoint is refused rather than migrated.
         """
         if self._listener is not None:
             if self._bind != control_bind:
-                assert self._bind is not None
                 raise KVCRServiceError(
                     f"KVCR pool {self._pool_index} answers on "
                     f"{self._bind[0]}:{self._bind[1]} and cannot be moved to "
@@ -640,8 +490,7 @@ class _Guard:
         try:
             listener.close()
         except BaseException as error:  # noqa: BLE001 - escalated, not swallowed
-            # An address that will not close is one the service can neither
-            # reach nor hand out, so nothing may claim this pool again.
+            # An address that will not close: nothing may claim this pool again.
             self._escalate(error)
 
     def _escalate(self, error: BaseException) -> None:
@@ -659,16 +508,13 @@ class _Guard:
 
     def _prepare(self) -> None:
         """Everything that depends only on the pool, and so needs no claim."""
-        attachment = KVCRPoolAttachment.attach(self._spec)
-        self._attachment = attachment
-        self._journal = RecoveryJournal(attachment)
+        self._attachment = KVCRPoolAttachment.attach(self._spec)
+        self._journal = RecoveryJournal(self._attachment)
 
     def _adopt(self, control: ZmqPeerControlChannel, tier_config: _TierConfig) -> None:
         """Take up a new primary, handing over whatever the last one left.
-
-        A Guard that is serving hands the pool back first, which is what stops
-        it answering before the replacement starts. A Guard that already holds
-        records keeps them rather than reading back the region it just wrote.
+        A serving Guard hands back first, so it stops answering before the
+        replacement starts; held records are kept, not re-read from the region.
         """
         try:
             # Everything that can refuse this claim runs before anything
@@ -679,9 +525,12 @@ class _Guard:
             served_under = self._configured.row_stride if self._configured else 0
             recovered = self._mirror
             if recovered is None:
-                # Nothing kept, so whatever a previous service left in the pool's
-                # tail is the baseline this lease's deltas apply to.
-                recovered = self._recovered_baseline(tier_config.row_stride)
+                # The prior handback is this lease's baseline. Read now, under
+                # the claim's stride: refusing at promotion stops the service,
+                # and a claimant dying in between takes everything with it.
+                recovered = read_handback(
+                    self._attachment, self._compatibility_digest, tier_config.row_stride
+                )
             # Last, once nothing left can refuse this claim: a pool whose handback
             # would not replay has not chosen anything, and a corrected claim can
             # still have it.
@@ -700,44 +549,31 @@ class _Guard:
                     # this lease's baseline is empty, not absent. A lease with
                     # no mirror would never be read again.
                     self._mirror = _RecoveryMirror()
-            assert self._journal is not None
             self._journal.reset()
+            # The old channel is the last reference to the prior primary's listener.
+            if self._control is not None:
+                self._control.close()
         except BaseException as error:
             # The pool has changed hands and nothing here can put it back, so
             # this stopped being something a claimant could be told about.
             control.close()
             self._record_background_failure(error)
             raise
-
-        try:
-            if self._control is not None:
-                self._control.close()
-        except BaseException as error:
-            # The new channel owns a duplicate of the pool's listener and this is
-            # the only reference to it left.
-            control.close()
-            self._record_background_failure(error)
-            raise
         self._control = control
 
     def _release(self) -> None:
-        """Give up the current primary, leaving its state where the next looks.
-
-        The next primary reads only the handback region, so the mirror is written out
-        and dropped. Keeping it would map keys to slots a claimant, told the pool was
-        empty, has since allocated over.
+        """Give up the current primary. The mirror is written out and dropped:
+        kept, it would map keys to slots a later claimant allocated over.
         """
         self._resumable = False
         if self._failure is not None:
             raise self._failure
-        assert self._configured is not None
         if self._serving:
             self._hand_back(self._configured.row_stride)
         elif self._mirror is not None:
             try:
                 # A primary that is asking to release has stopped publishing, so
                 # what is still in the ring is the tail of what it did publish.
-                assert self._journal is not None
                 while (frame := self._journal.read_next()) is not None:
                     self._mirror.apply(*frame)
                 # Taken, not copied: the mirror is dropped on the next line, and
@@ -760,56 +596,34 @@ class _Guard:
             self._control = None
 
     def _refuse_incompatible(self, tier_config: _TierConfig) -> None:
-        """Refuse a primary whose tiers are not the ones this pool was claimed with.
-
-        A pool's configuration is fixed for the service's lifetime, and holding no
-        records is not licence to change it: the records go, the bytes stay. A
-        different stride, or the same G3 paths in a different order, leaves every
-        slot number naming bytes it did not name before. Only the first claim
-        chooses.
+        """Refuse tiers other than the ones this pool was claimed with.
+        The first claim fixes configuration for the service's lifetime: the
+        bytes stay, and a changed stride or G3 path order misnames every slot.
         """
-        configured = self._configured
-        if configured is None or configured.tier_config == tier_config:
-            return
-        raise RecoveryMirrorError(
-            "KVCR pool was claimed with another tier configuration"
-        )
+        if self._configured is not None and self._configured != tier_config:
+            raise RecoveryMirrorError(
+                "KVCR pool was claimed with another tier configuration"
+            )
 
     def _configure(self, tier_config: _TierConfig) -> None:
-        """Take up the tiers this primary asked for, if this pool can have them.
-
-        One assignment of a record derived whole, so a configuration this pool
-        cannot have leaves the Guard in the one it already had.
+        """Take up this primary's tiers: the geometry check runs before the
+        assignment, so a bad configuration leaves the old one intact.
         """
-        self._configured = _ConfiguredTier.derive(self._spec, tier_config)
-
-    def _recovered_baseline(self, row_stride: int) -> _RecoveryMirror:
-        """The region a previous handover left, checked against these tiers.
-
-        Checked while the claim is still being granted rather than at promotion,
-        where refusing it stops the service: a claimant that dies in between would
-        otherwise take everything with it. The stride is the incoming claim's,
-        because this runs before the claim has been allowed to choose it.
-        """
-        assert self._attachment is not None
-        return read_handback(self._attachment, self._compatibility_digest, row_stride)
+        _compute_pool_geometry(self._spec.data_bytes, tier_config.row_stride)
+        self._configured = tier_config
 
     def _poll(self) -> bool:
-        """Mirror what is waiting, and say whether there was more of it.
-
-        A full batch means the primary is outrunning one wait, so the caller comes
-        straight back. The batch bounds how long a command waits, not how much drains.
+        """Mirror what is waiting; True if more remains. The batch bounds a
+        command's wait, not how much drains.
         """
         if self._failure is not None:
             return False
         try:
             if self._serving:
-                assert self._core is not None
                 self._core.poll_completed()
             elif self._mirror is not None:
                 # A mirror means a primary holds this pool. Without one the
                 # Guard is waiting to be claimed, and nothing is publishing.
-                assert self._journal is not None
                 for _ in range(_POLL_BATCH):
                     frame = self._journal.read_next()
                     if frame is None:
@@ -819,7 +633,6 @@ class _Guard:
         except RecoveryJournalError as error:
             self._drop_recovery(error)
         except RecoveryMirrorError as error:
-            assert self._journal is not None
             # Suppressed: this thread dying here would leave the pool unclaimable
             # with nobody told, which is the opposite of the intended failure.
             with suppress(Exception):
@@ -830,17 +643,12 @@ class _Guard:
         return False
 
     def _drop_recovery(self, error: RecoveryJournalError | OSError) -> None:
-        """Lose this pool's recovery without losing the service.
-
-        The primary outran this mirror, or the ring went bad under it. What is left
-        is incomplete, so it is dropped rather than served -- but a pool that can no
-        longer be recovered is not a Guard that has failed, and the primary treats
-        the same condition as survivable. Every reader of the journal ends up here,
+        """Lose this pool's recovery without losing the service: dropped, not
+        served, and not a Guard failure. Every reader of the journal ends up here,
         because which one reaches it first is a race.
         """
         logger.warning(
-            "KVCR pool recovery disabled; the pool will be claimable but "
-            "cold if this primary dies: %s",
+            "KVCR pool recovery disabled; claimable but cold if this primary dies: %s",
             error,
         )
         self._mirror = None
@@ -869,7 +677,6 @@ class _Guard:
         self._resumable = False
         if self._failure is not None:
             raise self._failure
-        assert self._journal is not None
         records: dict[BlockKey, _BlockRecord] = {}
         if self._mirror is None:
             logger.warning("KVCR pool has no recovered state to promote")
@@ -890,41 +697,22 @@ class _Guard:
     def _serve(self, records: dict[BlockKey, _BlockRecord]) -> None:
         """Answer on this pool's endpoint, with whatever came back from it.
 
-        Serving nothing is still serving. The dead primary's peers go on sending
-        to this address, and one that answers refuses them, where one that only
-        stays bound leaves them waiting on a reply nobody is going to send.
+        Serving nothing is still serving: answering refuses peers that staying
+        bound would leave hanging. G2 only, no G3: that half is kept whole for
+        the replacement. A new NIXL agent name keeps peers off the dead one's.
         """
-        # A Guard serves G2 and opens no G3: staging a block up to serve it would
-        # cost the tier a slot for a lease that ends at the next claim. The G3 half
-        # is kept whole and handed to the replacement, which does open G3.
         self._g3_records = {
             key: record.g3 for key, record in records.items() if record.g3 is not None
         }
-        core = self._serving_core()
-        self._core = core
-        install_recovery_records(core, _without_g3(records))
-        # A previous handover describes slots this Guard is about to move, and it is
-        # already in the mirror. Leaving it would map keys to overwritten bytes.
-        assert self._attachment is not None
-        clear_recovery_snapshot(self._attachment)
-        core.start()
-        self._serving = True
-
-    def _serving_core(self) -> _KVCRCore:
-        """A core over this pool's mapping, under an agent name of its own.
-
-        A new NIXL agent because a peer must not reach the dead primary's, and no
-        framework memory or G3: a Guard serves what the pool already holds.
-        """
 
         def reject_pin(keys: object) -> int:
-            del keys
             raise RuntimeError("Guard has no framework-owned memory")
 
-        assert self._attachment is not None
-        configured = self._configured
-        assert configured is not None
-        return _KVCRCore(
+        effective_bytes, rows = _compute_pool_geometry(
+            self._spec.data_bytes, self._configured.row_stride
+        )
+        dram = LocalDramInfo(self._attachment.data_address, effective_bytes, rows)
+        core = _KVCRCore(
             KVCRConfig(
                 nixl_agent_name=f"KVCR-Guard-{uuid.uuid4()}",
                 inventory_report_interval_ms=0,
@@ -936,22 +724,20 @@ class _Guard:
                 lambda _handle: False,
                 framework_control=self._control,
             ),
-            KVCRBackendConfigs(
-                local_dram=LocalDramInfo(
-                    self._attachment.data_address,
-                    configured.effective_bytes,
-                    configured.rows,
-                ),
-                g3=None,
-            ),
+            KVCRBackendConfigs(local_dram=dram, g3=None),
         )
+        self._core = core
+        core.adopt_recovery_records(_without_g3(records))
+        # A previous handover describes slots this Guard is about to move, and it is
+        # already in the mirror. Leaving it would map keys to overwritten bytes.
+        self._attachment.release_snapshot_region()
+        core.start()
+        self._serving = True
 
     def _hand_back(self, row_stride: int) -> None:
         """Stop serving, leaving this pool's state where the next primary looks.
-
-        Closing the core first stops this Guard answering before anything replaces it,
-        and makes the two halves agree: the region and the records both come from the
-        map close leaves behind.
+        The core closes first: the Guard stops answering, and region and
+        records both come from the map close leaves behind.
         """
         core = self._core
         mirror = self._mirror
@@ -965,11 +751,9 @@ class _Guard:
             if error.errno not in _RECOVERY_CAPACITY_ERRORS:
                 raise
             # The ring-full precedent: a pool whose state will not fit at the
-            # tail (ENOSPC or EDQUOT) is cold, not fatal. The region's error path
-            # truncated what it started, so the next claimant is told nothing
-            # rather than half of something -- and the mirror is dropped with
-            # it, because a claimant told the pool is empty must not race a
-            # mirror that still names slots.
+            # tail (ENOSPC or EDQUOT) is cold, not fatal. The write was
+            # truncated, and the mirror is dropped too: a claimant told the
+            # pool is empty must not race one.
             self._drop_recovery(error)
         else:
             mirror.adopt(records)
@@ -988,12 +772,9 @@ class _Guard:
         records: Mapping[BlockKey, _BlockRecord],
         row_stride: int,
     ) -> None:
-        """Leave these records where the next primary to claim will look.
-
-        The stride is the one the records were written under, not whatever is
-        incoming: the terms have to name the pool the records describe.
+        """Leave this state where the next primary to claim will look.
+        The stride is the one the records were written under, not the incoming.
         """
-        assert self._attachment is not None
         write_recovery_snapshot(
             self._attachment,
             canonical_pool_terms(self._compatibility_digest, row_stride, self._spec),
@@ -1005,7 +786,6 @@ class _Guard:
             if self._core is not None:
                 self._core.close()
         except BaseException:
-            assert self._core is not None
             if not self._core.is_quiescent():
                 # Still moving bytes, so nothing below runs: unmapping the
                 # pool under a thread still writing into it faults the process.
@@ -1014,13 +794,12 @@ class _Guard:
                 "KVCR Guard core close failed after reaching quiescence",
                 exc_info=True,
             )
-        # Everything else the pool has, whatever any one of them does about it:
-        # the first refusal is the one that explains the rest.
+        # Every close runs regardless; the first failure is the raised one.
         failure: BaseException | None = None
         for give_back in (
-            self._close_control,
-            self._close_attachment,
-            self._close_lease,
+            lambda: self._close_field("_control"),
+            lambda: self._close_field("_attachment"),
+            lambda: self._close_field("_lease"),
             self._close_listener,
             self._close_owner,
         ):
@@ -1031,29 +810,17 @@ class _Guard:
         if failure is not None:
             raise failure
 
-    # Each helper clears its field only once the close succeeded: a resource
-    # whose close failed stays referenced, so a kept pool can still name -- and
-    # retry -- what it leaked. Every close here is idempotent.
+    # A field is cleared only once its close succeeds, so a failed close stays
+    # referenced and retryable. Every close here is idempotent.
 
-    def _close_control(self) -> None:
-        if self._control is not None:
-            self._control.close()
-            self._control = None
-
-    def _close_attachment(self) -> None:
-        if self._attachment is not None:
-            self._attachment.close()
-            self._attachment = None
-
-    def _close_lease(self) -> None:
-        if self._lease is not None:
-            self._lease.liveness.close()
-            self._lease = None
+    def _close_field(self, name: str) -> None:
+        held = getattr(self, name)
+        if held is not None:
+            held.close()
+            setattr(self, name, None)
 
     def _close_listener(self) -> None:
-        # Unlike _unbind_listener, a failure here raises: at teardown there is
-        # no claim error to protect, and the kept pool must still name the
-        # endpoint it could not free.
+        # Unlike _unbind_listener, a failure raises: the kept pool must name the leak.
         if self._listener is not None:
             self._listener.close()
             self._listener = None
@@ -1063,9 +830,8 @@ class _Guard:
         if self._owner is None:
             return
         if self._attachment is not None:
-            # The mapping would not close, so the file must keep naming it:
-            # unlinking now would hide still-committed RAM from the next
-            # start's purge. The attachment failure above reports the pool.
+            # The mapping would not close; unlinking now would hide
+            # still-committed RAM from the next start's purge.
             return
         self._owner.close()
         self._owner = None

--- a/src/kvcr/guard.py
+++ b/src/kvcr/guard.py
@@ -52,8 +52,6 @@ _RECOVERY_CAPACITY_ERRORS = (errno.ENOSPC, errno.EDQUOT)
 # object, so nothing stale (reused pid, retried release) can touch a newer lease.
 _Lease = PidfdLiveness
 
-_OPS = dict(claim="_claim", release="_stand_down", abort="_abort", close="_close")
-
 
 def _without_g3(
     records: dict[BlockKey, _BlockRecord],
@@ -96,16 +94,25 @@ class _Command:
         self.future: concurrent.futures.Future[Any] = concurrent.futures.Future()
 
 
-# First six: stable resting states. Last three: transient reservations taken
-# before a command is queued, so a conflicting command is refused immediately.
-_Phase = enum.Enum(
-    "_Phase",
-    "UNCONFIGURED IDLE STANDBY PRIMARY FAILED CLOSED CLAIMING RELEASING PROMOTING",
-)
+class _Phase(enum.Enum):
+    """First six: stable resting states. Last three: transient reservations taken
+    before a command is queued, so a conflicting command is refused immediately.
+    """
+
+    UNCONFIGURED = enum.auto()
+    IDLE = enum.auto()
+    STANDBY = enum.auto()
+    PRIMARY = enum.auto()
+    FAILED = enum.auto()
+    CLOSED = enum.auto()
+    CLAIMING = enum.auto()
+    RELEASING = enum.auto()
+    PROMOTING = enum.auto()
 
 
 class _Guard:
-    """One pool's standby, alive as long as the service owns the pool.
+    """One pool's lifecycle actor: owns the pool file, control endpoint, holder
+    pidfd, and recovery state, alive as long as the service owns the pool.
     Outlives every primary: a claim is reported to it, not what creates it.
     """
 
@@ -136,6 +143,12 @@ class _Guard:
         # Recovered half a Guard cannot serve; kept for the next primary, which can.
         self._g3_records: dict[BlockKey, _G3Residency] = {}
         self._commands: queue.Queue[_Command] = queue.Queue()
+        self._ops = {
+            "claim": self._claim,
+            "release": self._stand_down,
+            "abort": self._abort,
+            "close": self._close,
+        }
         self._thread = threading.Thread(
             target=self._run, name=f"kvcr-guard-{spec.pool_id}", daemon=True
         )
@@ -320,7 +333,7 @@ class _Guard:
                 continue
             failed: BaseException | None = None
             try:
-                result = getattr(self, _OPS[command.operation])(*command.args)
+                result = self._ops[command.operation](*command.args)
             except BaseException as error:  # noqa: BLE001 - returned to caller
                 failed = error
                 with self._phase_lock:

--- a/src/kvcr/guard_protocol.py
+++ b/src/kvcr/guard_protocol.py
@@ -82,8 +82,7 @@ class _Claim(msgspec.Struct, frozen=True, tag="claim"):
             socket.inet_pton(socket.AF_INET, self.control_host)
         except OSError as error:
             raise ValueError(
-                f"KVCR control address must be a literal IPv4 address: "
-                f"{self.control_host}"
+                f"not a literal IPv4 address: {self.control_host}"
             ) from error
 
 
@@ -144,11 +143,7 @@ class PidfdLiveness:
         return self._pidfd
 
     def close(self) -> None:
-        """Give the descriptor up, whether or not the kernel agrees.
-
-        This stops representing a live holder either way, so a failure here is worth a
-        log line and nothing else.
-        """
+        """Give the descriptor up either way; a close failure is only logged."""
         # Under a lock: shutdown can race a failed claim's cleanup here, and
         # an unsynchronized swap lets both threads close -- the second close
         # can reach a descriptor number the process has since reused.
@@ -223,10 +218,25 @@ class KVCRClient:
         g3: G3Options | None = None,
     ) -> KVCRPoolHold:
         """Claim and map one service-owned pool."""
-        request = _claim_request(
-            pool_index, row_stride, compatibility_digest, g3, control_bind
+        g3_config = g3 and {
+            "paths": [str(path.expanduser().resolve()) for path in g3.paths],
+            "capacity_bytes_per_file": g3.capacity_bytes_per_file,
+            "backend": g3.backend,
+            "backend_options": dict(g3.backend_options),
+        }
+        # msgspec.convert validates where __init__ would not: bad stride,
+        # port or G3 path fails here, not at the service.
+        request = msgspec.convert(
+            {
+                "pool_index": pool_index,
+                "compatibility_digest": compatibility_digest,
+                "tier_config": {"row_stride": row_stride, "g3": g3_config},
+                "control_host": control_bind[0],
+                "control_port": control_bind[1],
+                "version": _PROTOCOL_VERSION,
+            },
+            type=_Claim,
         )
-        tier_config = request.tier_config
         connection = FramedConnection.connect(self._socket_path)
         attachment: KVCRPoolAttachment | None = None
         listener_fd: int | None = None
@@ -237,7 +247,7 @@ class KVCRClient:
             if isinstance(response, _Error):
                 raise KVCRServiceError(response.message)
             grant_received = True
-            spec = _grant_spec(response, pool_index, tier_config)
+            spec = _grant_spec(response, pool_index, request.tier_config)
             if listener_fd is None:
                 # Every pool has a Guard, and a Guard answers on the endpoint
                 # this claimant named. A grant without it means the two sides
@@ -247,12 +257,11 @@ class KVCRClient:
                 )
             try:
                 effective_bytes, rows = _compute_pool_geometry(
-                    spec.data_bytes, tier_config.row_stride
+                    spec.data_bytes, request.tier_config.row_stride
                 )
             except ValueError as geometry_error:
                 raise KVCRGuardProtocolError(
-                    "invalid pool grant: mapping must contain the journal and at "
-                    "least one complete KV row"
+                    "invalid pool grant: no room for the journal and one KV row"
                 ) from geometry_error
             attachment = KVCRPoolAttachment.attach(spec)
             return KVCRPoolHold(
@@ -264,83 +273,28 @@ class KVCRClient:
                 _control_listener_fd=listener_fd,
             )
         except BaseException as error:
-            _abandon_claim(connection, attachment, listener_fd)
+            # Release the lease only after local access has stopped, or the
+            # next claimant could map bytes this process can still reach.
+            if listener_fd is not None:
+                with contextlib.suppress(OSError):
+                    os.close(listener_fd)
+            local_access_stopped = True
+            if attachment is not None:
+                try:
+                    attachment.close()
+                except BaseException:
+                    # Even an interrupt mid-close must gate the release.
+                    local_access_stopped = False
+            if local_access_stopped:
+                # Sent even without a grant seen: the service may hold a lease
+                # this claimant never learned it won; only this message or death
+                # -- never bare EOF -- rolls it back. Must not mask the claim error.
+                with contextlib.suppress(BaseException):
+                    _send_release(connection, activated=False)
+            _close_quietly(connection)
             if not grant_received and isinstance(error, (OSError, EOFError)):
                 raise KVCRSocketError(f"KVCR-Service claim failed: {error}") from error
             raise
-
-
-def _abandon_claim(
-    connection: FramedConnection,
-    attachment: KVCRPoolAttachment | None,
-    listener_fd: int | None,
-) -> None:
-    """Give back everything a claim took before it failed.
-
-    The lease is only released once local access has actually stopped: telling
-    the service the pool is free while this process can still reach its bytes
-    is what would let the next claimant map them underneath us.
-    """
-    if listener_fd is not None:
-        with contextlib.suppress(OSError):
-            os.close(listener_fd)
-    local_access_stopped = True
-    if attachment is not None:
-        try:
-            attachment.close()
-        except BaseException:
-            # BaseException: even an interrupt mid-close must gate the release;
-            # the claim error re-raises above.
-            local_access_stopped = False
-    if local_access_stopped:
-        # Sent whether or not a grant was seen: the service may hold a lease
-        # this claimant never learned it won, and only this explicit message
-        # -- or the claimant's death -- may roll such a lease back. EOF alone
-        # must not, because a claimant that DID map the pool can drop its
-        # connection while still alive. Best-effort during unwind: nothing
-        # raised here may mask the claim error re-raised by the caller.
-        with contextlib.suppress(BaseException):
-            _send_release(connection, activated=False)
-    _close_quietly(connection)
-
-
-def _claim_request(
-    pool_index: int,
-    row_stride: int,
-    compatibility_digest: str,
-    g3: G3Options | None,
-    control_bind: tuple[str, int],
-) -> _Claim:
-    """Build the wire form of a claim, validating it before it is sent.
-
-    msgspec validates on convert and not on __init__, so a bad stride, port or G3
-    path is caught here rather than on the service's side of the socket.
-    """
-    return msgspec.convert(
-        {
-            "pool_index": pool_index,
-            "compatibility_digest": compatibility_digest,
-            "tier_config": {
-                "row_stride": row_stride,
-                "g3": (
-                    None
-                    if g3 is None
-                    else {
-                        "paths": [
-                            str(path.expanduser().resolve()) for path in g3.paths
-                        ],
-                        "capacity_bytes_per_file": g3.capacity_bytes_per_file,
-                        "backend": g3.backend,
-                        "backend_options": dict(g3.backend_options),
-                    }
-                ),
-            },
-            "control_host": control_bind[0],
-            "control_port": control_bind[1],
-            "version": _PROTOCOL_VERSION,
-        },
-        type=_Claim,
-    )
 
 
 def _grant_spec(

--- a/src/kvcr/kvcr_service.py
+++ b/src/kvcr/kvcr_service.py
@@ -18,7 +18,6 @@ import socketserver
 import stat
 import threading
 import time
-from collections.abc import Callable
 from pathlib import Path
 from types import FrameType
 from typing import Any
@@ -61,17 +60,11 @@ _DEFAULT_JOURNAL_BYTES = 100 * (1 << 20)
 _ORPHANED_POOL_NAME = re.compile(rf"{re.escape(_POOL_PREFIX)}-.+-[0-9a-f]{{32}}")
 
 
-def _log_uncontained_failure(error: BaseException) -> None:
-    """Stand-in until a server claims this registry."""
-    logger.critical("Uncontained KVCR pool failure: %s", error)
-
-
 class _PoolRegistry:
     """A directory of pools, each owned end to end by its own Guard thread.
 
-    Nothing here is locked. One pool's claims, releases and deaths are ordered
-    by that pool's mailbox, and no two pools share anything but the refusal
-    flag that stops the whole service granting more.
+    No locks: each pool's mailbox orders its claims, releases and deaths;
+    pools share nothing but the refusal flag.
     """
 
     def __init__(
@@ -88,9 +81,9 @@ class _PoolRegistry:
         self._pool_count = pool_count
         self._pools: dict[int, _Guard] = {}
         self._refusing = threading.Event()
-        # Replaced by the owning server: only it can stop the service.
-        self.on_uncontained_failure: Callable[[BaseException], None] = (
-            _log_uncontained_failure
+        # Stand-in until the owning server takes over; only it can stop the service.
+        self.on_uncontained_failure = functools.partial(
+            logger.critical, "Uncontained KVCR pool failure: %s"
         )
         self._purge_orphaned_pools()
         for rank in range(pool_count):
@@ -134,12 +127,10 @@ class _PoolRegistry:
                 guard.close()
             except BaseException:
                 # The Guard's thread may still hold this pool's mapping, and
-                # unlinking under it would fault the process. Leave the file --
-                # the next start's purge reclaims it once the process is gone --
-                # and keep the pool visible with whatever it still holds.
+                # unlinking under it would fault the process. Leave the file
+                # for the next start's purge, and keep the pool visible.
                 logger.warning(
-                    "Failed to close KVCR Guard for %s during rollback; "
-                    "leaving its pool in place",
+                    "Failed to close KVCR Guard for %s; leaving its pool in place",
                     guard._spec.path,
                     exc_info=True,
                 )
@@ -149,7 +140,7 @@ class _PoolRegistry:
     def _purge_orphaned_pools(self) -> None:
         """Remove pool files no live daemon owns.
 
-        A pool left by a crash fills a fixed-size directory and fails the next eager
+        Crash leftovers fill the fixed-size directory and fail the next eager
         allocation. Use is decided by the shared flock, never the filename.
         """
         with _pool_dir_guard(self._pool_dir, exclusive=True):
@@ -182,7 +173,7 @@ class _PoolRegistry:
             )
         guard = self._pools.get(pool_index)
         if guard is None:
-            raise KVCRServiceError("KVCR pool registry is closed")
+            raise KVCRServiceError(f"no claimable KVCR pool {pool_index}")
         return guard
 
     def claim(
@@ -194,9 +185,8 @@ class _PoolRegistry:
     ) -> "tuple[KVCRPoolSpec, int, _Lease]":
         """Give a pool to a primary, and hand back the endpoint it answers on.
 
-        This check is a fast path only; the grant is committed on the pool's
-        actor thread under the same lock refuse_claims is read under, so no
-        grant can be produced after a refusal has returned.
+        The refusal check is a fast path only; the grant commits on the pool's
+        actor under the same lock refuse_claims reads, so no grant follows it.
         """
         if self._refusing.is_set():
             raise KVCRServiceError("KVCR pool registry is closed")
@@ -212,33 +202,24 @@ class _PoolRegistry:
     def refuse_claims(self) -> None:
         """Stop granting pools without waiting for the close path to run.
 
-        Passing each pool's phase lock is the barrier that makes the promise
-        exact: a claim that read the flag before it was set has committed by
-        the time its lock is released, so once this returns, no grant can be
-        produced anywhere -- not even by a commit already in flight. Delivery
-        of a grant committed before the barrier may still complete after it;
-        that lease is fenced like any other, so refusal never double-grants.
+        Each pool's phase lock is the barrier: after this returns, no grant can
+        commit. Pre-barrier grants may still deliver; those leases are fenced.
         """
         self._refusing.set()
-        for guard in self._pools.values():
+        # Snapshot: close() deletes pools from the dict on other threads.
+        for guard in list(self._pools.values()):
             with guard._phase_lock:
                 pass
-
-    def is_closed(self) -> bool:
-        """Whether this registry has stopped granting pools."""
-        return self._refusing.is_set()
 
     def close(self) -> None:
         """Give every pool back, keeping the first reason one would not go.
 
-        Pools are independent, so one that will not close keeps only its own file
-        and endpoint. Nothing retries this: the flock dies with the process, and
-        the next service to start reclaims what is left.
+        A pool that will not close keeps only its own file and endpoint. No
+        retries: the flock dies with the process; the next start reclaims.
         """
         self._refusing.set()
         failure: BaseException | None = None
-        # Told before waited on: a wedged pool must not keep its neighbours
-        # from being told to close.
+        # Tell all pools before waiting on any: a wedged one must not block the rest.
         for guard in self._pools.values():
             try:
                 guard.begin_close()
@@ -255,19 +236,19 @@ class _PoolRegistry:
             except BaseException as error:  # noqa: BLE001 - raised below
                 failure = failure or error
                 kept.add(pool_index)
-        # A pool that would not go stays visible, with whatever it still holds.
+        # Wedged pools stay visible; drained ones stay listed until the whole
+        # drain finished, so a release racing shutdown is absorbed.
         for pool_index in [index for index in self._pools if index not in kept]:
             del self._pools[pool_index]
         if failure is not None:
             raise failure
         if wedged:
             raise TimeoutError(
-                "timed out waiting for KVCR pool transitions: "
-                f"pools {wedged} were left unclosed and leaked their resources"
+                f"timed out waiting for KVCR pool transitions: pools {wedged} leaked"
             )
 
     def _guard_failed(
-        self, pool_index: int, guard: "_Guard", error: BaseException
+        self, pool_index: int, _guard: "_Guard", error: BaseException
     ) -> None:
         """A Guard has stopped being one, which the service cannot survive.
 
@@ -275,7 +256,6 @@ class _PoolRegistry:
         still hold an endpoint the service cannot reach. One pool takes the others'
         workers with it; add isolation back if that stops being acceptable.
         """
-        del guard
         logger.critical("KVCR pool %d Guard failed", pool_index)
         self.on_uncontained_failure(error)
 
@@ -316,11 +296,8 @@ class _RequestHandler(socketserver.BaseRequestHandler):
 
         pool_index, listener_fd, lease = grant
         try:
-            # The accept-time idle timeout has done its job once a claim
-            # arrived; a held connection waits as long as the lease lives, and
-            # a timeout here would sever a healthy claimant's only clean-release
-            # path. Inside the try: a socket shutdown can already have landed,
-            # and the duplicated endpoint below must be closed either way.
+            # No timeout: a held connection must wait as long as the lease lives.
+            # Inside the try: shutdown may have landed; listener_fd closes either way.
             self.request.settimeout(None)
             self.channel.send_with_fd(response, listener_fd)
         # The lease is already granted and the send may have partially
@@ -339,9 +316,8 @@ class _RequestHandler(socketserver.BaseRequestHandler):
     def _await_release(self, pool_index: int, lease: "_Lease") -> None:
         """Wait for the one message a held connection may send: its release.
 
-        Nothing here watches the pidfd -- the pool's own actor does. An EOF
-        merely ends this connection; the lease outlives it, and a death still
-        promotes without any thread of ours in the loop.
+        The pool's actor watches the pidfd, not this thread. EOF only ends the
+        connection; the lease outlives it, and a death still promotes.
         """
         while True:
             try:
@@ -351,20 +327,13 @@ class _RequestHandler(socketserver.BaseRequestHandler):
             except (KVCRGuardProtocolError, KVCRMsgFramingError) as error:
                 self._send_error(error)
                 continue
-            if not self._release_or_fail(
-                pool_index, lease, activated=release.activated
-            ):
-                return
-            with contextlib.suppress(OSError):
-                self.channel.send(_Released(_PROTOCOL_VERSION))
+            if self._release_or_fail(pool_index, lease, release.activated):
+                with contextlib.suppress(OSError):
+                    self.channel.send(_Released(_PROTOCOL_VERSION))
             return
 
     def _release_or_fail(
-        self,
-        pool_index: int,
-        lease: "_Lease",
-        *,
-        activated: bool = True,
+        self, pool_index: int, lease: "_Lease", activated: bool = True
     ) -> bool:
         try:
             if activated:
@@ -374,8 +343,7 @@ class _RequestHandler(socketserver.BaseRequestHandler):
                 # it stood down may resume serving.
                 self.server.registry.abort_grant(pool_index, lease)
         except KVCRServiceError as error:
-            # The registry is closing under this release. The claimant still
-            # learns its release did not commit; nothing here is service-fatal.
+            # Registry closing: claimant learns the release did not commit; not fatal.
             self._send_error(error)
             return False
         except BaseException as error:  # noqa: BLE001 - post-grant failure
@@ -429,7 +397,6 @@ class _ThreadingUnixServer(
         request: _Claim,
         liveness: PidfdLiveness,
     ) -> "tuple[_Granted, tuple[int, int, _Lease]]":
-        """Claim a pool, returning the grant and the endpoint it promises."""
         if request.compatibility_digest != self.compatibility_digest:
             raise KVCRServiceError(
                 "KVCR compatibility digest does not match the service"
@@ -441,21 +408,14 @@ class _ThreadingUnixServer(
             (request.control_host, request.control_port),
         )
         return (
-            _Granted(
-                request.pool_index,
-                spec,
-                request.tier_config,
-                _PROTOCOL_VERSION,
-            ),
+            _Granted(request.pool_index, spec, request.tier_config, _PROTOCOL_VERSION),
             (request.pool_index, listener_fd, lease),
         )
 
     def fail(self, error: BaseException) -> None:
-        """Stop the service, keeping the failure that started it.
+        """Stop the service, keeping only the first failure.
 
-        A fatal failure cascades and the endings it triggers report failures of their
-        own. The first explains the rest, so it is kept -- under a lock, because Guard
-        and request threads both arrive here.
+        Locked: Guard and request threads race here; the first explains the rest.
         """
         with self._fatal_lock:
             if self._fatal_error is None:
@@ -504,11 +464,7 @@ class _KVCRService:
         # per pod and clears the path before starting it.
         _unlink_stale_socket(self.socket_path)
         self._registry = _PoolRegistry(
-            pool_dir,
-            pool_count,
-            pool_size_bytes,
-            journal_bytes,
-            compatibility_digest,
+            pool_dir, pool_count, pool_size_bytes, journal_bytes, compatibility_digest
         )
         try:
             self._server = _ThreadingUnixServer(

--- a/src/kvcr/kvcr_service.py
+++ b/src/kvcr/kvcr_service.py
@@ -214,8 +214,9 @@ class _PoolRegistry:
     def close(self) -> None:
         """Give every pool back, keeping the first reason one would not go.
 
-        A pool that will not close keeps only its own file and endpoint. No
-        retries: the flock dies with the process; the next start reclaims.
+        A pool that will not close keeps only its own file and endpoint and
+        stays listed, so a later close can try it again; failing that, the
+        flock dies with the process and the next start reclaims.
         """
         self._refusing.set()
         failure: BaseException | None = None

--- a/src/kvcr/kvcr_service.py
+++ b/src/kvcr/kvcr_service.py
@@ -12,7 +12,6 @@ import logging
 import math
 import os
 import re
-import select
 import signal
 import socket
 import socketserver
@@ -20,7 +19,6 @@ import stat
 import threading
 import time
 from collections.abc import Callable
-from dataclasses import dataclass
 from pathlib import Path
 from types import FrameType
 from typing import Any
@@ -30,9 +28,8 @@ from .control_channels import (
     KVCRGuardProtocolError,
     KVCRMsgFramingError,
     KVCRServiceError,
-    ZmqPeerControlChannel,
 )
-from .guard import _Guard
+from .guard import _Guard, _Lease
 from .guard_protocol import (
     _CLAIM_DECODER,
     _PROTOCOL_VERSION,
@@ -52,13 +49,11 @@ from .memory import (
     _reclaim_pool_if_orphaned,
     _unlink_if_identity,
 )
-from .recovery_journal import RecoveryMirrorError
 
 logger = logging.getLogger(__name__)
 
 _PRIVATE_SOCKET_UMASK = 0o177
 _CLIENT_IDLE_TIMEOUT_SECONDS = 30.0
-_HOLD_POLL_MILLISECONDS = 1000
 _REGISTRY_TRANSITION_TIMEOUT_SECONDS = 30.0
 _STALE_SOCKET_PROBE_SECONDS = 1.0
 _DEFAULT_JOURNAL_BYTES = 100 * (1 << 20)
@@ -71,36 +66,14 @@ def _log_uncontained_failure(error: BaseException) -> None:
     logger.critical("Uncontained KVCR pool failure: %s", error)
 
 
-@dataclass
-class _PoolDescriptor:
-    """Everything the service knows about one pool.
+class _PoolRegistry:
+    """A directory of pools, each owned end to end by its own Guard thread.
 
-    One record rather than a map per attribute, so a holder, a listener and a
-    Guard cannot disagree about which pool they belong to.
+    Nothing here is locked. One pool's claims, releases and deaths are ordered
+    by that pool's mailbox, and no two pools share anything but the refusal
+    flag that stops the whole service granting more.
     """
 
-    owner: _KVCRPoolOwner
-    guard: "_Guard"
-    holder: PidfdLiveness | None = None
-    listener: socket.socket | None = None
-    # The address as the claimant asked for it: getsockname() answers
-    # numerically and would reject every alias of the same address.
-    bind: tuple[str, int] | None = None
-    in_transition: bool = False
-
-    def close_holder(self) -> None:
-        if self.holder is not None:
-            self.holder.close()
-            self.holder = None
-
-    def close_listener(self) -> None:
-        if self.listener is not None:
-            self.listener.close()
-            self.listener = None
-            self.bind = None
-
-
-class _PoolRegistry:
     def __init__(
         self,
         pool_dir: str | os.PathLike[str],
@@ -113,11 +86,8 @@ class _PoolRegistry:
         if not self._pool_dir.is_dir():
             raise ValueError(f"KVCR pool directory does not exist: {self._pool_dir}")
         self._pool_count = pool_count
-        self._compatibility_digest = compatibility_digest
-        self._pools: dict[int, _PoolDescriptor] = {}
-        self._lock = threading.Lock()
-        self._condition = threading.Condition(self._lock)
-        self._closed = False
+        self._pools: dict[int, _Guard] = {}
+        self._refusing = threading.Event()
         # Replaced by the owning server: only it can stop the service.
         self.on_uncontained_failure: Callable[[BaseException], None] = (
             _log_uncontained_failure
@@ -138,6 +108,9 @@ class _PoolRegistry:
                         owner.spec,
                         functools.partial(self._guard_failed, rank),
                         compatibility_digest=compatibility_digest,
+                        pool_index=rank,
+                        owner=owner,
+                        refusing=self._refusing.is_set,
                     )
                 except BaseException:
                     # Nothing has recorded this pool yet, so the sweep below cannot
@@ -146,39 +119,32 @@ class _PoolRegistry:
                     raise
                 # Recorded before it starts, so a failed preparation is rolled back by
                 # the sweep below.
-                self._pools[rank] = _PoolDescriptor(owner, guard)
+                self._pools[rank] = guard
                 guard.start()
             except BaseException:
-                self._release_pools_locked()
+                self._release_pools()
                 raise
 
-    def _release_pools_locked(self) -> None:
+    def _release_pools(self) -> None:
         """Give back every pool built so far, for a startup that cannot finish."""
-        for entry in self._pools.values():
+        for pool_index, guard in list(self._pools.items()):
             # Even an interrupt must not stop the sweep: the startup failure is
             # already propagating, and every pool left behind is committed RAM.
             try:
-                entry.guard.close()
+                guard.close()
             except BaseException:
                 # The Guard's thread may still hold this pool's mapping, and
-                # unlinking under it would fault the process. Leave the file;
-                # the next start's purge reclaims it once the process is gone.
+                # unlinking under it would fault the process. Leave the file --
+                # the next start's purge reclaims it once the process is gone --
+                # and keep the pool visible with whatever it still holds.
                 logger.warning(
                     "Failed to close KVCR Guard for %s during rollback; "
                     "leaving its pool in place",
-                    entry.owner.spec.path,
+                    guard._spec.path,
                     exc_info=True,
                 )
                 continue
-            try:
-                entry.owner.close()
-            except (BufferError, OSError):
-                logger.warning(
-                    "Failed to release KVCR pool %s during allocation rollback",
-                    entry.owner.spec.path,
-                    exc_info=True,
-                )
-        self._pools.clear()
+            del self._pools[pool_index]
 
     def _purge_orphaned_pools(self) -> None:
         """Remove pool files no live daemon owns.
@@ -209,221 +175,88 @@ class _PoolRegistry:
                 else:
                     logger.info("Leaving KVCR pool still in use: %s", path)
 
+    def _pool(self, pool_index: int) -> _Guard:
+        if not (0 <= pool_index < self._pool_count):
+            raise KVCRServiceError(
+                f"pool_index {pool_index} is out of range [0, {self._pool_count})"
+            )
+        guard = self._pools.get(pool_index)
+        if guard is None:
+            raise KVCRServiceError("KVCR pool registry is closed")
+        return guard
+
     def claim(
         self,
         pool_index: int,
         tier_config: _TierConfig,
         liveness: PidfdLiveness,
         control_bind: tuple[str, int],
-    ) -> KVCRPoolSpec:
-        """Give a pool to a primary, and tell the pool's Guard about it."""
-        with self._condition:
-            self._ensure_open()
-            if not (0 <= pool_index < self._pool_count):
-                raise KVCRServiceError(
-                    f"pool_index {pool_index} is out of range [0, {self._pool_count})"
-                )
-            pool = self._pools[pool_index]
-            if pool.in_transition:
-                raise KVCRServiceError(f"KVCR pool {pool_index} is busy")
-            current = pool.holder
-            if current is not None:
-                poller = select.poll()
-                poller.register(current.fileno(), select.POLLIN)
-                if not any(flags & select.POLLIN for _, flags in poller.poll(0)):
-                    raise KVCRServiceError(
-                        f"KVCR pool {pool_index} is held by another worker"
-                    )
-                # Dead but not yet free: its watcher is the sole promotion authority.
-                raise KVCRServiceError(f"KVCR pool {pool_index} is busy")
-            # Layout, not use: the claimant and the Guard each derive geometry from the
-            # same numbers.
-            spec = pool.owner.spec
-            bound_here = pool.listener is None
-            listener = self._bind_control_listener_locked(
-                pool, pool_index, control_bind
-            )
-            pool.in_transition = True
+    ) -> "tuple[KVCRPoolSpec, int, _Lease]":
+        """Give a pool to a primary, and hand back the endpoint it answers on.
 
-        # Unlocked: adopting blocks, and every other pool's claim, release and
-        # death handling needs this lock in the meantime.
-        try:
-            # from_shared_listener detaches what it is given, so the Guard gets a
-            # duplicate and the service keeps the original. Closed here if never taken:
-            # a stray dup of a listening socket keeps the address bound.
-            duplicate = socket.socket(fileno=os.dup(listener.fileno()))
-            try:
-                control = ZmqPeerControlChannel.from_shared_listener(duplicate)
-            except BaseException:
-                duplicate.close()
-                raise
-            pool.guard.adopt(control, tier_config)
-        except BaseException as error:
-            unbind_error: BaseException | None = None
-            with self._condition:
-                try:
-                    if bound_here and pool.holder is None:
-                        # This claim chose the address and then failed, so keeping it
-                        # would refuse the retry as an endpoint move.
-                        try:
-                            pool.listener.close()
-                        except BaseException as close_error:  # noqa: BLE001
-                            unbind_error = close_error
-                        pool.listener = None
-                        pool.bind = None
-                    if unbind_error is not None:
-                        # Latched here rather than by the escalation below: the pool
-                        # is free and unbound the moment this lock drops, and nothing
-                        # may claim it on an address that would not close.
-                        self._closed = True
-                finally:
-                    # Including an interrupt landing mid-cleanup: a pool left in
-                    # transition is one no later claim can have, and one shutdown
-                    # waits out.
-                    self._finish_transition_locked(pool_index)
-            if unbind_error is not None:
-                # Outside the lock, which refuse_claims needs. An address that will
-                # not close is one the service can neither reach nor hand out.
-                self._guard_failed(pool_index, pool.guard, unbind_error)
-            if isinstance(error, (ValueError, RecoveryMirrorError)):
-                raise KVCRServiceError(str(error)) from error
-            raise
-
-        with self._condition:
-            # Recorded before the check: the pool has already changed hands, so a close
-            # racing this must see the holder rather than find it in transition.
-            pool.holder = liveness
-            self._finish_transition_locked(pool_index)
-            self._ensure_open()
-        return spec
-
-    def _begin_holder_transition(
-        self, pool_index: int, liveness: PidfdLiveness
-    ) -> bool:
-        """Reserve the transition this lease is ending through, if it owns one.
-
-        A release and a holder's death start the same way: the caller may be reporting
-        a lease the registry has already replaced, and a stale one owns nothing.
+        This check is a fast path only; the grant is committed on the pool's
+        actor thread under the same lock refuse_claims is read under, so no
+        grant can be produced after a refusal has returned.
         """
-        with self._condition:
-            pool = self._pools.get(pool_index)
-            if pool is None or pool.holder is not liveness:
-                stale = True
-            elif self._closed or pool.in_transition:
-                return False
-            else:
-                stale = False
-                pool.in_transition = True
-        if not stale:
-            return True
-        liveness.close()
-        return False
+        if self._refusing.is_set():
+            raise KVCRServiceError("KVCR pool registry is closed")
+        return self._pool(pool_index).claim(liveness, tier_config, control_bind)
 
-    def release(self, pool_index: int, liveness: PidfdLiveness) -> None:
-        """End a lease. The pool keeps its Guard, and the Guard its records."""
-        if not self._begin_holder_transition(pool_index, liveness):
-            return
-        pool = self._pools[pool_index]
-        try:
-            pool.guard.release()
-        except BaseException as error:
-            # Escalated before the pool is exposed: a Guard that failed here may
-            # have left a partial handback, and the next claimant could take it.
-            self._guard_failed(pool_index, pool.guard, error)
-            raise
-        finally:
-            liveness.close()
-            with self._condition:
-                if pool.holder is liveness:
-                    pool.holder = None
-                self._finish_transition_locked(pool_index)
+    def release(self, pool_index: int, lease: "_Lease") -> None:
+        self._pool(pool_index).release(lease)
 
-    def abort_grant(self, pool_index: int, liveness: PidfdLiveness) -> None:
-        """Take back a grant whose delivery failed; the claimant never saw it."""
-        if not self._begin_holder_transition(pool_index, liveness):
-            return
-        pool = self._pools[pool_index]
-        try:
-            pool.guard.abort_grant()
-        except BaseException as error:
-            self._guard_failed(pool_index, pool.guard, error)
-            raise
-        finally:
-            liveness.close()
-            with self._condition:
-                if pool.holder is liveness:
-                    pool.holder = None
-                self._finish_transition_locked(pool_index)
-
-    def holder_died(self, pool_index: int, liveness: PidfdLiveness) -> None:
-        """Promote this pool's Guard in place of the primary that died.
-
-        A promotion that fails takes the service with it: the pool has inherited the
-        dead primary's endpoint and half-adopted its records.
-        """
-        if not self._begin_holder_transition(pool_index, liveness):
-            return
-        pool = self._pools[pool_index]
-        try:
-            pool.guard.promote_after_death()
-        except BaseException as error:
-            # Escalated before the pool is exposed: a Guard that failed here may
-            # have left a partial handback, and the next claimant could take it.
-            self._guard_failed(pool_index, pool.guard, error)
-            raise
-        finally:
-            liveness.close()
-            with self._condition:
-                if pool.holder is liveness:
-                    pool.holder = None
-                self._finish_transition_locked(pool_index)
+    def abort_grant(self, pool_index: int, lease: "_Lease") -> None:
+        """Take back a grant its claimant declared it never served."""
+        self._pool(pool_index).abort_grant(lease)
 
     def refuse_claims(self) -> None:
-        """Stop granting pools without waiting for the close path to run."""
-        with self._condition:
-            self._closed = True
+        """Stop granting pools without waiting for the close path to run.
+
+        Passing each pool's phase lock is the barrier that makes the promise
+        exact: a claim that read the flag before it was set has committed by
+        the time its lock is released, so once this returns, no grant can be
+        produced anywhere -- not even by a commit already in flight. Delivery
+        of a grant committed before the barrier may still complete after it;
+        that lease is fenced like any other, so refusal never double-grants.
+        """
+        self._refusing.set()
+        for guard in self._pools.values():
+            with guard._phase_lock:
+                pass
 
     def is_closed(self) -> bool:
         """Whether this registry has stopped granting pools."""
-        with self._condition:
-            return self._closed
+        return self._refusing.is_set()
 
     def close(self) -> None:
-        """Release every pool, keeping the first reason one would not go.
+        """Give every pool back, keeping the first reason one would not go.
 
-        Pools are independent, so one that will not close keeps only its own file and
-        endpoint. Nothing retries this: the flock dies with the process, and the next
-        service to start reclaims what is left.
+        Pools are independent, so one that will not close keeps only its own file
+        and endpoint. Nothing retries this: the flock dies with the process, and
+        the next service to start reclaims what is left.
         """
-        deadline = time.monotonic() + _REGISTRY_TRANSITION_TIMEOUT_SECONDS
-        with self._condition:
-            self._closed = True
-            while any(entry.in_transition for entry in self._pools.values()):
-                if deadline - time.monotonic() <= 0:
-                    break
-                self._condition.wait(deadline - time.monotonic())
-            wedged = sorted(
-                index for index, entry in self._pools.items() if entry.in_transition
-            )
-
-        # No lock below: claims are refused and both endings return untouched.
+        self._refusing.set()
         failure: BaseException | None = None
-        for pool_index in sorted(self._pools):
-            if pool_index in wedged:
-                continue
-            pool = self._pools[pool_index]
+        # Told before waited on: a wedged pool must not keep its neighbours
+        # from being told to close.
+        for guard in self._pools.values():
             try:
-                # Only this gates the rest: a Guard that will not close may still be
-                # serving out of the mapping.
-                pool.guard.close()
+                guard.begin_close()
             except BaseException as error:  # noqa: BLE001 - raised below
                 failure = failure or error
-                continue
-            for step in (pool.close_holder, pool.close_listener, pool.owner.close):
-                try:
-                    step()
-                except BaseException as error:  # noqa: BLE001 - raised below
-                    failure = failure or error
+        deadline = time.monotonic() + _REGISTRY_TRANSITION_TIMEOUT_SECONDS
+        wedged: list[int] = []
+        kept: set[int] = set()
+        for pool_index in sorted(self._pools):
+            try:
+                if self._pools[pool_index].finish_close(deadline):
+                    wedged.append(pool_index)
+                    kept.add(pool_index)
+            except BaseException as error:  # noqa: BLE001 - raised below
+                failure = failure or error
+                kept.add(pool_index)
+        # A pool that would not go stays visible, with whatever it still holds.
+        for pool_index in [index for index in self._pools if index not in kept]:
             del self._pools[pool_index]
         if failure is not None:
             raise failure
@@ -432,42 +265,6 @@ class _PoolRegistry:
                 "timed out waiting for KVCR pool transitions: "
                 f"pools {wedged} were left unclosed and leaked their resources"
             )
-
-    def _bind_control_listener_locked(
-        self, pool: "_PoolDescriptor", pool_index: int, control_bind: tuple[str, int]
-    ) -> socket.socket:
-        """The address this pool answers on, bound once and never moved.
-
-        A Guard inherits the endpoint its primary used, so a claim naming a different
-        one is refused rather than migrated.
-        """
-        if pool.listener is not None:
-            if pool.bind != control_bind:
-                assert pool.bind is not None
-                raise KVCRServiceError(
-                    f"KVCR pool {pool_index} answers on "
-                    f"{pool.bind[0]}:{pool.bind[1]} and cannot be moved to "
-                    f"{control_bind[0]}:{control_bind[1]}"
-                )
-            return pool.listener
-        try:
-            listener = socket.create_server(control_bind)
-        except OSError as error:
-            raise KVCRServiceError(
-                f"KVCR pool {pool_index} control listener "
-                f"{control_bind[0]}:{control_bind[1]} is unavailable: {error}"
-            ) from error
-        pool.listener = listener
-        pool.bind = control_bind
-        return listener
-
-    def control_listener_fd(self, pool_index: int) -> int | None:
-        with self._condition:
-            pool = self._pools.get(pool_index)
-            if pool is None or pool.listener is None:
-                return None
-            listener = pool.listener
-            return os.dup(listener.fileno())
 
     def _guard_failed(
         self, pool_index: int, guard: "_Guard", error: BaseException
@@ -481,14 +278,6 @@ class _PoolRegistry:
         del guard
         logger.critical("KVCR pool %d Guard failed", pool_index)
         self.on_uncontained_failure(error)
-
-    def _finish_transition_locked(self, pool_index: int) -> None:
-        self._pools[pool_index].in_transition = False
-        self._condition.notify_all()
-
-    def _ensure_open(self) -> None:
-        if self._closed:
-            raise KVCRServiceError("KVCR pool registry is closed")
 
 
 class _RequestHandler(socketserver.BaseRequestHandler):
@@ -508,26 +297,32 @@ class _RequestHandler(socketserver.BaseRequestHandler):
             return
 
         liveness: PidfdLiveness | None = None
-        pool_index: int | None = None
+        grant: "tuple[int, int, _Lease] | None" = None
         try:
             liveness = PidfdLiveness.from_peer_socket(self.request)
-            response, pool_index = self.server.dispatch(request, liveness)
+            response, grant = self.server.dispatch(request, liveness)
         except KVCRServiceError as error:
             response = _Error(str(error), _PROTOCOL_VERSION)
         except Exception:  # noqa: BLE001 - report internal claim failures
             logger.exception("Unexpected failure while handling KVCR claim")
             response = _Error("internal KVCR service error", _PROTOCOL_VERSION)
 
-        if pool_index is None:
+        if grant is None:
             if liveness is not None:
                 liveness.close()
             with contextlib.suppress(OSError):
                 self.channel.send(response)
             return
 
-        assert liveness is not None
+        pool_index, listener_fd, lease = grant
         try:
-            self._deliver_grant(pool_index, response)
+            # The accept-time idle timeout has done its job once a claim
+            # arrived; a held connection waits as long as the lease lives, and
+            # a timeout here would sever a healthy claimant's only clean-release
+            # path. Inside the try: a socket shutdown can already have landed,
+            # and the duplicated endpoint below must be closed either way.
+            self.request.settimeout(None)
+            self.channel.send_with_fd(response, listener_fd)
         # The lease is already granted and the send may have partially
         # crossed: releasing could double-grant a pool a claimant just mapped.
         # Hold it instead, under the same fencing as any lease: the claimant's
@@ -536,112 +331,54 @@ class _RequestHandler(socketserver.BaseRequestHandler):
         # DID map the pool can drop its connection while still alive.
         except BaseException:
             logger.exception("KVCR grant delivery failed; holding the lease")
-        self._hold(pool_index, liveness)
-
-    def _deliver_grant(self, pool_index: int, response: "_Granted | _Error") -> None:
-        """Send a grant, with the endpoint it promises when it promises one."""
-        listener_fd: int | None = None
-        try:
-            if isinstance(response, _Granted):
-                listener_fd = self.server.registry.control_listener_fd(pool_index)
-                if listener_fd is None:
-                    # The grant says a Guard stands behind this endpoint; without the
-                    # descriptor the claimant would serve its own.
-                    raise KVCRServiceError(
-                        f"KVCR pool {pool_index} was granted with a Guard but "
-                        "has no control listener to hand over"
-                    )
-            if listener_fd is None:
-                self.channel.send(response)
-            else:
-                self.channel.send_with_fd(response, listener_fd)
         finally:
-            if listener_fd is not None:
-                with contextlib.suppress(OSError):
-                    os.close(listener_fd)
+            with contextlib.suppress(OSError):
+                os.close(listener_fd)
+        self._await_release(pool_index, lease)
 
-    def _hold(self, pool_index: int, liveness: PidfdLiveness) -> None:
-        try:
-            socket_fd = self.request.fileno()
-            pidfd = liveness.fileno()
-            poller = select.poll()
-            poller.register(socket_fd, select.POLLIN | select.POLLHUP | select.POLLERR)
-            poller.register(pidfd, select.POLLIN | select.POLLHUP | select.POLLERR)
-        except (OSError, ValueError) as error:
-            self._fail_unless_closed(error)
-            return
+    def _await_release(self, pool_index: int, lease: "_Lease") -> None:
+        """Wait for the one message a held connection may send: its release.
 
+        Nothing here watches the pidfd -- the pool's own actor does. An EOF
+        merely ends this connection; the lease outlives it, and a death still
+        promotes without any thread of ours in the loop.
+        """
         while True:
             try:
-                events = poller.poll(_HOLD_POLL_MILLISECONDS)
-            except OSError as error:
-                self.server.fail(error)
+                release = self.channel.receive(_RELEASE_DECODER)
+            except (EOFError, OSError):
                 return
-            if not events:
-                try:
-                    liveness.fileno()
-                except ValueError:
-                    return
-            ready = dict(events)
-            socket_flags = ready.get(socket_fd, 0)
-            if socket_flags & select.POLLIN:
-                try:
-                    release = self.channel.receive(_RELEASE_DECODER)
-                except (EOFError, OSError):
-                    poller.unregister(socket_fd)
-                    socket_flags = 0
-                except (KVCRGuardProtocolError, KVCRMsgFramingError) as error:
-                    self._send_error(error)
-                else:
-                    if not self._release_or_fail(
-                        pool_index, liveness, activated=release.activated
-                    ):
-                        return
-                    with contextlib.suppress(OSError):
-                        self.channel.send(_Released(_PROTOCOL_VERSION))
-                    return
-            pidfd_flags = ready.get(pidfd, 0)
-            if pidfd_flags & select.POLLIN:
-                try:
-                    self.server.registry.holder_died(pool_index, liveness)
-                except BaseException as error:
-                    self.server.fail(error)
+            except (KVCRGuardProtocolError, KVCRMsgFramingError) as error:
+                self._send_error(error)
+                continue
+            if not self._release_or_fail(
+                pool_index, lease, activated=release.activated
+            ):
                 return
-            if pidfd_flags & (select.POLLHUP | select.POLLERR | select.POLLNVAL):
-                self._fail_unless_closed(
-                    OSError(f"pidfd poll returned without POLLIN: {pidfd_flags:#x}")
-                )
-                return
-            if socket_flags & (select.POLLHUP | select.POLLERR | select.POLLNVAL):
-                poller.unregister(socket_fd)
-
-    def _fail_unless_closed(self, error: BaseException) -> None:
-        """Report a broken holder descriptor, unless shutdown is what broke it.
-
-        Closing the registry closes each holder's pidfd without waiting for the
-        thread watching it, which that thread sees as a descriptor that died. Both
-        the setup and the poll notice it, and neither has anything to report:
-        failing here would latch a cause that hides whatever stopped the service.
-        """
-        if self.server.registry.is_closed():
+            with contextlib.suppress(OSError):
+                self.channel.send(_Released(_PROTOCOL_VERSION))
             return
-        self.server.fail(error)
 
     def _release_or_fail(
         self,
         pool_index: int,
-        liveness: PidfdLiveness,
+        lease: "_Lease",
         *,
         activated: bool = True,
     ) -> bool:
         try:
             if activated:
-                self.server.registry.release(pool_index, liveness)
+                self.server.registry.release(pool_index, lease)
             else:
                 # The claimant declared it never served this lease; the Guard
                 # it stood down may resume serving.
-                self.server.registry.abort_grant(pool_index, liveness)
-        except BaseException as error:
+                self.server.registry.abort_grant(pool_index, lease)
+        except KVCRServiceError as error:
+            # The registry is closing under this release. The claimant still
+            # learns its release did not commit; nothing here is service-fatal.
+            self._send_error(error)
+            return False
+        except BaseException as error:  # noqa: BLE001 - post-grant failure
             self.server.fail(error)
             return False
         return True
@@ -691,12 +428,13 @@ class _ThreadingUnixServer(
         self,
         request: _Claim,
         liveness: PidfdLiveness,
-    ) -> tuple[_Granted, int]:
+    ) -> "tuple[_Granted, tuple[int, int, _Lease]]":
+        """Claim a pool, returning the grant and the endpoint it promises."""
         if request.compatibility_digest != self.compatibility_digest:
             raise KVCRServiceError(
                 "KVCR compatibility digest does not match the service"
             )
-        spec = self.registry.claim(
+        spec, listener_fd, lease = self.registry.claim(
             request.pool_index,
             request.tier_config,
             liveness,
@@ -709,7 +447,7 @@ class _ThreadingUnixServer(
                 request.tier_config,
                 _PROTOCOL_VERSION,
             ),
-            request.pool_index,
+            (request.pool_index, listener_fd, lease),
         )
 
     def fail(self, error: BaseException) -> None:

--- a/src/kvcr/memory.py
+++ b/src/kvcr/memory.py
@@ -149,28 +149,17 @@ class KVCRPoolAttachment:
         os.ftruncate(self._file_descriptor, offset + size)
         try:
             _populate_pages(self._file_descriptor, offset, size)
-            region = mmap.mmap(
+            # Mapping must close before the truncate; shrinking under it would fault.
+            with mmap.mmap(
                 self._file_descriptor, size, offset=offset, access=mmap.ACCESS_WRITE
-            )
+            ) as region:
+                yield region
         except BaseException:
-            # Back to the pool: an unusable tail still reads as a region, and
-            # the next claimant would try to replay it.
+            # Truncate back: a partial or stale tail still reads as a region; a
+            # claimant replaying it would diverge from the failed Guard's mirror.
             with contextlib.suppress(OSError):
                 os.ftruncate(self._file_descriptor, offset)
             raise
-        try:
-            yield region
-        except BaseException:
-            # A write that did not finish must not leave the previous snapshot
-            # readable: the Guard that failed here dropped its mirror, and a
-            # claimant replaying old frames would diverge from it. The mapping
-            # closes before the truncate; shrinking under it would fault.
-            region.close()
-            with contextlib.suppress(OSError):
-                os.ftruncate(self._file_descriptor, offset)
-            raise
-        else:
-            region.close()
 
     @contextlib.contextmanager
     def mapped_snapshot(self) -> Iterator[mmap.mmap | None]:
@@ -180,13 +169,10 @@ class KVCRPoolAttachment:
         if size <= 0:
             yield None
             return
-        region = mmap.mmap(
+        with mmap.mmap(
             self._file_descriptor, size, offset=offset, access=mmap.ACCESS_READ
-        )
-        try:
+        ) as region:
             yield region
-        finally:
-            region.close()
 
     def release_snapshot_region(self) -> None:
         """Give the region back once its records have been installed.
@@ -250,17 +236,14 @@ class _KVCRPoolOwner:
             file_stat = os.fstat(file_descriptor)
             file_identity = (file_stat.st_dev, file_stat.st_ino)
             try:
-                spec = msgspec.convert(
-                    {
-                        "pool_id": pool_id,
-                        "path": str(path),
-                        "generation": generation,
-                        "device": file_identity[0],
-                        "inode": file_identity[1],
-                        "mapping_bytes": pool_size_bytes,
-                        "journal_bytes": journal_bytes,
-                    },
-                    type=KVCRPoolSpec,
+                spec = KVCRPoolSpec(
+                    pool_id=pool_id,
+                    path=str(path),
+                    generation=generation,
+                    device=file_identity[0],
+                    inode=file_identity[1],
+                    mapping_bytes=pool_size_bytes,
+                    journal_bytes=journal_bytes,
                 )
                 # Dropped by the kernel on death, which is how another
                 # daemon tells a live pool from a crashed one's.
@@ -391,7 +374,7 @@ def _populate_pages(file_descriptor: int, offset: int, length: int) -> None:
     """Commit backing blocks so a later mapping touch cannot fault on ENOSPC.
 
     The range is explicit because the fallback writes: reserving past a live pool
-    must not touch the pool itself.
+    must not touch the pool itself. The pwrite fallback is O(pages), latent on Linux.
     """
     posix_fallocate = getattr(os, "posix_fallocate", None)
     if posix_fallocate is not None:
@@ -410,9 +393,7 @@ def _populate_pages(file_descriptor: int, offset: int, length: int) -> None:
     # where the same write through the descriptor reports ENOSPC. A whole page at a
     # time, so a filesystem with sub-page blocks does not leave every block but the
     # first sparse.
-    end = offset + length
-    chunk = bytes(mmap.PAGESIZE)
-    position = offset
+    chunk, position, end = bytes(mmap.PAGESIZE), offset, offset + length
     while position < end:
         span = min(mmap.PAGESIZE, end - position)
         count = os.pwrite(file_descriptor, chunk[:span], position)

--- a/src/kvcr/recovery_journal.py
+++ b/src/kvcr/recovery_journal.py
@@ -30,8 +30,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_ACQUIRE = 2
-_RELEASE = 3
+_ACQUIRE, _RELEASE = 2, 3
 
 
 @cache
@@ -42,21 +41,11 @@ def _atomics() -> tuple[Any, Any]:
     importing kvcr must not require what only recovery uses.
     """
     library = ctypes.CDLL(ctypes.util.find_library("atomic") or "libatomic.so.1")
-
-    def bind(name: str, argtypes: list[object], restype: object) -> Any:
-        function = getattr(library, name)
-        function.argtypes = argtypes
-        function.restype = restype
-        return function
-
-    return (
-        bind("__atomic_load_8", [ctypes.c_void_p, ctypes.c_int], ctypes.c_uint64),
-        bind(
-            "__atomic_store_8",
-            [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_int],
-            None,
-        ),
-    )
+    load, store = library["__atomic_load_8"], library["__atomic_store_8"]
+    load.argtypes, load.restype = [ctypes.c_void_p, ctypes.c_int], ctypes.c_uint64
+    store.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_int]
+    store.restype = None
+    return load, store
 
 
 class _AtomicU64:
@@ -71,13 +60,9 @@ class _AtomicU64:
         self._store(self._address, value, _RELEASE)
 
 
-_INVALID_OFFSET = 0
-_PUBLISHED_OFFSET = 128
-_CONSUMED_OFFSET = 192
-_VALID = 0
-_INVALID = 1
+_INVALID_OFFSET, _PUBLISHED_OFFSET, _CONSUMED_OFFSET = 0, 128, 192
+_VALID, _INVALID = 0, 1
 _ALIGNMENT = 8
-_MAX_U64 = (1 << 64) - 1
 _MAX_FRAME_SIZE = (1 << 16) - 1
 # Size, record type, key size. Per frame because BlockKey has no declared
 # width, so nothing would make a lease-wide key size true.
@@ -92,13 +77,10 @@ _RECORD_TYPES = frozenset({_RECORD_BLOCK})
 # filling ends recovery. 3 bytes a record instead of 21.
 #
 # Field order is the format. Append only -- never reorder or remove.
-_NonNegativeInt = Annotated[int, msgspec.Meta(ge=0)]
-
-
 class _RecoveryBlock(msgspec.Struct, frozen=True, array_like=True):
     # A slot per tier, or nothing. Bare ints: wrapping one costs a byte each.
-    g2: _NonNegativeInt | None = None
-    g3: _NonNegativeInt | None = None
+    g2: Annotated[int, msgspec.Meta(ge=0)] | None = None
+    g3: Annotated[int, msgspec.Meta(ge=0)] | None = None
 
 
 _RECOVERY_ENCODER = msgspec.msgpack.Encoder()
@@ -169,10 +151,9 @@ class RecoveryJournal:
     """
 
     def __init__(self, pool: KVCRPoolAttachment) -> None:
-        mapping = pool._require_mapping()
         self._pool = pool
         self._capacity = pool._spec.journal_bytes - _JOURNAL_HEADER_BYTES
-        base = ctypes.addressof(ctypes.c_char.from_buffer(mapping))
+        base = pool.address
         self._published = _AtomicU64(base + _PUBLISHED_OFFSET)
         self._consumed = _AtomicU64(base + _CONSUMED_OFFSET)
         self._invalid = _AtomicU64(base + _INVALID_OFFSET)
@@ -187,8 +168,7 @@ class RecoveryJournal:
         self._consumed.store_release(0)
         self._published.store_release(0)
         self._invalid.store_release(_VALID)
-        self._published_local = 0
-        self._consumed_local = 0
+        self._published_local = self._consumed_local = 0
         self._invalid_local = False
 
     def publish(self, record_type: int, key: bytes, payload: bytes) -> bool:
@@ -196,10 +176,6 @@ class RecoveryJournal:
         mapping = self._pool._require_mapping()
         if record_type not in _RECORD_TYPES:
             raise ValueError(f"unknown journal record type: {record_type}")
-        if not isinstance(key, bytes):
-            raise TypeError("journal key must be bytes")
-        if not isinstance(payload, bytes):
-            raise TypeError("journal payload must be bytes")
         if self._invalid_local:
             return False
 
@@ -208,7 +184,7 @@ class RecoveryJournal:
             return self._invalidate(
                 f"frame is {frame_size} bytes; maximum is {_MAX_FRAME_SIZE} bytes"
             )
-        stored_size = _align_up(frame_size)
+        stored_size = frame_size + (-frame_size % _ALIGNMENT)
         published = self._published_local
         if published is None:
             if self.is_invalid():
@@ -266,9 +242,8 @@ class RecoveryJournal:
             raise self._fail("journal frame has an invalid key size")
         if record_type not in _RECORD_TYPES:
             raise self._fail(f"journal frame has an unknown type: {record_type}")
-        stored_size = _align_up(frame_size)
-        available = published - consumed
-        if stored_size > self._capacity or stored_size > available:
+        stored_size = frame_size + (-frame_size % _ALIGNMENT)
+        if stored_size > self._capacity or stored_size > published - consumed:
             raise self._fail("journal frame exceeds the published bytes")
 
         frame = self._read_ring(mapping, position, stored_size)
@@ -320,20 +295,16 @@ class RecoveryJournal:
         start = _JOURNAL_HEADER_BYTES + position
         mapping[start : start + first] = data[:first]
         if first < len(data):
-            remaining = len(data) - first
-            mapping[_JOURNAL_HEADER_BYTES : _JOURNAL_HEADER_BYTES + remaining] = data[
-                first:
-            ]
+            end = _JOURNAL_HEADER_BYTES + len(data) - first
+            mapping[_JOURNAL_HEADER_BYTES:end] = data[first:]
 
     def _read_ring(self, mapping: object, position: int, length: int) -> bytes:
         first = min(length, self._capacity - position)
         start = _JOURNAL_HEADER_BYTES + position
         data = bytes(mapping[start : start + first])
         if first < length:
-            remaining = length - first
-            data += bytes(
-                mapping[_JOURNAL_HEADER_BYTES : _JOURNAL_HEADER_BYTES + remaining]
-            )
+            end = _JOURNAL_HEADER_BYTES + length - first
+            data += bytes(mapping[_JOURNAL_HEADER_BYTES:end])
         return data
 
 
@@ -395,9 +366,7 @@ class _RecoveryMirror:
 
 
 def _attach_journal(
-    local_dram: _LocalDram,
-    journal: RecoveryJournal,
-    g3: _G3 | None = None,
+    local_dram: _LocalDram, journal: RecoveryJournal, g3: _G3 | None = None
 ) -> None:
     """Attach stable G2/G3 residency publication to one journal."""
     enabled = True
@@ -409,8 +378,7 @@ def _attach_journal(
         try:
             if not journal.publish(record_type, key, payload):
                 logger.warning(
-                    "KVCR recovery publication disabled after the journal "
-                    "rejected a frame"
+                    "KVCR recovery publication disabled after a rejected frame"
                 )
                 enabled = False
         except Exception:
@@ -472,12 +440,11 @@ def claim_guarded_pool(
             "guard_config needs a framework control that can share its control "
             "endpoint, so that a Guard can answer on it after this worker dies"
         )
-    control_bind = bind_address()
     hold = KVCRClient(guard_config.kvcr_service_socket_path).claim(
         guard_config.pool_index,
         guard_config.row_stride,
         guard_config.compatibility_digest,
-        control_bind,
+        bind_address(),
         backend_configs.g3,
     )
     # The lease is live from here, and the caller cannot release what it has not
@@ -552,14 +519,8 @@ def _pack_frame(record_type: int, key: bytes, payload: bytes, size: int) -> byte
     frame = bytearray(size)
     frame_size = _FRAME_HEADER.size + len(key) + len(payload)
     _FRAME_HEADER.pack_into(frame, 0, frame_size, record_type, len(key))
-    key_end = _FRAME_HEADER.size + len(key)
-    frame[_FRAME_HEADER.size : key_end] = key
-    frame[key_end:frame_size] = payload
+    frame[_FRAME_HEADER.size : frame_size] = key + payload
     return frame
-
-
-def _align_up(value: int) -> int:
-    return value + (-value % _ALIGNMENT)
 
 
 def _recovery_frames(
@@ -591,31 +552,21 @@ def canonical_pool_terms(
         + b"\0"
         + bytes.fromhex(spec.generation)
         + _SNAPSHOT_TERMS.pack(
-            row_stride,
-            spec.journal_bytes,
-            spec.mapping_bytes,
-            spec.device,
-            spec.inode,
+            row_stride, spec.journal_bytes, spec.mapping_bytes, spec.device, spec.inode
         )
     )
 
 
-# A slice at a time: hashing whole would copy a tier's worth of records, and
-# a memoryview would keep the mmap exported so it could not be closed.
-_DIGEST_CHUNK_BYTES = 1 << 20
-
-
 def _snapshot_digest(terms: bytes, mapping: mmap.mmap, start: int, size: int) -> bytes:
     digest = hashlib.sha256(terms)
-    for offset in range(start, start + size, _DIGEST_CHUNK_BYTES):
-        digest.update(mapping[offset : min(offset + _DIGEST_CHUNK_BYTES, start + size)])
+    # memoryview avoids a tier-sized copy; an exported view blocks mmap close.
+    with memoryview(mapping) as view, view[start : start + size] as window:
+        digest.update(window)
     return digest.digest()
 
 
 def write_recovery_snapshot(
-    pool: KVCRPoolAttachment,
-    terms: bytes,
-    frames: Iterable[tuple[int, bytes, bytes]],
+    pool: KVCRPoolAttachment, terms: bytes, frames: Iterable[tuple[int, bytes, bytes]]
 ) -> None:
     """Publish this pool's state as a handback region past the pool itself.
 
@@ -693,11 +644,8 @@ def read_recovery_snapshot(
                 )
             key_start = offset + _FRAME_HEADER.size
             key_end = key_start + key_size
-            yield (
-                record_type,
-                bytes(region[key_start:key_end]),
-                bytes(region[key_end : offset + frame_size]),
-            )
+            payload = bytes(region[key_end : offset + frame_size])
+            yield record_type, bytes(region[key_start:key_end]), payload
             offset += frame_size
 
 
@@ -719,10 +667,9 @@ def read_handback(
             mirror.apply(*frame)
     except RecoveryJournalTornError:
         logger.warning(
-            "KVCR discarding a handback region that was never finished",
-            exc_info=True,
+            "KVCR discarding a handback region that was never finished", exc_info=True
         )
-        clear_recovery_snapshot(pool)
+        pool.release_snapshot_region()
         return _RecoveryMirror()
     return mirror
 

--- a/src/kvcr/recovery_journal.py
+++ b/src/kvcr/recovery_journal.py
@@ -519,7 +519,9 @@ def _pack_frame(record_type: int, key: bytes, payload: bytes, size: int) -> byte
     frame = bytearray(size)
     frame_size = _FRAME_HEADER.size + len(key) + len(payload)
     _FRAME_HEADER.pack_into(frame, 0, frame_size, record_type, len(key))
-    frame[_FRAME_HEADER.size : frame_size] = key + payload
+    body_start = _FRAME_HEADER.size + len(key)
+    frame[_FRAME_HEADER.size : body_start] = key
+    frame[body_start:frame_size] = payload
     return frame
 
 

--- a/tests/unit/test_control_channels.py
+++ b/tests/unit/test_control_channels.py
@@ -110,23 +110,6 @@ def channel() -> Iterator[ZmqPeerControlChannel]:
         yield ready
 
 
-def test_construction_does_not_claim_the_port_until_it_is_needed() -> None:
-    """A channel constructs while its port is held; the conflict surfaces at use."""
-    port = free_port()
-    # A returning primary must construct its channel while a Guard holds the port.
-    with (
-        listening_socket(port) as holder,
-        _channel(port) as channel,
-    ):
-        # A real conflict is still reported, just at the point of use.
-        with pytest.raises(OSError):
-            channel.initialize()
-
-        holder.close()
-
-        channel.initialize()
-
-
 def test_messages_keep_their_boundaries(pair: Pair) -> None:
     sender, receiver = pair
     claim = _Message("claim", {"pool_index": 3})
@@ -264,33 +247,8 @@ def test_recv_checks_for_data_without_blocking() -> None:
         fake_socket.poll.assert_called_once_with(0)
 
 
-def test_close_gives_up_every_socket_even_when_one_will_not_go() -> None:
-    """Stopping at the first failure would leave the pool's address bound."""
-    with listening_socket() as owner:
-        port = int(owner.getsockname()[1])
-        channel = ZmqPeerControlChannel("127.0.0.1", port, "127.0.0.1")
-        channel.adopt_listener(os.dup(owner.fileno()))
-        channel.initialize()
-        listener = channel._listener
-        pull = channel._socket
-        assert listener is not None and pull is not None
-        stubborn = Mock()
-        stubborn.close.side_effect = OSError("outgoing will not close")
-        channel._outgoing = {"tcp://peer": stubborn}
-
-        with pytest.raises(OSError, match="will not close"):
-            channel.close()
-
-        # The address has to be free whatever the outgoing socket did.
-        stubborn.close.assert_called_once_with()
-        assert listener.fileno() == -1
-        assert pull.closed
-        # And a second close finds nothing left to do.
-        channel.close()
-
-
-def test_an_adopted_listener_advertises_its_port_and_outlives_the_primary() -> None:
-    """An adopted listener advertises its port, serves the primary, then the Guard."""
+def test_an_adopted_listener_serves_conflicts_primary_and_guard() -> None:
+    """An adopted endpoint outlives bind conflicts, the primary, and a bad close."""
     # The service owns the endpoint; the worker adopts it, a Guard duplicates it.
     with listening_socket() as owner:
         port = int(owner.getsockname()[1])
@@ -302,6 +260,10 @@ def test_an_adopted_listener_advertises_its_port_and_outlives_the_primary() -> N
             closing(guarded) as guard,
             _push_socket() as sender,
         ):
+            # A returning primary constructs while a Guard holds its port; a
+            # real conflict is still reported, but only at the point of use.
+            with pytest.raises(OSError):
+                primary.initialize()
             primary.adopt_listener(os.dup(owner.fileno()))
             # A primary needs a real advertised endpoint; a Guard reflects routes.
             assert primary.endpoint == f"tcp://advertised-host:{port}"
@@ -316,7 +278,18 @@ def test_an_adopted_listener_advertises_its_port_and_outlives_the_primary() -> N
             sender.send(b"primary")
             assert _recv_until(primary, 1) == [b"primary"]
 
+            # Stopping at the first close failure would leave the address bound.
+            listener, pull = primary._listener, primary._socket
+            stubborn = Mock()
+            stubborn.close.side_effect = OSError("outgoing will not close")
+            primary._outgoing = {"tcp://peer": stubborn}
+            with pytest.raises(OSError, match="will not close"):
+                primary.close()
+            stubborn.close.assert_called_once_with()
+            assert listener.fileno() == -1 and pull.closed
+            # A second close finds nothing left to do.
             primary.close()
+
             guard.initialize()
             deadline = time.monotonic() + 2
             received: list[bytes] = []

--- a/tests/unit/test_control_channels.py
+++ b/tests/unit/test_control_channels.py
@@ -264,6 +264,31 @@ def test_recv_checks_for_data_without_blocking() -> None:
         fake_socket.poll.assert_called_once_with(0)
 
 
+def test_close_gives_up_every_socket_even_when_one_will_not_go() -> None:
+    """Stopping at the first failure would leave the pool's address bound."""
+    with listening_socket() as owner:
+        port = int(owner.getsockname()[1])
+        channel = ZmqPeerControlChannel("127.0.0.1", port, "127.0.0.1")
+        channel.adopt_listener(os.dup(owner.fileno()))
+        channel.initialize()
+        listener = channel._listener
+        pull = channel._socket
+        assert listener is not None and pull is not None
+        stubborn = Mock()
+        stubborn.close.side_effect = OSError("outgoing will not close")
+        channel._outgoing = {"tcp://peer": stubborn}
+
+        with pytest.raises(OSError, match="will not close"):
+            channel.close()
+
+        # The address has to be free whatever the outgoing socket did.
+        stubborn.close.assert_called_once_with()
+        assert listener.fileno() == -1
+        assert pull.closed
+        # And a second close finds nothing left to do.
+        channel.close()
+
+
 def test_an_adopted_listener_advertises_its_port_and_outlives_the_primary() -> None:
     """An adopted listener advertises its port, serves the primary, then the Guard."""
     # The service owns the endpoint; the worker adopts it, a Guard duplicates it.

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Private Guard lifecycle tests."""
 
+import concurrent.futures
 import errno
 import logging
 import os
@@ -9,22 +10,20 @@ import queue
 import select
 import socket
 import threading
-import time
 import uuid
 from contextlib import nullcontext
 from unittest.mock import Mock
 
+import msgspec
 import pytest
-from _kvcr_test_utils import _recovered_record
+from _kvcr_test_utils import _recovered_record, _wait_until
 
 from kvcr.config import LocalDramInfo
 from kvcr.control_channels import KVCRServiceError, ZmqPeerControlChannel
 from kvcr.core import _BlockRecord
 from kvcr.guard import (
     _Command,
-    _ConfiguredTier,
     _Guard,
-    _Lease,
     _Phase,
 )
 from kvcr.guard_protocol import _G3Config, _TierConfig
@@ -55,180 +54,18 @@ _TEST_DIGEST = "opaque digest: Preserve-Me EXACTLY"
 # G3 terms are refused at decode unless a real claimant could open them, so
 # tests that carry G3 use page-aligned strides over a page-sized pool.
 _PAGE_STRIDE = os.sysconf("SC_PAGE_SIZE")
-_PAGE_SPEC = KVCRPoolSpec(
-    pool_id="pool_0",
-    path="/tmp/kvcr-pool_0-" + "a" * 32,
-    generation="a" * 32,
-    device=0,
-    inode=0,
-    mapping_bytes=8192 + 2 * _PAGE_STRIDE,
-    journal_bytes=8192,
-)
+_PAGE_SPEC = msgspec.structs.replace(_TEST_SPEC, mapping_bytes=8192 + 2 * _PAGE_STRIDE)
 
 
-def _fake_attachment(**overrides) -> Mock:
+def _fake_attachment() -> Mock:
     """A stand-in with the pool-tail surface a Guard reaches for."""
     attachment = Mock(
         address=1234,
         data_address=1234 + _TEST_SPEC.journal_bytes,
         _spec=_TEST_SPEC,
-        **overrides,
     )
     attachment.mapped_snapshot.return_value = nullcontext(None)
     return attachment
-
-
-def _wait_until(predicate) -> None:
-    deadline = time.monotonic() + 2
-    while not predicate():
-        if time.monotonic() >= deadline:
-            raise AssertionError("condition was not reached")
-        time.sleep(0.001)
-
-
-def test_a_command_reaching_a_dead_actor_is_answered_with_a_typed_error() -> None:
-    """Nothing may wait forever on a thread that will never answer."""
-    guard = _guard_with_thread(alive=False)
-
-    with pytest.raises(KVCRServiceError, match="closed"):
-        guard._submit(_Command("release", (object(),)))
-
-
-def test_a_close_beginning_mid_poll_still_blocks_the_promotion() -> None:
-    """The one window the first gate cannot see: closing set while poll ran."""
-    guard = _configurable_guard()
-    read_fd, write_fd = os.pipe()
-    try:
-        os.write(write_fd, b"x")
-        guard._phase = _Phase.PRIMARY
-        guard._lease = _Lease(Mock(fileno=lambda: read_fd))
-        guard._promote_for = Mock()
-        poller = Mock()
-
-        def poll_during_which_close_begins(_timeout):
-            guard._closing = True
-            return [(read_fd, select.POLLIN)]
-
-        poller.poll.side_effect = poll_during_which_close_begins
-        poller.register = Mock()
-        import kvcr.guard as guard_module
-
-        with_mocked = Mock(return_value=poller)
-        original = guard_module.select.poll
-        guard_module.select.poll = with_mocked
-        try:
-            guard._observe_holder()
-        finally:
-            guard_module.select.poll = original
-
-        guard._promote_for.assert_not_called()
-        assert guard._reserved is None
-        assert guard._phase is _Phase.PRIMARY
-    finally:
-        os.close(read_fd)
-        os.close(write_fd)
-
-
-def test_a_claim_on_a_busy_pool_answers_busy_immediately() -> None:
-    """The reservation is taken on the caller's thread, before anything queues."""
-    guard = _configurable_guard()
-    guard._reserved = _Phase.CLAIMING
-
-    with pytest.raises(KVCRServiceError, match="busy"):
-        guard._reserve_claim()
-
-
-def test_a_claim_on_a_failed_pool_reports_the_failure() -> None:
-    guard = _configurable_guard()
-    failure = RuntimeError("promotion failed")
-    guard._failure = failure
-
-    with pytest.raises(RuntimeError) as raised:
-        guard._reserve_claim()
-
-    assert raised.value is failure
-
-
-def test_serving_guard_notifies_service_and_fences_core_after_poll_failure(
-    caplog,
-) -> None:
-    error = RuntimeError("poll failed")
-    core = Mock()
-    core.poll_completed.side_effect = error
-    control = Mock()
-    failure_callback = Mock()
-    guard = _Guard(
-        _TEST_SPEC,
-        failure_callback,
-        compatibility_digest=_TEST_DIGEST,
-    )
-    guard._control = control
-    guard._configure(_TierConfig(16, None))
-    guard._serving = True
-    guard._core = core
-    caplog.set_level(logging.ERROR, logger="kvcr.guard")
-
-    guard._poll()
-
-    assert guard._failure is error
-    assert caplog.messages == ["KVCR Guard background polling failed"]
-    assert caplog.records[0].exc_info is not None
-    assert caplog.records[0].exc_info[1] is error
-    core.close.assert_called_once_with()
-    control.close.assert_not_called()
-    failure_callback.assert_called_once_with(guard, error)
-
-
-def test_a_serving_guard_that_cannot_fence_its_endpoint_says_so() -> None:
-    """An address still bound to a dead Guard is the service's problem."""
-    error = RuntimeError("poll failed")
-    core = Mock()
-    core.poll_completed.side_effect = error
-    core.close.side_effect = OSError("close failed")
-    failure_callback = Mock()
-    guard = _Guard(
-        _TEST_SPEC,
-        failure_callback,
-        compatibility_digest=_TEST_DIGEST,
-    )
-    guard._control = Mock()
-    guard._configure(_TierConfig(16, None))
-    guard._serving = True
-    guard._core = core
-
-    guard._poll()
-
-    failure_callback.assert_called_once_with(guard, error)
-
-
-def test_standby_guard_failure_releases_adopted_listener() -> None:
-    """A standby that has failed must stop holding the pool's endpoint."""
-    listener = socket.create_server(("127.0.0.1", 0))
-    port = int(listener.getsockname()[1])
-    control = ZmqPeerControlChannel.from_shared_listener(
-        socket.socket(fileno=os.dup(listener.fileno()))
-    )
-    failure_callback = Mock()
-    error = RuntimeError("journal poll failed")
-    journal = Mock()
-    journal.read_next.side_effect = error
-    guard = _Guard(
-        _TEST_SPEC,
-        failure_callback,
-        compatibility_digest=_TEST_DIGEST,
-    )
-    guard._control = control
-    guard._configure(_TierConfig(16, None))
-    guard._journal = journal
-    guard._mirror = Mock()
-
-    guard._poll()
-
-    failure_callback.assert_called_once_with(guard, error)
-    listener.close()
-    # Only the Guard's duplicate could still be holding this now.
-    with socket.socket() as replacement:
-        replacement.bind(("127.0.0.1", port))
 
 
 class _Journal:
@@ -247,402 +84,16 @@ class _Journal:
             yield record
 
 
-def test_guard_prepares_promotes_and_closes_in_ownership_order(
-    tmp_path, monkeypatch
-) -> None:
-    first, second, g3_only = (
-        BlockKey(b"first"),
-        BlockKey(b"second"),
-        BlockKey(b"g3-only"),
-    )
-    first_record = _BlockRecord(
-        local_dram=_LocalDramResidency(0, _LocalDramState.READY),
-        g3=_G3Residency(7),
-    )
-    second_record = _BlockRecord(
-        local_dram=_LocalDramResidency(1, _LocalDramState.READY)
-    )
-    recovered = {
-        first: first_record,
-        second: second_record,
-        g3_only: _BlockRecord(g3=_G3Residency(9)),
-    }
-    frames = list(
-        (
-            _RECORD_BLOCK,
-            bytes(key),
-            _RECOVERY_ENCODER.encode(_project_recovery_record(record)),
-        )
-        for key, record in recovered.items()
-    )
-    journal = _Journal(frames)
-    closed = []
-    attachment = _fake_attachment()
-    attachment.close.side_effect = lambda: closed.append("attachment")
-    local_dram = Mock()
-    core = Mock(_local_dram=local_dram, _g3=None, _block_record_map={})
-    core.close.side_effect = lambda: closed.append("core")
-    constructed = []
-    order = []
-
-    # The seeding mechanics live on the core (adopt_recovery_records); this
-    # test orders the Guard's calls around it, not what happens inside it.
-    core.adopt_recovery_records.side_effect = lambda records: order.append(
-        ("adopt", tuple(records))
-    )
-    core.start.side_effect = lambda: order.append("start")
-    monkeypatch.setattr(
-        "kvcr.guard.clear_recovery_snapshot",
-        lambda _pool: order.append("clear"),
-    )
-
-    def new_core(config, bindings, backends):
-        constructed.append((config, bindings, backends))
-        return core
-
-    attach = Mock(return_value=attachment)
-    channel = Mock()
-    channel.close.side_effect = lambda: closed.append("control")
-    monkeypatch.setattr("kvcr.guard.KVCRPoolAttachment.attach", attach)
-    monkeypatch.setattr("kvcr.guard.RecoveryJournal", Mock(return_value=journal))
-    monkeypatch.setattr("kvcr.guard._KVCRCore", new_core)
-    spec = _PAGE_SPEC
-    g3_config = _G3Config(
-        paths=(str(tmp_path / "g3.data"),),
-        capacity_bytes_per_file=10 * _PAGE_STRIDE,
-        backend="FILE",
-        backend_options={},
-    )
-    guard = _Guard(spec, compatibility_digest=_TEST_DIGEST)
-    # Driven directly, then the thread starts already busy: the actor blocks
-    # on an empty mailbox when idle, so mutating around a sleeping thread
-    # would race its wakeup instead of testing the ordering.
-    guard._started = True
-    guard._prepare()
-    guard._adopt(channel, _TierConfig(_PAGE_STRIDE, g3_config))
-    try:
-        attach.assert_called_once_with(spec)
-        assert journal.reset_called
-        assert constructed == []
-        core.start.assert_not_called()
-
-        guard._promote()
-        guard._thread.start()
-
-        config, bindings, backends = constructed[0]
-        prefix = "KVCR-Guard-"
-        assert config.nixl_agent_name.startswith(prefix)
-        uuid.UUID(config.nixl_agent_name.removeprefix(prefix))
-        assert config.nixl_listen_port == 0
-        assert bindings.framework_control is channel
-        assert backends.local_dram == LocalDramInfo(1234 + 8192, 2 * _PAGE_STRIDE, 2)
-        # A Guard opens no G3: it serves the G2 half and keeps the rest for the
-        # primary that takes the pool back.
-        assert backends.g3 is None
-        assert set(guard._g3_records) == {first, g3_only}
-
-        assert journal.pending == []
-        assert order == [
-            ("adopt", (first, second)),
-            # Dropped before a slot moves: it describes rows about to be overwritten.
-            "clear",
-            "start",
-        ]
-        core.start.assert_called_once_with()
-        _wait_until(lambda: core.poll_completed.call_count > 0)
-    finally:
-        guard.close()
-
-    assert closed == ["core", "control", "attachment"]
+def _frame(key: BlockKey, record: _BlockRecord) -> tuple[int, bytes, bytes]:
+    """One journal frame, exactly as a primary would publish it."""
+    payload = _RECOVERY_ENCODER.encode(_project_recovery_record(record))
+    return (_RECORD_BLOCK, bytes(key), payload)
 
 
-def test_adopting_a_new_primary_canonicalises_the_records_it_keeps(
-    tmp_path, monkeypatch
-) -> None:
-    """Kept rather than rebuilt, so what is kept must be what a replay gives."""
-    core = Mock(_local_dram=Mock(), _g3=None, _block_record_map={})
-    monkeypatch.setattr(
-        "kvcr.guard.KVCRPoolAttachment.attach",
-        Mock(return_value=_fake_attachment()),
-    )
-    monkeypatch.setattr("kvcr.guard.RecoveryJournal", Mock(return_value=_Journal(())))
-    monkeypatch.setattr("kvcr.guard._KVCRCore", Mock(return_value=core))
-    monkeypatch.setattr(
-        "kvcr.guard.write_recovery_snapshot", lambda *args, **kwargs: None
-    )
-    guard = _Guard(_TEST_SPEC, compatibility_digest=_TEST_DIGEST)
-    guard.start()
-    guard._adopt(Mock(), _TierConfig(16, None))
-    try:
-        guard._promote()
-        unfinished = BlockKey(b"unfinished")
-        record = _BlockRecord(
-            local_dram=_LocalDramResidency(0, _LocalDramState.FILLING),
-            g3=_G3Residency(7),
-        )
-        record.g3.claim_count = 3
-        core._block_record_map = {unfinished: record}
-
-        guard._g3_records = {unfinished: _G3Residency(7)}
-
-        guard._adopt(Mock(), _TierConfig(16, None))
-
-        # The half-written G2 slot is dropped; the G3 half is carried whole.
-        records = guard._mirror.take_records()
-        assert records == {unfinished: _recovered_record(g3=7)}
-    finally:
-        guard.close()
-
-
-@pytest.mark.parametrize("reader", ["poll", "release", "promote"])
-def test_an_invalid_journal_costs_the_pool_on_every_path_that_reads_it(
-    reader: str,
-) -> None:
-    """Which reader gets there first is a race; none of them may take the service."""
-    guard = _configurable_guard()
-    # Every one of these readers runs on a pool a primary has already claimed.
-    guard._configured = _ConfiguredTier.derive(_TEST_SPEC, _TierConfig(16, None))
-    guard._mirror = _RecoveryMirror()
-    guard._attachment = Mock()
-    guard._control = None
-    journal = Mock()
-    error = RecoveryJournalError("recovery journal is invalid")
-    journal.read_next.side_effect = error
-    journal.drain.side_effect = error
-    guard._journal = journal
-    written: list[object] = []
-    guard._write_handback = lambda records, stride: written.append(records)
-    served: list[dict] = []
-    guard._serve = served.append
-    reported: list[BaseException] = []
-    guard._failure_callback = lambda _guard, failure: reported.append(failure)
-
-    if reader == "poll":
-        # Dropped rather than served: what is left of it is incomplete.
-        assert guard._poll() is False
-        assert guard._mirror is None
-        assert served == []
-    elif reader == "release":
-        guard._release()
-        # A standby that gave up recovery keeps nothing and serves nothing.
-        assert guard._mirror is None
-        assert served == []
-    else:
-        guard._promote()
-        # Promotion still happens, with nothing in it: the endpoint has to answer.
-        assert served == [{}]
-
-    # A primary outrunning its Guard is not a Guard failure.
-    assert reported == []
-    assert guard._failure is None
-    # Nothing is handed on: a prefix of what the primary published would name
-    # slots it has since reused.
-    assert written == []
-
-
-def test_a_guard_with_nothing_left_to_recover_still_takes_the_endpoint() -> None:
-    """The pool comes back cold, but its address still has to answer.
-
-    A Guard that declined to serve would leave the dead primary's peers sending
-    into an address nobody reads, waiting on a reply that is never sent.
-    """
-    guard = _configurable_guard()
-    guard._journal = Mock()
-    guard._mirror = None
-    served: list[dict] = []
-    guard._serve = served.append
-
-    guard._promote()
-
-    assert served == [{}]
-    # A handover after this still needs somewhere to put the core's records.
-    assert guard._mirror is not None
-
-
-def test_a_second_promotion_takes_the_g3_half_from_the_generation_that_left_it(
-    monkeypatch,
-) -> None:
-    """Two failovers: the second must not hand on the first's disk slots."""
-    stale, fresh = BlockKey(b"stale"), BlockKey(b"fresh")
-
-    def frames(key: BlockKey, slot: int) -> list[tuple[int, bytes, bytes]]:
-        return [
-            (
-                _RECORD_BLOCK,
-                bytes(key),
-                _RECOVERY_ENCODER.encode(
-                    _project_recovery_record(
-                        _BlockRecord(
-                            local_dram=_LocalDramResidency(0, _LocalDramState.READY),
-                            g3=_G3Residency(slot),
-                        )
-                    )
-                ),
-            )
-        ]
-
-    def evicted(key: BlockKey) -> tuple[int, bytes, bytes]:
-        return (
-            _RECORD_BLOCK,
-            bytes(key),
-            _RECOVERY_ENCODER.encode(_project_recovery_record(_BlockRecord())),
-        )
-
-    journals = [_Journal(frames(stale, 1))]
-    cores: list[Mock] = []
-
-    def new_core(*_args, **_kwargs) -> Mock:
-        # A promotion builds its own core, so the second starts empty.
-        core = Mock(_local_dram=Mock(), _g3=None, _block_record_map={})
-        cores.append(core)
-        return core
-
-    monkeypatch.setattr(
-        "kvcr.guard.KVCRPoolAttachment.attach",
-        Mock(return_value=_fake_attachment()),
-    )
-    monkeypatch.setattr("kvcr.guard.RecoveryJournal", Mock(side_effect=journals))
-    monkeypatch.setattr("kvcr.guard._KVCRCore", new_core)
-    monkeypatch.setattr(
-        "kvcr.guard.write_recovery_snapshot", lambda *args, **kwargs: None
-    )
-    monkeypatch.setattr(
-        "kvcr.guard.clear_recovery_snapshot", lambda *args, **kwargs: None
-    )
-    guard = _Guard(_TEST_SPEC, compatibility_digest=_TEST_DIGEST)
-    guard.start()
-    guard._adopt(Mock(), _TierConfig(16, None))
-    try:
-        guard._promote()
-        assert set(guard._g3_records) == {stale}
-
-        # A replacement takes the pool back, so the Guard stops holding it.
-        cores[-1]._block_record_map = {}
-        guard._adopt(Mock(), _TierConfig(16, None))
-        assert guard._g3_records == {}
-
-        # That replacement dies too, having dropped the old block and spilled
-        # a different one into the slot it freed.
-        guard._journal = _Journal([evicted(stale), *frames(fresh, 1)])
-        guard._promote()
-
-        assert set(guard._g3_records) == {fresh}
-        assert guard._g3_records[fresh].slot == 1
-    finally:
-        guard.close()
-
-
-def test_configuring_a_pool_is_what_fixes_the_tiers_it_will_accept(
-    tmp_path,
-) -> None:
-    """A real Guard, so the geometry the claim is measured against is the pool's."""
-    g3 = _G3Config(
-        paths=(str(tmp_path / "g3.data"),),
-        capacity_bytes_per_file=_PAGE_STRIDE,
-        backend="FILE",
-        backend_options={},
-    )
-    guard = _Guard(_TEST_SPEC, compatibility_digest=_TEST_DIGEST)
-
-    # Unclaimed, so any shape is still available.
-    guard._refuse_incompatible(_TierConfig(_PAGE_STRIDE, g3))
-    guard._configure(_TierConfig(32, None))
-
-    guard._refuse_incompatible(_TierConfig(32, None))
-    with pytest.raises(RecoveryMirrorError, match="another tier configuration"):
-        guard._refuse_incompatible(_TierConfig(_PAGE_STRIDE, g3))
-
-
-def test_guard_closes_control_when_its_thread_does_not_start(monkeypatch) -> None:
-    control = Mock()
-    attachment = _fake_attachment()
-    monkeypatch.setattr(
-        "kvcr.guard.KVCRPoolAttachment.attach", Mock(return_value=attachment)
-    )
-    monkeypatch.setattr("kvcr.guard.RecoveryJournal", Mock())
-    guard = _Guard(
-        _TEST_SPEC,
-        compatibility_digest=_TEST_DIGEST,
-    )
-    guard._control = control
-    guard._configure(_TierConfig(16, None))
-    guard._thread.start = Mock(side_effect=RuntimeError("thread start failed"))
-
-    with pytest.raises(RuntimeError, match="thread start failed"):
-        guard.start()
-    guard.close()
-
-    control.close.assert_called_once_with()
-    # The pool was attached before the thread was asked for, so close gives it back.
-    attachment.close.assert_called_once_with()
-
-
-def test_guard_retains_resources_when_promoted_core_is_not_quiescent() -> None:
-    control = Mock()
-    attachment = Mock()
-    core = Mock()
-    close_error = RuntimeError("progress did not stop")
-    core.close.side_effect = close_error
-    core.is_quiescent.return_value = False
-    guard = _Guard(
-        _TEST_SPEC,
-        compatibility_digest=_TEST_DIGEST,
-    )
-    guard._control = control
-    guard._configure(_TierConfig(16, None))
-    guard._core = core
-    guard._attachment = attachment
-
-    with pytest.raises(RuntimeError) as raised:
-        guard.close()
-
-    assert raised.value is close_error
-    control.close.assert_not_called()
-    attachment.close.assert_not_called()
-
-    core.close.side_effect = None
-    guard.close()
-    control.close.assert_called_once_with()
-    attachment.close.assert_called_once_with()
-
-
-def test_guard_contains_core_close_failure_after_quiescence(caplog) -> None:
-    control = Mock()
-    attachment = Mock()
-    core = Mock()
-    error = RuntimeError("close failed")
-    core.close.side_effect = error
-    core.is_quiescent.return_value = True
-    guard = _Guard(
-        _TEST_SPEC,
-        compatibility_digest=_TEST_DIGEST,
-    )
-    guard._control = control
-    guard._configure(_TierConfig(16, None))
-    guard._core = core
-    guard._attachment = attachment
-    caplog.set_level(logging.WARNING, logger="kvcr.guard")
-
-    guard.close()
-
-    assert caplog.messages == ["KVCR Guard core close failed after reaching quiescence"]
-    assert caplog.records[0].exc_info is not None
-    assert caplog.records[0].exc_info[1] is error
-    control.close.assert_called_once_with()
-    attachment.close.assert_called_once_with()
-
-
-def _guard_with_thread(*, alive: bool) -> _Guard:
-    """A Guard with only what _submit and close touch."""
-    guard = object.__new__(_Guard)
-    guard._thread = Mock()
-    guard._thread.is_alive.return_value = alive
-    guard._commands = queue.Queue()
-    guard._phase_lock = threading.Lock()
-    guard._closing = False
-    guard._started = True
-    guard._closed = False
-    return guard
+def _warm_core() -> Mock:
+    """A serving core still holding one READY G2 block."""
+    record = _BlockRecord(local_dram=_LocalDramResidency(0, _LocalDramState.READY))
+    return Mock(_block_record_map={BlockKey(b"warm"): record})
 
 
 def _configurable_guard() -> _Guard:
@@ -669,91 +120,475 @@ def _configurable_guard() -> _Guard:
     return guard
 
 
+def test_a_wait_timeout_racing_the_answer_returns_the_answer() -> None:
+    """A slow command's success must never be reported back as a timeout."""
+    guard = object.__new__(_Guard)
+    guard._commands = queue.Queue()
+
+    # The wait times out; the actor answers before the re-check.
+    command = _Command("claim")
+    command.future = Mock(
+        result=Mock(side_effect=[concurrent.futures.TimeoutError, "the-grant"]),
+        done=Mock(return_value=True),
+        exception=Mock(return_value=None),
+    )
+    assert guard._submit(command) == "the-grant"
+
+    # The handler's own TimeoutError is the answer and must propagate.
+    error = TimeoutError("hand-back timed out")
+    command = _Command("release")
+    command.future = Mock(
+        result=Mock(side_effect=error),
+        done=Mock(return_value=True),
+        exception=Mock(return_value=error),
+    )
+    with pytest.raises(TimeoutError, match="hand-back timed out"):
+        guard._submit(command)
+
+
+def test_a_command_reaching_a_dead_actor_is_answered_with_a_typed_error() -> None:
+    """Nothing may wait forever on a thread that will never answer."""
+    guard = object.__new__(_Guard)
+    guard._thread = Mock()
+    guard._thread.is_alive.return_value = False
+    guard._commands = queue.Queue()
+
+    with pytest.raises(KVCRServiceError, match="closed"):
+        guard._submit(_Command("release", (object(),)))
+
+
+def test_a_close_beginning_mid_poll_still_blocks_the_promotion(monkeypatch) -> None:
+    """The one window the first gate cannot see: closing set while poll ran."""
+    guard = _configurable_guard()
+    guard._phase = _Phase.PRIMARY
+    guard._lease = Mock(fileno=lambda: 7)
+    guard._promote_for = Mock()
+    poller = Mock()
+
+    def poll_during_which_close_begins(_timeout):
+        guard._closing = True
+        return [(7, select.POLLIN)]
+
+    poller.poll.side_effect = poll_during_which_close_begins
+    monkeypatch.setattr("kvcr.guard.select.poll", Mock(return_value=poller))
+
+    guard._observe_holder()
+
+    guard._promote_for.assert_not_called()
+    assert guard._reserved is None
+    assert guard._phase is _Phase.PRIMARY
+
+
+def test_a_claim_on_a_busy_or_failed_pool_answers_before_anything_queues() -> None:
+    """The reservation is taken on the caller's thread: busy and failed answer now."""
+    busy = _configurable_guard()
+    busy._reserved = _Phase.CLAIMING
+    with pytest.raises(KVCRServiceError, match="busy"):
+        busy._reserve_claim()
+
+    failed = _configurable_guard()
+    failure = RuntimeError("promotion failed")
+    failed._failure = failure
+    with pytest.raises(RuntimeError) as raised:
+        failed._reserve_claim()
+    assert raised.value is failure
+
+
+def test_a_serving_guard_reports_a_poll_failure_and_fences_its_core(caplog) -> None:
+    """A poll failure is recorded, reported, fences the core; a bad fence is said."""
+    error = RuntimeError("poll failed")
+    core = Mock()
+    core.poll_completed.side_effect = error
+    core.close.side_effect = OSError("close failed")
+    control = Mock()
+    failure_callback = Mock()
+    guard = _Guard(_TEST_SPEC, failure_callback, compatibility_digest=_TEST_DIGEST)
+    guard._control = control
+    guard._configure(_TierConfig(16, None))
+    guard._serving = True
+    guard._core = core
+    caplog.set_level(logging.ERROR, logger="kvcr.guard")
+
+    guard._poll()
+
+    assert guard._failure is error
+    assert caplog.messages == [
+        "KVCR Guard background polling failed",
+        "Failed to fence a failed KVCR Guard endpoint",
+    ]
+    assert caplog.records[0].exc_info is not None
+    assert caplog.records[0].exc_info[1] is error
+    core.close.assert_called_once_with()
+    control.close.assert_not_called()
+    failure_callback.assert_called_once_with(guard, error)
+
+
+def test_standby_guard_failure_releases_adopted_listener() -> None:
+    """A standby that has failed must stop holding the pool's endpoint."""
+    listener = socket.create_server(("127.0.0.1", 0))
+    port = int(listener.getsockname()[1])
+    control = ZmqPeerControlChannel.from_shared_listener(
+        socket.socket(fileno=os.dup(listener.fileno()))
+    )
+    failure_callback = Mock()
+    error = RuntimeError("journal poll failed")
+    journal = Mock()
+    journal.read_next.side_effect = error
+    guard = _Guard(_TEST_SPEC, failure_callback, compatibility_digest=_TEST_DIGEST)
+    guard._control = control
+    guard._configure(_TierConfig(16, None))
+    guard._journal = journal
+    guard._mirror = Mock()
+
+    guard._poll()
+
+    failure_callback.assert_called_once_with(guard, error)
+    listener.close()
+    # Only the Guard's duplicate could still be holding this now.
+    with socket.socket() as replacement:
+        replacement.bind(("127.0.0.1", port))
+
+
+def test_guard_lives_out_adopt_promote_and_readopt_in_ownership_order(
+    tmp_path, monkeypatch
+) -> None:
+    """The Guard's whole life: each stage hands the next exactly what it left."""
+    first, second, g3_only, fresh = (
+        BlockKey(b"first"),
+        BlockKey(b"second"),
+        BlockKey(b"g3-only"),
+        BlockKey(b"fresh"),
+    )
+    journal = _Journal(
+        [
+            _frame(first, _recovered_record(g2=0, g3=7)),
+            _frame(second, _recovered_record(g2=1)),
+            _frame(g3_only, _recovered_record(g3=9)),
+        ]
+    )
+    closed: list[str] = []
+    order: list[object] = []
+    constructed: list[tuple] = []
+    cores: list[Mock] = []
+    channels: list[Mock] = []
+    attachment = _fake_attachment()
+    attachment.close.side_effect = lambda: closed.append("attachment")
+
+    # The seeding mechanics live on the core (adopt_recovery_records); this
+    # test orders the Guard's calls around it, not what happens inside it.
+    def new_core(config, bindings, backends) -> Mock:
+        constructed.append((config, bindings, backends))
+        core = Mock(_local_dram=Mock(), _g3=None, _block_record_map={})
+        core.adopt_recovery_records.side_effect = lambda records: order.append(
+            ("adopt", tuple(records))
+        )
+        core.start.side_effect = lambda: order.append("start")
+        label = f"core{len(cores) + 1}"
+        core.close.side_effect = lambda: closed.append(label)
+        cores.append(core)
+        return core
+
+    def new_channel() -> Mock:
+        channel = Mock()
+        label = f"control{len(channels) + 1}"
+        channel.close.side_effect = lambda: closed.append(label)
+        channels.append(channel)
+        return channel
+
+    attach = Mock(return_value=attachment)
+    monkeypatch.setattr("kvcr.guard.KVCRPoolAttachment.attach", attach)
+    monkeypatch.setattr("kvcr.guard.RecoveryJournal", Mock(return_value=journal))
+    monkeypatch.setattr("kvcr.guard._KVCRCore", new_core)
+    monkeypatch.setattr(
+        "kvcr.guard.write_recovery_snapshot", lambda *args, **kwargs: None
+    )
+    attachment.release_snapshot_region.side_effect = lambda: order.append("clear")
+    g3_config = _G3Config(
+        paths=(str(tmp_path / "g3.data"),),
+        capacity_bytes_per_file=10 * _PAGE_STRIDE,
+        backend="FILE",
+        backend_options={},
+    )
+    tier = _TierConfig(_PAGE_STRIDE, g3_config)
+    guard = _Guard(_PAGE_SPEC, compatibility_digest=_TEST_DIGEST)
+    # Driven directly, then the thread starts already busy: the actor blocks
+    # on an empty mailbox when idle, so mutating around a sleeping thread
+    # would race its wakeup instead of testing the ordering.
+    guard._started = True
+    guard._prepare()
+    # Unclaimed, so any tier shape is still available; the first claim fixes it.
+    guard._refuse_incompatible(_TierConfig(16, None))
+    guard._adopt(new_channel(), tier)
+    try:
+        attach.assert_called_once_with(_PAGE_SPEC)
+        assert journal.reset_called
+        # Adoption only grants; a core exists once a promotion needs one.
+        assert constructed == []
+        with pytest.raises(RecoveryMirrorError, match="another tier configuration"):
+            guard._refuse_incompatible(_TierConfig(16, None))
+
+        guard._promote()
+
+        config, bindings, backends = constructed[0]
+        prefix = "KVCR-Guard-"
+        assert config.nixl_agent_name.startswith(prefix)
+        uuid.UUID(config.nixl_agent_name.removeprefix(prefix))
+        assert config.nixl_listen_port == 0
+        assert bindings.framework_control is channels[0]
+        assert backends.local_dram == LocalDramInfo(1234 + 8192, 2 * _PAGE_STRIDE, 2)
+        # A Guard opens no G3: it serves the G2 half and keeps the rest for the
+        # primary that takes the pool back.
+        assert backends.g3 is None
+        assert journal.pending == []
+        assert order == [
+            ("adopt", (first, second)),
+            # Dropped before a slot moves: it describes rows about to be overwritten.
+            "clear",
+            "start",
+        ]
+        assert set(guard._g3_records) == {first, g3_only}
+
+        # A replacement claims the pool. What is kept must be what a replay
+        # gives: the half-written G2 slot is dropped, and the G3 halves are
+        # carried whole -- g3_only no longer names any live record, so a
+        # rebuild from the core's map could not produce it.
+        cores[0]._block_record_map = {
+            first: _BlockRecord(
+                local_dram=_LocalDramResidency(0, _LocalDramState.FILLING),
+                g3=_G3Residency(7),
+            ),
+            second: _recovered_record(g2=1),
+        }
+        guard._adopt(new_channel(), tier)
+        assert guard._mirror._records == {
+            first: _recovered_record(g3=7),
+            second: _recovered_record(g2=1),
+            g3_only: _recovered_record(g3=9),
+        }
+        assert guard._g3_records == {}
+
+        # The replacement dies too, having dropped the first generation's
+        # blocks and spilled a different one into the slot that freed.
+        guard._journal = _Journal(
+            [
+                _frame(first, _BlockRecord()),
+                _frame(g3_only, _BlockRecord()),
+                _frame(fresh, _recovered_record(g2=0, g3=7)),
+            ]
+        )
+        guard._promote()
+
+        assert set(guard._g3_records) == {fresh}
+        assert guard._g3_records[fresh].slot == 7
+        assert order[3:] == [("adopt", (second, fresh)), "clear", "start"]
+
+        guard._thread.start()
+        _wait_until(lambda: cores[-1].poll_completed.call_count > 0, timeout=2)
+    finally:
+        guard.close()
+
+    # Each generation's core went before its channel; the pool went last.
+    assert closed == ["core1", "control1", "core2", "control2", "attachment"]
+
+
+@pytest.mark.parametrize("reader", ["poll", "release", "promote", "cold-promote"])
+def test_a_pool_that_lost_its_recovery_stays_claimable_on_every_path(
+    reader: str,
+) -> None:
+    """Which reader finds the invalid journal is a race; none may take the service."""
+    guard = _configurable_guard()
+    # Every one of these readers runs on a pool a primary has already claimed.
+    guard._configured = _TierConfig(16, None)
+    guard._mirror = _RecoveryMirror()
+    guard._attachment = Mock()
+    guard._control = None
+    journal = Mock()
+    error = RecoveryJournalError("recovery journal is invalid")
+    journal.read_next.side_effect = error
+    journal.drain.side_effect = error
+    guard._journal = journal
+    written: list[object] = []
+    guard._write_handback = lambda records, stride: written.append(records)
+    served: list[dict] = []
+    guard._serve = served.append
+    reported: list[BaseException] = []
+    guard._failure_callback = lambda _guard, failure: reported.append(failure)
+
+    if reader == "poll":
+        # Dropped rather than served: what is left of it is incomplete.
+        assert guard._poll() is False
+        assert guard._mirror is None
+        assert served == []
+    elif reader == "release":
+        guard._release()
+        # A standby that gave up recovery keeps nothing and serves nothing.
+        assert guard._mirror is None
+        assert served == []
+    elif reader == "promote":
+        guard._promote()
+        # Promotion still happens, with nothing in it: the endpoint has to answer.
+        # A Guard that declined to serve would leave the dead primary's peers
+        # sending into an address nobody reads, waiting on a reply never sent.
+        assert served == [{}]
+    else:
+        # No mirror at all -- recovery was never there, or already given up.
+        guard._mirror = None
+        guard._promote()
+        assert served == [{}]
+        # A handover after this still needs somewhere to put the core's records.
+        assert guard._mirror is not None
+
+    # A primary outrunning its Guard is not a Guard failure.
+    assert reported == []
+    assert guard._failure is None
+    # Nothing is handed on: a prefix of what the primary published would name
+    # slots it has since reused.
+    assert written == []
+
+
 def test_the_same_g3_paths_in_another_order_are_another_configuration() -> None:
     """A slot names its file by position, so reordering renames every slot."""
     guard = _configurable_guard()
-    guard._configured = _ConfiguredTier.derive(
-        _PAGE_SPEC,
-        _TierConfig(_PAGE_STRIDE, _G3Config(("/a", "/b"), _PAGE_STRIDE, "MOCK", {})),
+    guard._configured = _TierConfig(
+        _PAGE_STRIDE, _G3Config(("/a", "/b"), _PAGE_STRIDE, "MOCK", {})
     )
-
     with pytest.raises(RecoveryMirrorError, match="another tier configuration"):
         guard._refuse_incompatible(
             _TierConfig(_PAGE_STRIDE, _G3Config(("/b", "/a"), _PAGE_STRIDE, "MOCK", {}))
         )
 
 
-def test_a_failure_once_the_pool_has_changed_hands_is_the_services() -> None:
-    """A hand-back that fails cannot be reported as a refused claim."""
-    reported: list[BaseException] = []
-    guard = _configurable_guard()
-    guard._control = None
-    guard._journal = Mock()
-    guard._attachment = None
-    guard._failure_callback = lambda _guard, error: reported.append(error)
-    guard._configured = _ConfiguredTier.derive(_TEST_SPEC, _TierConfig(16, None))
-    guard._serving = True
-    guard._mirror = _RecoveryMirror()
-    guard._core = Mock(_block_record_map={})
-    failure = OSError("no space left on device")
-    guard._hand_back = Mock(side_effect=failure)
+def test_guard_closes_control_when_its_thread_does_not_start(monkeypatch) -> None:
+    """A start that never got a thread must not keep the pool or its endpoint."""
     control = Mock()
+    attachment = _fake_attachment()
+    monkeypatch.setattr(
+        "kvcr.guard.KVCRPoolAttachment.attach", Mock(return_value=attachment)
+    )
+    monkeypatch.setattr("kvcr.guard.RecoveryJournal", Mock())
+    guard = _Guard(_TEST_SPEC, compatibility_digest=_TEST_DIGEST)
+    guard._control = control
+    guard._configure(_TierConfig(16, None))
+    guard._thread.start = Mock(side_effect=RuntimeError("thread start failed"))
 
-    with pytest.raises(OSError, match="no space left"):
-        guard._adopt(control, _TierConfig(16, None))
+    with pytest.raises(RuntimeError, match="thread start failed"):
+        guard.start()
+    guard.close()
 
-    assert reported == [failure]
-    assert guard._failure is failure
     control.close.assert_called_once_with()
+    # The pool was attached before the thread was asked for, so close gives it back.
+    attachment.close.assert_called_once_with()
 
 
-@pytest.mark.parametrize("refused_by", ["geometry", "handback"])
-def test_a_refused_claim_leaves_the_pool_choosable_for_the_next_one(
+def test_a_close_refused_by_a_moving_core_retains_the_pool_until_quiescent(
+    caplog,
+) -> None:
+    """Close keeps everything while the core moves; once quiescent it contains."""
+    control = Mock()
+    attachment = Mock()
+    core = Mock()
+    error = RuntimeError("close failed")
+    core.close.side_effect = error
+    core.is_quiescent.return_value = False
+    guard = _Guard(_TEST_SPEC, compatibility_digest=_TEST_DIGEST)
+    guard._control = control
+    guard._configure(_TierConfig(16, None))
+    guard._core = core
+    guard._attachment = attachment
+    caplog.set_level(logging.WARNING, logger="kvcr.guard")
+
+    # Still moving bytes: nothing may be unmapped under it.
+    with pytest.raises(RuntimeError) as raised:
+        guard.close()
+    assert raised.value is error
+    control.close.assert_not_called()
+    attachment.close.assert_not_called()
+
+    # Quiescent: the same failure is contained and everything goes back.
+    core.is_quiescent.return_value = True
+    guard.close()
+    assert caplog.messages == ["KVCR Guard core close failed after reaching quiescence"]
+    assert caplog.records[0].exc_info is not None
+    assert caplog.records[0].exc_info[1] is error
+    control.close.assert_called_once_with()
+    attachment.close.assert_called_once_with()
+
+
+@pytest.mark.parametrize("refused_by", ["geometry", "handback", "hand-over"])
+def test_only_a_claim_refused_before_the_pool_moves_costs_nothing(
     monkeypatch,
     refused_by: str,
 ) -> None:
-    """The service survives these claims, so the pool they failed on must too."""
+    """Refusals before the pool moves leave it choosable; failures after are fatal."""
     reported: list[BaseException] = []
     guard = _configurable_guard()
     guard._attachment = Mock()
     guard._journal = Mock()
     guard._failure_callback = lambda _guard, error: reported.append(error)
-    guard._hand_back = Mock(side_effect=AssertionError("stood down for a bad claim"))
     control = Mock()
-    if refused_by == "geometry":
-        expected: type[Exception] = ValueError
-        tier_config = _TierConfig(_TEST_SPEC.mapping_bytes, None)
-        handback = Mock(return_value=_RecoveryMirror())
+
+    if refused_by == "hand-over":
+        # A hand-back that fails cannot be reported as a refused claim.
+        guard._configured = _TierConfig(16, None)
+        guard._serving = True
+        guard._mirror = _RecoveryMirror()
+        guard._core = Mock(_block_record_map={})
+        failure = OSError("no space left on device")
+        guard._hand_back = Mock(side_effect=failure)
+
+        with pytest.raises(OSError, match="no space left"):
+            guard._adopt(control, _TierConfig(16, None))
+
+        assert reported == [failure]
+        assert guard._failure is failure
     else:
-        expected = RecoveryJournalError
-        tier_config = _TierConfig(16, None)
-        handback = Mock(side_effect=RecoveryJournalError("written for other terms"))
-    monkeypatch.setattr("kvcr.guard.read_handback", handback)
+        guard._hand_back = Mock(
+            side_effect=AssertionError("stood down for a bad claim")
+        )
+        if refused_by == "geometry":
+            expected: type[Exception] = ValueError
+            tier_config = _TierConfig(_TEST_SPEC.mapping_bytes, None)
+            handback = Mock(return_value=_RecoveryMirror())
+        else:
+            expected = RecoveryJournalError
+            tier_config = _TierConfig(16, None)
+            handback = Mock(side_effect=RecoveryJournalError("written for other terms"))
+        monkeypatch.setattr("kvcr.guard.read_handback", handback)
 
-    with pytest.raises(expected):
-        guard._adopt(control, tier_config)
+        with pytest.raises(expected):
+            guard._adopt(control, tier_config)
 
-    assert reported == []
-    assert guard._failure is None
-    assert guard._serving is False
-    guard._hand_back.assert_not_called()
+        # The service survives these claims, so the pool they failed on must too.
+        assert reported == []
+        assert guard._failure is None
+        assert guard._serving is False
+        guard._hand_back.assert_not_called()
+        # Nothing was chosen, so a corrected claim can still have this pool.
+        assert guard._configured is None
+        guard._refuse_incompatible(_TierConfig(32, None))
     control.close.assert_called_once_with()
-    # Nothing was chosen, so a corrected claim can still have this pool.
-    assert guard._configured is None
-    guard._refuse_incompatible(_TierConfig(32, None))
+
+
+def test_a_handback_with_an_unexpected_storage_error_fails() -> None:
+    """Only capacity errors (ENOSPC/EDQUOT) are survivable at the handback writer."""
+    guard = _configurable_guard()
+    guard._mirror = _RecoveryMirror()
+    guard._core = _warm_core()
+    guard._serving = True
+    error = OSError(errno.EIO, "I/O error")
+    guard._write_handback = Mock(side_effect=error)
+
+    with pytest.raises(OSError) as raised:
+        guard._hand_back(16)
+
+    assert raised.value is error
 
 
 def test_a_handback_the_filesystem_refuses_leaves_a_cold_pool() -> None:
-    """ENOSPC at the pool tail is the ring-full precedent, not a dead service."""
+    """ENOSPC at the pool tail drops the mirror with the handback it refused."""
     guard = _configurable_guard()
     guard._mirror = _RecoveryMirror()
-    guard._core = Mock(
-        _block_record_map={
-            BlockKey(b"warm"): _BlockRecord(
-                local_dram=_LocalDramResidency(0, _LocalDramState.READY)
-            )
-        }
-    )
+    guard._core = _warm_core()
     guard._serving = True
     guard._write_handback = Mock(
         side_effect=OSError(errno.ENOSPC, "No space left on device")
@@ -766,26 +601,24 @@ def test_a_handback_the_filesystem_refuses_leaves_a_cold_pool() -> None:
     assert guard._mirror is None
 
 
-def test_a_dropped_handback_still_leaves_the_new_lease_mirrored() -> None:
-    """ENOSPC at adopt-time handback costs one generation, not every one after."""
+@pytest.mark.parametrize("code", [errno.ENOSPC, errno.EDQUOT])
+def test_a_dropped_handback_still_leaves_the_new_lease_mirrored(code: int) -> None:
+    """A capacity-refused handback goes cold, one generation only, never fatal."""
     guard = _configurable_guard()
     guard._control = None
     guard._failure_callback = lambda *_args: None
-    guard._configured = _ConfiguredTier.derive(_TEST_SPEC, _TierConfig(16, None))
+    guard._configured = _TierConfig(16, None)
     guard._mirror = _RecoveryMirror()
-    guard._core = Mock(
-        _block_record_map={
-            BlockKey(b"warm"): _BlockRecord(
-                local_dram=_LocalDramResidency(0, _LocalDramState.READY)
-            )
-        }
-    )
+    guard._core = _warm_core()
     guard._serving = True
     guard._journal = _Journal()
-    guard._write_handback = Mock(side_effect=OSError(errno.ENOSPC, "No space left"))
+    guard._write_handback = Mock(side_effect=OSError(code, "No space left"))
 
     guard._adopt(Mock(), _TierConfig(16, None))
 
+    # The pool went cold, not fatal: the Guard stood down and dropped the core.
+    assert guard._serving is False
+    assert guard._core is None
     # The claimant was told cold; the new lease is still mirrored, so this
     # primary's deposits survive its own death.
     assert guard._mirror is not None
@@ -807,64 +640,31 @@ def test_a_grant_that_never_arrived_resumes_the_guard_it_stood_down() -> None:
     guard._promote = lambda: outcomes.append("promote")
     guard._release = lambda: outcomes.append("release")
 
-    lease = _Lease(Mock())
+    lease = Mock()
     guard._lease = lease
     guard._abort(lease)
     assert outcomes == ["promote"]
-    lease.liveness.close.assert_called_once_with()
+    lease.close.assert_called_once_with()
     assert guard._lease is None
     assert guard._phase is _Phase.STANDBY
 
     guard._resumable = False
-    stale = _Lease(Mock())
+    stale = Mock()
     guard._lease = stale
     guard._abort(stale)
     assert outcomes == ["promote", "release"]
     assert guard._phase is _Phase.IDLE
 
 
-def test_a_handback_with_an_unexpected_storage_error_fails() -> None:
-    guard = _configurable_guard()
-    guard._mirror = _RecoveryMirror()
-    guard._core = Mock(
-        _block_record_map={
-            BlockKey(b"warm"): _BlockRecord(
-                local_dram=_LocalDramResidency(0, _LocalDramState.READY)
-            )
-        }
-    )
-    guard._serving = True
-    error = OSError(errno.EIO, "I/O error")
-    guard._write_handback = Mock(side_effect=error)
-
-    with pytest.raises(OSError) as raised:
-        guard._hand_back(16)
-
-    assert raised.value is error
-
-
-def test_a_release_the_filesystem_refuses_still_releases() -> None:
+@pytest.mark.parametrize("filesystem", ["accepts", "refuses"])
+def test_a_release_hands_its_cache_on_and_a_refused_write_still_releases(
+    filesystem: str,
+) -> None:
+    """A mirror the next primary is never told about is a mirror that lies."""
     guard = _configurable_guard()
     control = Mock()
     guard._control = control
-    guard._configured = _ConfiguredTier.derive(_TEST_SPEC, _TierConfig(16, None))
-    guard._mirror = _RecoveryMirror()
-    guard._journal = _Journal()
-    guard._write_handback = Mock(
-        side_effect=OSError(errno.ENOSPC, "No space left on device")
-    )
-
-    guard._release()
-
-    assert guard._mirror is None
-    control.close.assert_called_once()
-
-
-def test_a_clean_release_hands_its_cache_on_instead_of_keeping_it() -> None:
-    """A mirror the next primary is never told about is a mirror that lies."""
-    guard = _configurable_guard()
-    guard._control = Mock()
-    guard._configured = _ConfiguredTier.derive(_TEST_SPEC, _TierConfig(16, None))
+    guard._configured = _TierConfig(16, None)
     guard._mirror = _RecoveryMirror()
     guard._mirror.apply(
         _RECORD_BLOCK, b"published", _RECOVERY_ENCODER.encode(_RecoveryBlock(g2=0))
@@ -872,11 +672,16 @@ def test_a_clean_release_hands_its_cache_on_instead_of_keeping_it() -> None:
     # One frame the Guard had not polled yet when the release arrived.
     tail = (_RECORD_BLOCK, b"tail", _RECOVERY_ENCODER.encode(_RecoveryBlock(g2=1)))
     guard._journal = _Journal(pending=[tail])
-    guard._write_handback = Mock()
+    refused = OSError(errno.ENOSPC, "No space left on device")
+    guard._write_handback = Mock(
+        side_effect=refused if filesystem == "refuses" else None
+    )
 
     guard._release()
 
     assert guard._mirror is None
-    records, row_stride = guard._write_handback.call_args.args
-    assert set(records) == {BlockKey(b"published"), BlockKey(b"tail")}
-    assert row_stride == 16
+    control.close.assert_called_once_with()
+    if filesystem == "accepts":
+        records, row_stride = guard._write_handback.call_args.args
+        assert set(records) == {BlockKey(b"published"), BlockKey(b"tail")}
+        assert row_stride == 16

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -179,21 +179,6 @@ def test_a_close_beginning_mid_poll_still_blocks_the_promotion(monkeypatch) -> N
     assert guard._phase is _Phase.PRIMARY
 
 
-def test_a_claim_on_a_busy_or_failed_pool_answers_before_anything_queues() -> None:
-    """The reservation is taken on the caller's thread: busy and failed answer now."""
-    busy = _configurable_guard()
-    busy._reserved = _Phase.CLAIMING
-    with pytest.raises(KVCRServiceError, match="busy"):
-        busy._reserve_claim()
-
-    failed = _configurable_guard()
-    failure = RuntimeError("promotion failed")
-    failed._failure = failure
-    with pytest.raises(RuntimeError) as raised:
-        failed._reserve_claim()
-    assert raised.value is failure
-
-
 def test_a_serving_guard_reports_a_poll_failure_and_fences_its_core(caplog) -> None:
     """A poll failure is recorded, reported, fences the core; a bad fence is said."""
     error = RuntimeError("poll failed")

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -6,22 +6,26 @@ import errno
 import logging
 import os
 import queue
+import select
 import socket
+import threading
 import time
 import uuid
 from contextlib import nullcontext
-from functools import partial
 from unittest.mock import Mock
 
 import pytest
+from _kvcr_test_utils import _recovered_record
 
 from kvcr.config import LocalDramInfo
-from kvcr.control_channels import ZmqPeerControlChannel
-from kvcr.core import _BlockRecord, _KVCRCore
+from kvcr.control_channels import KVCRServiceError, ZmqPeerControlChannel
+from kvcr.core import _BlockRecord
 from kvcr.guard import (
     _Command,
     _ConfiguredTier,
     _Guard,
+    _Lease,
+    _Phase,
 )
 from kvcr.guard_protocol import _G3Config, _TierConfig
 from kvcr.local_disk import _G3Residency
@@ -82,27 +86,149 @@ def _wait_until(predicate) -> None:
         time.sleep(0.001)
 
 
-def _guard_with_thread(*, alive: bool) -> _Guard:
-    """A Guard with only what _submit touches."""
-    guard = object.__new__(_Guard)
-    guard._thread = Mock()
-    guard._thread.is_alive.return_value = alive
-    guard._commands = queue.Queue()
-    return guard
+def test_a_command_reaching_a_dead_actor_is_answered_with_a_typed_error() -> None:
+    """Nothing may wait forever on a thread that will never answer."""
+    guard = _guard_with_thread(alive=False)
+
+    with pytest.raises(KVCRServiceError, match="closed"):
+        guard._submit(_Command("release", (object(),)))
 
 
-def _configurable_guard() -> _Guard:
-    """A Guard past preparation, with nothing held and no thread running."""
-    guard = object.__new__(_Guard)
-    guard._spec = _TEST_SPEC
-    guard._compatibility_digest = _TEST_DIGEST
-    guard._failure = None
-    guard._configured = None
-    guard._g3_records = {}
-    guard._serving = False
-    guard._core = None
-    guard._mirror = None
-    return guard
+def test_a_close_beginning_mid_poll_still_blocks_the_promotion() -> None:
+    """The one window the first gate cannot see: closing set while poll ran."""
+    guard = _configurable_guard()
+    read_fd, write_fd = os.pipe()
+    try:
+        os.write(write_fd, b"x")
+        guard._phase = _Phase.PRIMARY
+        guard._lease = _Lease(Mock(fileno=lambda: read_fd))
+        guard._promote_for = Mock()
+        poller = Mock()
+
+        def poll_during_which_close_begins(_timeout):
+            guard._closing = True
+            return [(read_fd, select.POLLIN)]
+
+        poller.poll.side_effect = poll_during_which_close_begins
+        poller.register = Mock()
+        import kvcr.guard as guard_module
+
+        with_mocked = Mock(return_value=poller)
+        original = guard_module.select.poll
+        guard_module.select.poll = with_mocked
+        try:
+            guard._observe_holder()
+        finally:
+            guard_module.select.poll = original
+
+        guard._promote_for.assert_not_called()
+        assert guard._reserved is None
+        assert guard._phase is _Phase.PRIMARY
+    finally:
+        os.close(read_fd)
+        os.close(write_fd)
+
+
+def test_a_claim_on_a_busy_pool_answers_busy_immediately() -> None:
+    """The reservation is taken on the caller's thread, before anything queues."""
+    guard = _configurable_guard()
+    guard._reserved = _Phase.CLAIMING
+
+    with pytest.raises(KVCRServiceError, match="busy"):
+        guard._reserve_claim()
+
+
+def test_a_claim_on_a_failed_pool_reports_the_failure() -> None:
+    guard = _configurable_guard()
+    failure = RuntimeError("promotion failed")
+    guard._failure = failure
+
+    with pytest.raises(RuntimeError) as raised:
+        guard._reserve_claim()
+
+    assert raised.value is failure
+
+
+def test_serving_guard_notifies_service_and_fences_core_after_poll_failure(
+    caplog,
+) -> None:
+    error = RuntimeError("poll failed")
+    core = Mock()
+    core.poll_completed.side_effect = error
+    control = Mock()
+    failure_callback = Mock()
+    guard = _Guard(
+        _TEST_SPEC,
+        failure_callback,
+        compatibility_digest=_TEST_DIGEST,
+    )
+    guard._control = control
+    guard._configure(_TierConfig(16, None))
+    guard._serving = True
+    guard._core = core
+    caplog.set_level(logging.ERROR, logger="kvcr.guard")
+
+    guard._poll()
+
+    assert guard._failure is error
+    assert caplog.messages == ["KVCR Guard background polling failed"]
+    assert caplog.records[0].exc_info is not None
+    assert caplog.records[0].exc_info[1] is error
+    core.close.assert_called_once_with()
+    control.close.assert_not_called()
+    failure_callback.assert_called_once_with(guard, error)
+
+
+def test_a_serving_guard_that_cannot_fence_its_endpoint_says_so() -> None:
+    """An address still bound to a dead Guard is the service's problem."""
+    error = RuntimeError("poll failed")
+    core = Mock()
+    core.poll_completed.side_effect = error
+    core.close.side_effect = OSError("close failed")
+    failure_callback = Mock()
+    guard = _Guard(
+        _TEST_SPEC,
+        failure_callback,
+        compatibility_digest=_TEST_DIGEST,
+    )
+    guard._control = Mock()
+    guard._configure(_TierConfig(16, None))
+    guard._serving = True
+    guard._core = core
+
+    guard._poll()
+
+    failure_callback.assert_called_once_with(guard, error)
+
+
+def test_standby_guard_failure_releases_adopted_listener() -> None:
+    """A standby that has failed must stop holding the pool's endpoint."""
+    listener = socket.create_server(("127.0.0.1", 0))
+    port = int(listener.getsockname()[1])
+    control = ZmqPeerControlChannel.from_shared_listener(
+        socket.socket(fileno=os.dup(listener.fileno()))
+    )
+    failure_callback = Mock()
+    error = RuntimeError("journal poll failed")
+    journal = Mock()
+    journal.read_next.side_effect = error
+    guard = _Guard(
+        _TEST_SPEC,
+        failure_callback,
+        compatibility_digest=_TEST_DIGEST,
+    )
+    guard._control = control
+    guard._configure(_TierConfig(16, None))
+    guard._journal = journal
+    guard._mirror = Mock()
+
+    guard._poll()
+
+    failure_callback.assert_called_once_with(guard, error)
+    listener.close()
+    # Only the Guard's duplicate could still be holding this now.
+    with socket.socket() as replacement:
+        replacement.bind(("127.0.0.1", port))
 
 
 class _Journal:
@@ -121,118 +247,9 @@ class _Journal:
             yield record
 
 
-def test_a_dead_lifecycle_thread_refuses_commands_and_returns_the_channel() -> None:
-    """A refused command never queues, and a refused adopt closes its channel."""
-    guard = _guard_with_thread(alive=False)
-    control = Mock()
-
-    # Queueing it would wait on a thread that will never answer.
-    with pytest.raises(RuntimeError, match="lifecycle thread stopped"):
-        guard._submit(_Command("close"))
-    assert guard._commands.empty()
-
-    # Nothing else owns the pool listener's duplicate until _adopt takes it.
-    with pytest.raises(RuntimeError, match="lifecycle thread stopped"):
-        guard.adopt(control, _TierConfig(16, None))
-    control.close.assert_called_once_with()
-
-
-def test_a_caller_deadline_times_out_while_state_changing_commands_wait_untimed(
-    monkeypatch,
-) -> None:
-    """A deadline times out without cancelling; promote and adopt carry none."""
-    guard = _guard_with_thread(alive=True)
-    command = _Command("close")
-
-    with pytest.raises(TimeoutError, match="close timed out"):
-        guard._submit(command, 0)
-
-    # Queued regardless: a deadline here cancels nothing.
-    assert guard._commands.get_nowait() is command
-
-    submitted: list[tuple[str, float | None]] = []
-    monkeypatch.setattr(
-        _Guard,
-        "_submit",
-        lambda self, command, timeout=None: submitted.append(
-            (command.operation, timeout)
-        ),
-    )
-    guard.promote_after_death()
-    guard.adopt(Mock(), _TierConfig(16, None))
-
-    # Giving up does not cancel them; the thread carries on regardless.
-    assert submitted == [("promote", None), ("adopt", None)]
-
-
-def test_a_failed_guard_fences_what_it_holds_and_always_tells_the_service(
-    caplog,
-) -> None:
-    """Serving or standby, a poll failure frees the endpoint and reaches the service."""
-    error = RuntimeError("poll failed")
-    core = Mock()
-    core.poll_completed.side_effect = error
-    control = Mock()
-    failure_callback = Mock()
-    guard = _Guard(_TEST_SPEC, failure_callback, compatibility_digest=_TEST_DIGEST)
-    guard._control = control
-    guard._configure(_TierConfig(16, None))
-    guard._serving = True
-    guard._core = core
-    caplog.set_level(logging.ERROR, logger="kvcr.guard")
-
-    guard._poll()
-
-    assert guard._failure is error
-    assert caplog.messages == ["KVCR Guard background polling failed"]
-    assert caplog.records[0].exc_info is not None
-    assert caplog.records[0].exc_info[1] is error
-    core.close.assert_called_once_with()
-    control.close.assert_not_called()
-    failure_callback.assert_called_once_with(guard, error)
-
-    # An address still bound to a dead Guard is the service's problem, so a
-    # core that cannot be fenced must not stop the report.
-    fenceless = _Guard(_TEST_SPEC, failure_callback, compatibility_digest=_TEST_DIGEST)
-    fenceless._control = Mock()
-    fenceless._configure(_TierConfig(16, None))
-    fenceless._serving = True
-    fenceless._core = Mock()
-    fenceless._core.poll_completed.side_effect = error
-    fenceless._core.close.side_effect = OSError("close failed")
-
-    fenceless._poll()
-
-    failure_callback.assert_called_with(fenceless, error)
-
-    # A standby that has failed must stop holding the pool's endpoint.
-    listener = socket.create_server(("127.0.0.1", 0))
-    port = int(listener.getsockname()[1])
-    journal_error = RuntimeError("journal poll failed")
-    journal = Mock()
-    journal.read_next.side_effect = journal_error
-    standby = _Guard(_TEST_SPEC, failure_callback, compatibility_digest=_TEST_DIGEST)
-    standby._control = ZmqPeerControlChannel.from_shared_listener(
-        socket.socket(fileno=os.dup(listener.fileno()))
-    )
-    standby._configure(_TierConfig(16, None))
-    standby._journal = journal
-    standby._mirror = Mock()
-
-    standby._poll()
-
-    failure_callback.assert_called_with(standby, journal_error)
-    assert failure_callback.call_count == 3
-    listener.close()
-    # Only the Guard's duplicate could still be holding this now.
-    with socket.socket() as replacement:
-        replacement.bind(("127.0.0.1", port))
-
-
 def test_guard_prepares_promotes_and_closes_in_ownership_order(
     tmp_path, monkeypatch
 ) -> None:
-    """Prepare only attaches; promote builds and serves; close reverses ownership."""
     first, second, g3_only = (
         BlockKey(b"first"),
         BlockKey(b"second"),
@@ -268,18 +285,11 @@ def test_guard_prepares_promotes_and_closes_in_ownership_order(
     constructed = []
     order = []
 
-    def adopt(tier):
-        def adopted(records):
-            order.append((f"adopt:{tier}", tuple(records)))
-
-        return adopted
-
-    local_dram.adopt_recovery_slots.side_effect = adopt("g2")
-    # The double routes adoption through the real mechanics it stands in for.
-    core.adopt_recovery_records.side_effect = partial(
-        _KVCRCore.adopt_recovery_records, core
+    # The seeding mechanics live on the core (adopt_recovery_records); this
+    # test orders the Guard's calls around it, not what happens inside it.
+    core.adopt_recovery_records.side_effect = lambda records: order.append(
+        ("adopt", tuple(records))
     )
-    core._policy.on_ingest.side_effect = lambda *_: order.append("ingest")
     core.start.side_effect = lambda: order.append("start")
     monkeypatch.setattr(
         "kvcr.guard.clear_recovery_snapshot",
@@ -304,15 +314,20 @@ def test_guard_prepares_promotes_and_closes_in_ownership_order(
         backend_options={},
     )
     guard = _Guard(spec, compatibility_digest=_TEST_DIGEST)
-    guard.start()
-    guard.adopt(channel, _TierConfig(_PAGE_STRIDE, g3_config))
+    # Driven directly, then the thread starts already busy: the actor blocks
+    # on an empty mailbox when idle, so mutating around a sleeping thread
+    # would race its wakeup instead of testing the ordering.
+    guard._started = True
+    guard._prepare()
+    guard._adopt(channel, _TierConfig(_PAGE_STRIDE, g3_config))
     try:
         attach.assert_called_once_with(spec)
         assert journal.reset_called
         assert constructed == []
         core.start.assert_not_called()
 
-        guard.promote_after_death()
+        guard._promote()
+        guard._thread.start()
 
         config, bindings, backends = constructed[0]
         prefix = "KVCR-Guard-"
@@ -328,9 +343,7 @@ def test_guard_prepares_promotes_and_closes_in_ownership_order(
 
         assert journal.pending == []
         assert order == [
-            ("adopt:g2", (first, second)),
-            "ingest",
-            "ingest",
+            ("adopt", (first, second)),
             # Dropped before a slot moves: it describes rows about to be overwritten.
             "clear",
             "start",
@@ -341,6 +354,44 @@ def test_guard_prepares_promotes_and_closes_in_ownership_order(
         guard.close()
 
     assert closed == ["core", "control", "attachment"]
+
+
+def test_adopting_a_new_primary_canonicalises_the_records_it_keeps(
+    tmp_path, monkeypatch
+) -> None:
+    """Kept rather than rebuilt, so what is kept must be what a replay gives."""
+    core = Mock(_local_dram=Mock(), _g3=None, _block_record_map={})
+    monkeypatch.setattr(
+        "kvcr.guard.KVCRPoolAttachment.attach",
+        Mock(return_value=_fake_attachment()),
+    )
+    monkeypatch.setattr("kvcr.guard.RecoveryJournal", Mock(return_value=_Journal(())))
+    monkeypatch.setattr("kvcr.guard._KVCRCore", Mock(return_value=core))
+    monkeypatch.setattr(
+        "kvcr.guard.write_recovery_snapshot", lambda *args, **kwargs: None
+    )
+    guard = _Guard(_TEST_SPEC, compatibility_digest=_TEST_DIGEST)
+    guard.start()
+    guard._adopt(Mock(), _TierConfig(16, None))
+    try:
+        guard._promote()
+        unfinished = BlockKey(b"unfinished")
+        record = _BlockRecord(
+            local_dram=_LocalDramResidency(0, _LocalDramState.FILLING),
+            g3=_G3Residency(7),
+        )
+        record.g3.claim_count = 3
+        core._block_record_map = {unfinished: record}
+
+        guard._g3_records = {unfinished: _G3Residency(7)}
+
+        guard._adopt(Mock(), _TierConfig(16, None))
+
+        # The half-written G2 slot is dropped; the G3 half is carried whole.
+        records = guard._mirror.take_records()
+        assert records == {unfinished: _recovered_record(g3=7)}
+    finally:
+        guard.close()
 
 
 @pytest.mark.parametrize("reader", ["poll", "release", "promote"])
@@ -379,16 +430,7 @@ def test_an_invalid_journal_costs_the_pool_on_every_path_that_reads_it(
     else:
         guard._promote()
         # Promotion still happens, with nothing in it: the endpoint has to answer.
-        # A Guard that declined to serve would leave the dead primary's peers
-        # sending into an address nobody reads.
         assert served == [{}]
-        # The same cold promotion with no mirror at all: the journal is not
-        # read again, and a handover after this still needs somewhere to put
-        # the core's records.
-        guard._mirror = None
-        guard._promote()
-        assert served == [{}, {}]
-        assert guard._mirror is not None
 
     # A primary outrunning its Guard is not a Guard failure.
     assert reported == []
@@ -398,12 +440,30 @@ def test_an_invalid_journal_costs_the_pool_on_every_path_that_reads_it(
     assert written == []
 
 
+def test_a_guard_with_nothing_left_to_recover_still_takes_the_endpoint() -> None:
+    """The pool comes back cold, but its address still has to answer.
+
+    A Guard that declined to serve would leave the dead primary's peers sending
+    into an address nobody reads, waiting on a reply that is never sent.
+    """
+    guard = _configurable_guard()
+    guard._journal = Mock()
+    guard._mirror = None
+    served: list[dict] = []
+    guard._serve = served.append
+
+    guard._promote()
+
+    assert served == [{}]
+    # A handover after this still needs somewhere to put the core's records.
+    assert guard._mirror is not None
+
+
 def test_a_second_promotion_takes_the_g3_half_from_the_generation_that_left_it(
     monkeypatch,
 ) -> None:
-    """Between failovers the Guard keeps canonical records, never stale slots."""
+    """Two failovers: the second must not hand on the first's disk slots."""
     stale, fresh = BlockKey(b"stale"), BlockKey(b"fresh")
-    unfinished, both = BlockKey(b"unfinished"), BlockKey(b"both")
 
     def frames(key: BlockKey, slot: int) -> list[tuple[int, bytes, bytes]]:
         return [
@@ -428,7 +488,7 @@ def test_a_second_promotion_takes_the_g3_half_from_the_generation_that_left_it(
             _RECOVERY_ENCODER.encode(_project_recovery_record(_BlockRecord())),
         )
 
-    journals = [_Journal([*frames(stale, 1), *frames(both, 2)])]
+    journals = [_Journal(frames(stale, 1))]
     cores: list[Mock] = []
 
     def new_core(*_args, **_kwargs) -> Mock:
@@ -451,75 +511,38 @@ def test_a_second_promotion_takes_the_g3_half_from_the_generation_that_left_it(
     )
     guard = _Guard(_TEST_SPEC, compatibility_digest=_TEST_DIGEST)
     guard.start()
-    guard.adopt(Mock(), _TierConfig(16, None))
+    guard._adopt(Mock(), _TierConfig(16, None))
     try:
-        guard.promote_after_death()
-        assert set(guard._g3_records) == {stale, both}
+        guard._promote()
+        assert set(guard._g3_records) == {stale}
 
         # A replacement takes the pool back, so the Guard stops holding it.
-        # What the Guard's core held goes with the pool, kept rather than
-        # rebuilt, so what is kept must be what a replay would give.
-        unfinished_record = _BlockRecord(
-            local_dram=_LocalDramResidency(0, _LocalDramState.FILLING),
-            g3=_G3Residency(7),
-        )
-        unfinished_record.g3.claim_count = 3
-        cores[-1]._block_record_map = {
-            unfinished: unfinished_record,
-            both: _BlockRecord(
-                local_dram=_LocalDramResidency(1, _LocalDramState.READY)
-            ),
-        }
-        guard.adopt(Mock(), _TierConfig(16, None))
+        cores[-1]._block_record_map = {}
+        guard._adopt(Mock(), _TierConfig(16, None))
         assert guard._g3_records == {}
 
-        # The mirror is what the next claimant will be handed: peeked rather
-        # than taken, so the eviction replay below still has records to evict.
-        kept = guard._mirror._records
-        assert set(kept) == {stale, unfinished, both}
-        # An unfinished fill is dropped and claims are reset.
-        assert kept[unfinished].local_dram is None
-        assert kept[unfinished].g3 is not None
-        assert kept[unfinished].g3.slot == 7
-        assert kept[unfinished].g3.claim_count == 0
-        # A block hot enough for DRAM and already spilled keeps both halves.
-        assert kept[both].local_dram is not None
-        assert kept[both].g3 is not None
-        assert kept[both].g3.slot == 2
+        # That replacement dies too, having dropped the old block and spilled
+        # a different one into the slot it freed.
+        guard._journal = _Journal([evicted(stale), *frames(fresh, 1)])
+        guard._promote()
 
-        # That replacement dies too, having dropped every old block and spilled
-        # a different one into the slot the first generation freed.
-        guard._journal = _Journal(
-            [evicted(stale), evicted(unfinished), evicted(both), *frames(fresh, 1)]
-        )
-        guard.promote_after_death()
-
-        # The second promotion must not hand on the first generation's slots.
         assert set(guard._g3_records) == {fresh}
         assert guard._g3_records[fresh].slot == 1
     finally:
         guard.close()
 
 
-def test_only_the_first_committed_claim_chooses_the_tiers_a_pool_accepts(
+def test_configuring_a_pool_is_what_fixes_the_tiers_it_will_accept(
     tmp_path,
 ) -> None:
-    """Only the first committed claim fixes a pool's tiers; refusals fix nothing."""
+    """A real Guard, so the geometry the claim is measured against is the pool's."""
     g3 = _G3Config(
         paths=(str(tmp_path / "g3.data"),),
         capacity_bytes_per_file=_PAGE_STRIDE,
         backend="FILE",
         backend_options={},
     )
-    # A real Guard, so the geometry the claim is measured against is the pool's.
     guard = _Guard(_TEST_SPEC, compatibility_digest=_TEST_DIGEST)
-
-    # A rejected claim must not be able to make the next one skip the check.
-    impossible = _TierConfig(_TEST_SPEC.mapping_bytes, None)
-    for _ in range(2):
-        with pytest.raises(ValueError, match="one complete KV row"):
-            guard._configure(impossible)
-        assert guard._configured is None
 
     # Unclaimed, so any shape is still available.
     guard._refuse_incompatible(_TierConfig(_PAGE_STRIDE, g3))
@@ -529,121 +552,217 @@ def test_only_the_first_committed_claim_chooses_the_tiers_a_pool_accepts(
     with pytest.raises(RecoveryMirrorError, match="another tier configuration"):
         guard._refuse_incompatible(_TierConfig(_PAGE_STRIDE, g3))
 
-    # A slot names its file by position, so reordering renames every slot.
+
+def test_guard_closes_control_when_its_thread_does_not_start(monkeypatch) -> None:
+    control = Mock()
+    attachment = _fake_attachment()
+    monkeypatch.setattr(
+        "kvcr.guard.KVCRPoolAttachment.attach", Mock(return_value=attachment)
+    )
+    monkeypatch.setattr("kvcr.guard.RecoveryJournal", Mock())
+    guard = _Guard(
+        _TEST_SPEC,
+        compatibility_digest=_TEST_DIGEST,
+    )
+    guard._control = control
+    guard._configure(_TierConfig(16, None))
+    guard._thread.start = Mock(side_effect=RuntimeError("thread start failed"))
+
+    with pytest.raises(RuntimeError, match="thread start failed"):
+        guard.start()
+    guard.close()
+
+    control.close.assert_called_once_with()
+    # The pool was attached before the thread was asked for, so close gives it back.
+    attachment.close.assert_called_once_with()
+
+
+def test_guard_retains_resources_when_promoted_core_is_not_quiescent() -> None:
+    control = Mock()
+    attachment = Mock()
+    core = Mock()
+    close_error = RuntimeError("progress did not stop")
+    core.close.side_effect = close_error
+    core.is_quiescent.return_value = False
+    guard = _Guard(
+        _TEST_SPEC,
+        compatibility_digest=_TEST_DIGEST,
+    )
+    guard._control = control
+    guard._configure(_TierConfig(16, None))
+    guard._core = core
+    guard._attachment = attachment
+
+    with pytest.raises(RuntimeError) as raised:
+        guard.close()
+
+    assert raised.value is close_error
+    control.close.assert_not_called()
+    attachment.close.assert_not_called()
+
+    core.close.side_effect = None
+    guard.close()
+    control.close.assert_called_once_with()
+    attachment.close.assert_called_once_with()
+
+
+def test_guard_contains_core_close_failure_after_quiescence(caplog) -> None:
+    control = Mock()
+    attachment = Mock()
+    core = Mock()
+    error = RuntimeError("close failed")
+    core.close.side_effect = error
+    core.is_quiescent.return_value = True
+    guard = _Guard(
+        _TEST_SPEC,
+        compatibility_digest=_TEST_DIGEST,
+    )
+    guard._control = control
+    guard._configure(_TierConfig(16, None))
+    guard._core = core
+    guard._attachment = attachment
+    caplog.set_level(logging.WARNING, logger="kvcr.guard")
+
+    guard.close()
+
+    assert caplog.messages == ["KVCR Guard core close failed after reaching quiescence"]
+    assert caplog.records[0].exc_info is not None
+    assert caplog.records[0].exc_info[1] is error
+    control.close.assert_called_once_with()
+    attachment.close.assert_called_once_with()
+
+
+def _guard_with_thread(*, alive: bool) -> _Guard:
+    """A Guard with only what _submit and close touch."""
+    guard = object.__new__(_Guard)
+    guard._thread = Mock()
+    guard._thread.is_alive.return_value = alive
+    guard._commands = queue.Queue()
+    guard._phase_lock = threading.Lock()
+    guard._closing = False
+    guard._started = True
+    guard._closed = False
+    return guard
+
+
+def _configurable_guard() -> _Guard:
+    """A Guard past preparation, with nothing held and no thread running."""
+    guard = object.__new__(_Guard)
+    guard._spec = _TEST_SPEC
+    guard._compatibility_digest = _TEST_DIGEST
+    guard._failure = None
+    guard._configured = None
+    guard._g3_records = {}
+    guard._serving = False
+    guard._resumable = False
+    guard._core = None
+    guard._mirror = None
+    guard._phase_lock = threading.Lock()
+    guard._phase = _Phase.IDLE
+    guard._reserved = None
+    guard._closing = False
+    guard._lease = None
+    guard._refusing = lambda: False
+    guard._pool_index = 0
+    guard._listener = None
+    guard._bind = None
+    return guard
+
+
+def test_the_same_g3_paths_in_another_order_are_another_configuration() -> None:
+    """A slot names its file by position, so reordering renames every slot."""
+    guard = _configurable_guard()
     guard._configured = _ConfiguredTier.derive(
         _PAGE_SPEC,
         _TierConfig(_PAGE_STRIDE, _G3Config(("/a", "/b"), _PAGE_STRIDE, "MOCK", {})),
     )
+
     with pytest.raises(RecoveryMirrorError, match="another tier configuration"):
         guard._refuse_incompatible(
             _TierConfig(_PAGE_STRIDE, _G3Config(("/b", "/a"), _PAGE_STRIDE, "MOCK", {}))
         )
 
 
-@pytest.mark.parametrize("failed_by", ["geometry", "handback", "changed_hands"])
-def test_a_failed_claim_is_fatal_only_once_the_pool_has_changed_hands(
-    monkeypatch,
-    failed_by: str,
-) -> None:
-    """A refusal before the pool moves is the claimant's; a failure after is fatal."""
+def test_a_failure_once_the_pool_has_changed_hands_is_the_services() -> None:
+    """A hand-back that fails cannot be reported as a refused claim."""
     reported: list[BaseException] = []
     guard = _configurable_guard()
+    guard._control = None
     guard._journal = Mock()
+    guard._attachment = None
     guard._failure_callback = lambda _guard, error: reported.append(error)
+    guard._configured = _ConfiguredTier.derive(_TEST_SPEC, _TierConfig(16, None))
+    guard._serving = True
+    guard._mirror = _RecoveryMirror()
+    guard._core = Mock(_block_record_map={})
+    failure = OSError("no space left on device")
+    guard._hand_back = Mock(side_effect=failure)
     control = Mock()
 
-    if failed_by == "changed_hands":
-        # A hand-back that fails cannot be reported as a refused claim.
-        guard._control = None
-        guard._attachment = None
-        guard._configured = _ConfiguredTier.derive(_TEST_SPEC, _TierConfig(16, None))
-        guard._serving = True
-        guard._mirror = _RecoveryMirror()
-        guard._core = Mock(_block_record_map={})
-        failure = OSError("no space left on device")
-        guard._hand_back = Mock(side_effect=failure)
+    with pytest.raises(OSError, match="no space left"):
+        guard._adopt(control, _TierConfig(16, None))
 
-        with pytest.raises(OSError, match="no space left"):
-            guard._adopt(control, _TierConfig(16, None))
-
-        assert reported == [failure]
-        assert guard._failure is failure
-    else:
-        # The service survives these claims, so the pool they failed on must too.
-        guard._attachment = Mock()
-        guard._hand_back = Mock(
-            side_effect=AssertionError("stood down for a bad claim")
-        )
-        if failed_by == "geometry":
-            expected: type[Exception] = ValueError
-            tier_config = _TierConfig(_TEST_SPEC.mapping_bytes, None)
-            handback = Mock(return_value=_RecoveryMirror())
-        else:
-            expected = RecoveryJournalError
-            tier_config = _TierConfig(16, None)
-            handback = Mock(side_effect=RecoveryJournalError("written for other terms"))
-        monkeypatch.setattr("kvcr.guard.read_handback", handback)
-
-        with pytest.raises(expected):
-            guard._adopt(control, tier_config)
-
-        assert reported == []
-        assert guard._failure is None
-        assert guard._serving is False
-        guard._hand_back.assert_not_called()
-        # Nothing was chosen, so a corrected claim can still have this pool.
-        assert guard._configured is None
-        guard._refuse_incompatible(_TierConfig(32, None))
-
+    assert reported == [failure]
+    assert guard._failure is failure
     control.close.assert_called_once_with()
 
 
-@pytest.mark.parametrize(
-    ("writer", "err"),
-    [
-        ("hand_back", errno.ENOSPC),
-        ("release", errno.ENOSPC),
-        ("hand_back", errno.EIO),
-    ],
-    ids=["hand_back-enospc", "release-enospc", "hand_back-eio"],
-)
-def test_a_recovery_write_without_space_leaves_a_cold_pool_not_a_dead_guard(
-    writer: str, err: int
+@pytest.mark.parametrize("refused_by", ["geometry", "handback"])
+def test_a_refused_claim_leaves_the_pool_choosable_for_the_next_one(
+    monkeypatch,
+    refused_by: str,
 ) -> None:
-    """ENOSPC is the ring-full precedent, cold not fatal; other errnos fail loudly."""
+    """The service survives these claims, so the pool they failed on must too."""
+    reported: list[BaseException] = []
+    guard = _configurable_guard()
+    guard._attachment = Mock()
+    guard._journal = Mock()
+    guard._failure_callback = lambda _guard, error: reported.append(error)
+    guard._hand_back = Mock(side_effect=AssertionError("stood down for a bad claim"))
+    control = Mock()
+    if refused_by == "geometry":
+        expected: type[Exception] = ValueError
+        tier_config = _TierConfig(_TEST_SPEC.mapping_bytes, None)
+        handback = Mock(return_value=_RecoveryMirror())
+    else:
+        expected = RecoveryJournalError
+        tier_config = _TierConfig(16, None)
+        handback = Mock(side_effect=RecoveryJournalError("written for other terms"))
+    monkeypatch.setattr("kvcr.guard.read_handback", handback)
+
+    with pytest.raises(expected):
+        guard._adopt(control, tier_config)
+
+    assert reported == []
+    assert guard._failure is None
+    assert guard._serving is False
+    guard._hand_back.assert_not_called()
+    control.close.assert_called_once_with()
+    # Nothing was chosen, so a corrected claim can still have this pool.
+    assert guard._configured is None
+    guard._refuse_incompatible(_TierConfig(32, None))
+
+
+def test_a_handback_the_filesystem_refuses_leaves_a_cold_pool() -> None:
+    """ENOSPC at the pool tail is the ring-full precedent, not a dead service."""
     guard = _configurable_guard()
     guard._mirror = _RecoveryMirror()
-    error = OSError(err, os.strerror(err))
-    guard._write_handback = Mock(side_effect=error)
+    guard._core = Mock(
+        _block_record_map={
+            BlockKey(b"warm"): _BlockRecord(
+                local_dram=_LocalDramResidency(0, _LocalDramState.READY)
+            )
+        }
+    )
+    guard._serving = True
+    guard._write_handback = Mock(
+        side_effect=OSError(errno.ENOSPC, "No space left on device")
+    )
 
-    if writer == "hand_back":
-        guard._core = Mock(_block_record_map={BlockKey(b"warm"): object()})
-        guard._serving = True
+    guard._hand_back(16)
 
-        if err not in (errno.ENOSPC, errno.EDQUOT):
-            # EIO is a broken pool, not a full one: the hand-back fails loudly
-            # with the original error, before any state is torn down.
-            with pytest.raises(OSError) as raised:
-                guard._hand_back(16)
-            assert raised.value is error
-            return
-
-        guard._hand_back(16)
-
-        assert guard._serving is False
-        assert guard._core is None
-    else:
-        control = Mock()
-        guard._control = control
-        guard._configured = _ConfiguredTier.derive(_TEST_SPEC, _TierConfig(16, None))
-        guard._journal = _Journal()
-
-        guard._release()
-
-        control.close.assert_called_once()
-
-    # Recovery is gone either way: the next claimant is told nothing rather
-    # than half of something.
+    assert guard._serving is False
+    assert guard._core is None
     assert guard._mirror is None
 
 
@@ -663,7 +782,7 @@ def test_a_dropped_handback_still_leaves_the_new_lease_mirrored() -> None:
     )
     guard._serving = True
     guard._journal = _Journal()
-    guard._write_handback = Mock(side_effect=OSError(28, "No space left on device"))
+    guard._write_handback = Mock(side_effect=OSError(errno.ENOSPC, "No space left"))
 
     guard._adopt(Mock(), _TierConfig(16, None))
 
@@ -683,18 +802,62 @@ def test_a_grant_that_never_arrived_resumes_the_guard_it_stood_down() -> None:
     """An aborted grant re-promotes after a hand-back; otherwise it releases."""
     guard = _configurable_guard()
     guard._resumable = True
-    guard._serving = False
     guard._mirror = _RecoveryMirror()
     outcomes: list[str] = []
     guard._promote = lambda: outcomes.append("promote")
     guard._release = lambda: outcomes.append("release")
 
-    guard._abort()
+    lease = _Lease(Mock())
+    guard._lease = lease
+    guard._abort(lease)
     assert outcomes == ["promote"]
+    lease.liveness.close.assert_called_once_with()
+    assert guard._lease is None
+    assert guard._phase is _Phase.STANDBY
 
     guard._resumable = False
-    guard._abort()
+    stale = _Lease(Mock())
+    guard._lease = stale
+    guard._abort(stale)
     assert outcomes == ["promote", "release"]
+    assert guard._phase is _Phase.IDLE
+
+
+def test_a_handback_with_an_unexpected_storage_error_fails() -> None:
+    guard = _configurable_guard()
+    guard._mirror = _RecoveryMirror()
+    guard._core = Mock(
+        _block_record_map={
+            BlockKey(b"warm"): _BlockRecord(
+                local_dram=_LocalDramResidency(0, _LocalDramState.READY)
+            )
+        }
+    )
+    guard._serving = True
+    error = OSError(errno.EIO, "I/O error")
+    guard._write_handback = Mock(side_effect=error)
+
+    with pytest.raises(OSError) as raised:
+        guard._hand_back(16)
+
+    assert raised.value is error
+
+
+def test_a_release_the_filesystem_refuses_still_releases() -> None:
+    guard = _configurable_guard()
+    control = Mock()
+    guard._control = control
+    guard._configured = _ConfiguredTier.derive(_TEST_SPEC, _TierConfig(16, None))
+    guard._mirror = _RecoveryMirror()
+    guard._journal = _Journal()
+    guard._write_handback = Mock(
+        side_effect=OSError(errno.ENOSPC, "No space left on device")
+    )
+
+    guard._release()
+
+    assert guard._mirror is None
+    control.close.assert_called_once()
 
 
 def test_a_clean_release_hands_its_cache_on_instead_of_keeping_it() -> None:
@@ -717,62 +880,3 @@ def test_a_clean_release_hands_its_cache_on_instead_of_keeping_it() -> None:
     records, row_stride = guard._write_handback.call_args.args
     assert set(records) == {BlockKey(b"published"), BlockKey(b"tail")}
     assert row_stride == 16
-
-
-def test_close_gives_the_pool_back_exactly_when_no_core_still_moves_bytes(
-    monkeypatch, caplog
-) -> None:
-    """Control and attachment go back the moment it is safe, and never before."""
-    # A thread that never started still gives back what _prepare took.
-    control = Mock()
-    attachment = _fake_attachment()
-    monkeypatch.setattr(
-        "kvcr.guard.KVCRPoolAttachment.attach", Mock(return_value=attachment)
-    )
-    monkeypatch.setattr("kvcr.guard.RecoveryJournal", Mock())
-    unstarted = _Guard(_TEST_SPEC, compatibility_digest=_TEST_DIGEST)
-    unstarted._control = control
-    unstarted._configure(_TierConfig(16, None))
-    unstarted._thread.start = Mock(side_effect=RuntimeError("thread start failed"))
-
-    with pytest.raises(RuntimeError, match="thread start failed"):
-        unstarted.start()
-    unstarted.close()
-
-    control.close.assert_called_once_with()
-    # The pool was attached before the thread was asked for, so close gives it back.
-    attachment.close.assert_called_once_with()
-
-    # A core still moving bytes pins everything: unmapping the pool under a
-    # thread still writing into it faults the process.
-    control = Mock()
-    attachment = Mock()
-    core = Mock()
-    close_error = RuntimeError("progress did not stop")
-    core.close.side_effect = close_error
-    core.is_quiescent.return_value = False
-    guard = _Guard(_TEST_SPEC, compatibility_digest=_TEST_DIGEST)
-    guard._control = control
-    guard._configure(_TierConfig(16, None))
-    guard._core = core
-    guard._attachment = attachment
-
-    with pytest.raises(RuntimeError) as raised:
-        guard.close()
-
-    assert raised.value is close_error
-    control.close.assert_not_called()
-    attachment.close.assert_not_called()
-
-    # Once the core is quiescent the same failure is contained, and the
-    # resources still go back.
-    core.is_quiescent.return_value = True
-    caplog.set_level(logging.WARNING, logger="kvcr.guard")
-
-    guard.close()
-
-    assert caplog.messages == ["KVCR Guard core close failed after reaching quiescence"]
-    assert caplog.records[0].exc_info is not None
-    assert caplog.records[0].exc_info[1] is close_error
-    control.close.assert_called_once_with()
-    attachment.close.assert_called_once_with()

--- a/tests/unit/test_guard_integration.py
+++ b/tests/unit/test_guard_integration.py
@@ -343,7 +343,7 @@ def test_a_promoted_guard_serves_real_nixl_transfers(
         "_real_nixl_primary_child", service.socket_path, g3_path, control_port
     )
     _await_marker(primary, "ready", _REAL_NIXL_TIMEOUT_SECONDS)
-    guard = service._registry._pools[0].guard
+    guard = service._registry._pools[0]
 
     primary.kill()
     primary.wait(timeout=_TIMEOUT_SECONDS)
@@ -527,7 +527,7 @@ def test_request_timeout_during_promotion_then_retry_uses_guard(
         child.kill()
         child.wait(timeout=_TIMEOUT_SECONDS)
         assert promotion_started.wait(timeout=_TIMEOUT_SECONDS)
-        guard = service._registry._pools[0].guard
+        guard = service._registry._pools[0]
 
         now[0] = 6.0
         _wait_until(
@@ -599,7 +599,7 @@ def test_replacement_primary_takes_the_cache_back_from_a_guard(
     # operation deadline instead of failing them now.
     idle = spawn("_idle_primary_child", service.socket_path, g3_path, control_port)
     _expect_child_line(idle, "ready")
-    first_guard = service._registry._pools[0].guard
+    first_guard = service._registry._pools[0]
     idle.kill()
     idle.wait(timeout=_TIMEOUT_SECONDS)
     _wait_until(lambda: first_guard._serving, timeout=_TIMEOUT_SECONDS)

--- a/tests/unit/test_guard_integration.py
+++ b/tests/unit/test_guard_integration.py
@@ -10,6 +10,7 @@ import sys
 import threading
 import time
 from collections.abc import Callable, Iterator
+from contextlib import nullcontext
 from pathlib import Path
 
 import msgspec
@@ -54,7 +55,6 @@ class _FileBackedNixlAgent(FakeNixlAgent):
         self.block_remote_writes = False
         self.blocked_remote_writes = 0
         self.backends: dict[str, dict[str, str]] = {}
-        self._xfer_backends: dict[int, tuple[str, ...]] = {}
 
     def add_remote_agent(self, metadata: bytes) -> bytes:
         self.remote_agents.append(metadata)
@@ -75,28 +75,9 @@ class _FileBackedNixlAgent(FakeNixlAgent):
     def deregister_memory(self, handle, backends=None):
         return super().deregister_memory(handle)
 
-    def initialize_xfer(
-        self,
-        op,
-        local_descs,
-        remote_descs,
-        remote_agent,
-        notif_msg=b"",
-        backends=None,
-    ):
-        handle = super().initialize_xfer(
-            op,
-            local_descs,
-            remote_descs,
-            remote_agent,
-            notif_msg,
-            backends,
-        )
-        self._xfer_backends[handle] = tuple(backends or ())
-        return handle
-
     def transfer(self, handle):
-        if not self._xfer_backends[handle]:
+        # The base class already records per-xfer backends; none means DRAM.
+        if not self.xfer_backends[handle - 1]:
             if self.block_remote_writes:
                 self.transfers.append(handle)
                 self.blocked_remote_writes += 1
@@ -120,17 +101,20 @@ class _FileBackedNixlAgent(FakeNixlAgent):
         return "DONE"
 
 
-def _claim_kvcr(
-    agent: FakeNixlAgent,
+def _make_kvcr(
     socket_path: str,
     g3_path: str,
-    slot_bytes: int,
-    control_port: int,
+    control_port: int | str,
     agent_name: str,
+    *,
+    agent: FakeNixlAgent | None = None,
+    framework: "ctypes.Array | None" = None,
 ) -> KVCR:
-    """The prologue every fake-agent role shares: claim a service pool."""
+    """A claiming KVCR: a fake agent gets a MOCK G3, a real one POSIX plus
+    NIXL-registered framework memory every descriptor it hands KVCR points into."""
+    page_size = os.sysconf("SC_PAGE_SIZE")
     pinning = FakePrimaryPinning()
-    with _use_nixl_agent(agent):
+    with _use_nixl_agent(agent) if agent is not None else nullcontext():
         return KVCR(
             KVCRConfig(
                 nixl_agent_name=agent_name,
@@ -142,21 +126,28 @@ def _claim_kvcr(
                 pinning.poll_pin_results,
                 pinning.release_pin,
                 framework_control=ZmqPeerControlChannel(
-                    "127.0.0.1", control_port, "127.0.0.1"
+                    "127.0.0.1", int(control_port), "127.0.0.1"
                 ),
             ),
             KVCRBackendConfigs(
+                framework_dram=(
+                    FrameworkDramInput(ctypes.addressof(framework), len(framework))
+                    if framework is not None
+                    else None
+                ),
                 g3=G3Options(
                     paths=(Path(g3_path),),
-                    capacity_bytes_per_file=slot_bytes,
-                    backend="MOCK",
+                    capacity_bytes_per_file=(
+                        page_size if agent is not None else page_size * 2
+                    ),
+                    backend="MOCK" if agent is not None else "POSIX",
                 ),
                 remote_fw_dram=RemoteFWDramOptions(eager_ctrl_connect=False),
             ),
             KVCRGuardConfig(
                 kvcr_service_socket_path=socket_path,
                 pool_index=0,
-                row_stride=slot_bytes,
+                row_stride=page_size,
                 compatibility_digest=_DIGEST,
             ),
         )
@@ -176,53 +167,28 @@ def _deposit_two_blocks(kvcr: KVCR, source: int, block_bytes: int) -> None:
     ]
 
 
-def _stalling_primary_child(socket_path: str, g3_path: str, control_port: str) -> None:
-    """Fill the pool, then hold a peer write stalled mid-flight until killed."""
+def _primary_child(
+    socket_path: str, g3_path: str, control_port: str, mode: str
+) -> None:
+    """Claim the pool, deposit unless idle, then hold it -- stalled mid-write
+    when asked -- until killed."""
     slot_bytes = os.sysconf("SC_PAGE_SIZE")
     agent = _FileBackedNixlAgent()
     agent.state = "DONE"
-    kvcr = _claim_kvcr(
-        agent, socket_path, g3_path, slot_bytes, int(control_port), "primary"
-    )
-    source = ctypes.create_string_buffer(slot_bytes)
-    _deposit_two_blocks(kvcr, ctypes.addressof(source), slot_bytes)
-    agent.block_remote_writes = True
-    agent.state = "PROC"
-    print("stable", flush=True)
-    while not agent.blocked_remote_writes:
-        kvcr.poll_completed()
-        time.sleep(0.001)
-    print("in-flight", flush=True)
-    time.sleep(60)
-
-
-def _handback_primary_child(socket_path: str, g3_path: str, control_port: str) -> None:
-    """Fill the pool, then hold the claim until killed."""
-    slot_bytes = os.sysconf("SC_PAGE_SIZE")
-    agent = _FileBackedNixlAgent()
-    agent.state = "DONE"
-    kvcr = _claim_kvcr(
-        agent, socket_path, g3_path, slot_bytes, int(control_port), "primary"
-    )
-    source = ctypes.create_string_buffer(slot_bytes)
-    _deposit_two_blocks(kvcr, ctypes.addressof(source), slot_bytes)
-    print("ready", flush=True)
-    time.sleep(60)
-
-
-def _idle_primary_child(socket_path: str, g3_path: str, control_port: str) -> None:
-    """Claim the pool and hold it, storing nothing, until killed."""
-    agent = _FileBackedNixlAgent()
-    agent.state = "DONE"
-    _claim_kvcr(
-        agent,
-        socket_path,
-        g3_path,
-        os.sysconf("SC_PAGE_SIZE"),
-        int(control_port),
-        "idle",
-    )
-    print("ready", flush=True)
+    kvcr = _make_kvcr(socket_path, g3_path, control_port, mode, agent=agent)
+    if mode != "idle":
+        source = ctypes.create_string_buffer(slot_bytes)
+        _deposit_two_blocks(kvcr, ctypes.addressof(source), slot_bytes)
+    if mode == "stall":
+        agent.block_remote_writes = True
+        agent.state = "PROC"
+        print("stable", flush=True)
+        while not agent.blocked_remote_writes:
+            kvcr.poll_completed()
+            time.sleep(0.001)
+        print("in-flight", flush=True)
+    else:
+        print("ready", flush=True)
     time.sleep(60)
 
 
@@ -255,13 +221,6 @@ def _stale_peer_child(control_port: str, probe_port: str) -> None:
         if decoded.get("type") == "write_refused" and decoded["op_handle"] == 7:
             print("refused", flush=True)
             return
-
-
-def _expect_child_line(child: subprocess.Popen[str], expected: str) -> None:
-    # Through the drain thread, never select() on a buffered text stream: a
-    # prior readline can prefetch the next marker, and select would then wait
-    # on an fd whose data already sits in the buffer.
-    _await_marker(child, expected)
 
 
 @pytest.fixture
@@ -320,11 +279,26 @@ def live_service(
     assert not server_thread.is_alive()
 
 
-# First in the file, deliberately: this scenario builds real NIXL agents in
-# this process, and real createXferReq starts failing with
-# NIXL_ERR_INVALID_PARAM when fake-agent/ZMQ scenarios have run here first.
-# Pre-existing sensitivity, reproduced without any of the surrounding tests'
-# recent changes; worth its own investigation.
+_RAN_BEFORE_REAL_NIXL: list[str] = []
+
+
+@pytest.fixture(autouse=True)
+def _real_nixl_runs_first(request: pytest.FixtureRequest) -> None:
+    # Enforced, not just asked for: this module's real-NIXL scenario builds
+    # real NIXL agents in this process, and real createXferReq starts failing
+    # with NIXL_ERR_INVALID_PARAM when fake-agent/ZMQ scenarios have run here
+    # first. Pre-existing sensitivity, reproduced without any of the
+    # surrounding tests' recent changes; worth its own investigation. A
+    # reordering (xdist, -p, a new test added above) fails loudly here instead
+    # of as an inscrutable NIXL error.
+    if "real_nixl" in request.node.name and _RAN_BEFORE_REAL_NIXL:
+        pytest.fail(
+            f"{request.node.name} must run first in this module; "
+            f"{_RAN_BEFORE_REAL_NIXL[0]} already ran in this process"
+        )
+    _RAN_BEFORE_REAL_NIXL.append(request.node.name)
+
+
 def test_a_promoted_guard_serves_real_nixl_transfers(
     tmp_path: Path,
     live_service: tuple[_KVCRService, Callable[..., subprocess.Popen[str]]],
@@ -404,12 +378,12 @@ def test_a_promoted_guard_serves_real_nixl_transfers(
     # Inline, not a child: adoption only claims and reads, and this process
     # already runs real agents beside the Guard's own.
     framework = ctypes.create_string_buffer(page_size * 2)
-    replacement = _real_nixl_kvcr(
+    replacement = _make_kvcr(
         str(service.socket_path),
         str(g3_path),
         control_port,
         "real-replacement",
-        framework,
+        framework=framework,
     )
     try:
         destination = ctypes.addressof(framework) + page_size
@@ -471,15 +445,11 @@ def test_request_timeout_during_promotion_then_retry_uses_guard(
         # The stalled write must die with its process: only a SIGKILL mid-flight
         # leaves the journal the way a crashed primary would.
         child = spawn(
-            "_stalling_primary_child", service.socket_path, g3_path, primary_port
+            "_primary_child", service.socket_path, g3_path, primary_port, "stall"
         )
-        _expect_child_line(child, "stable")
+        _await_marker(child, "stable")
 
-        target_control = ZmqPeerControlChannel(
-            "127.0.0.1",
-            free_port(),
-            "127.0.0.1",
-        )
+        target_control = ZmqPeerControlChannel("127.0.0.1", free_port(), "127.0.0.1")
         target_agent = FakeNixlAgent(b"target-md")
         target_memory = ctypes.create_string_buffer(3 * page_size)
         target = _new_kvcr(
@@ -492,31 +462,17 @@ def test_request_timeout_during_promotion_then_retry_uses_guard(
                 ctypes.addressof(target_memory), len(target_memory)
             ),
         )
-        assert target_agent.registrations == [
-            (
-                [(ctypes.addressof(target_memory), len(target_memory), 0, "")],
-                "DRAM",
-            )
-        ]
         now = [0.0]
         target._core._clock = lambda: now[0]
         # The G2 block: a Guard serves what the pool holds and opens no G3.
         key = BlockKey(b"resident-b")
         stalled_destination = (ctypes.c_char * page_size).from_buffer(target_memory)
-        target.submit_hint(
-            (),
-            src=source_endpoint,
-            request_id="stalled",
-        )
+        target.submit_hint((), src=source_endpoint, request_id="stalled")
         target.deliver(
-            {
-                key: _mem_descriptor(
-                    ctypes.addressof(stalled_destination), len(stalled_destination)
-                )
-            },
+            {key: _mem_descriptor(ctypes.addressof(stalled_destination), page_size)},
             request_id="stalled",
         )
-        _expect_child_line(child, "in-flight")
+        _await_marker(child, "in-flight")
         _wait_until(
             lambda: (
                 source_endpoint in target._core._remote_fw_dram._metadata_acked_sources
@@ -597,8 +553,8 @@ def test_replacement_primary_takes_the_cache_back_from_a_guard(
     # must still serve -- one that declined would leave the dead primary's
     # peers sending into an endpoint nobody reads, stalling them until their
     # operation deadline instead of failing them now.
-    idle = spawn("_idle_primary_child", service.socket_path, g3_path, control_port)
-    _expect_child_line(idle, "ready")
+    idle = spawn("_primary_child", service.socket_path, g3_path, control_port, "idle")
+    _await_marker(idle, "ready")
     first_guard = service._registry._pools[0]
     idle.kill()
     idle.wait(timeout=_TIMEOUT_SECONDS)
@@ -609,13 +565,13 @@ def test_replacement_primary_takes_the_cache_back_from_a_guard(
     # process, as a real peer is -- and because a ZMQ probe in this process
     # destabilizes the real-NIXL test that follows.
     peer = spawn("_stale_peer_child", control_port, free_port())
-    _expect_child_line(peer, "refused")
+    _await_marker(peer, "refused")
     peer.wait(timeout=_TIMEOUT_SECONDS)
 
     primary = spawn(
-        "_handback_primary_child", service.socket_path, g3_path, control_port
+        "_primary_child", service.socket_path, g3_path, control_port, "held"
     )
-    _expect_child_line(primary, "ready")
+    _await_marker(primary, "ready")
 
     primary.kill()
     primary.wait(timeout=_TIMEOUT_SECONDS)
@@ -627,13 +583,12 @@ def test_replacement_primary_takes_the_cache_back_from_a_guard(
     # pidfd on our own live pid never fires.
     replacement_agent = _FileBackedNixlAgent()
     replacement_agent.state = "DONE"
-    replacement = _claim_kvcr(
-        replacement_agent,
+    replacement = _make_kvcr(
         str(service.socket_path),
         str(g3_path),
-        page_size,
         control_port,
         "replacement",
+        agent=replacement_agent,
     )
     try:
         for key, payload in (
@@ -715,59 +670,12 @@ def _real_nixl_available() -> bool:
     return True
 
 
-def _real_nixl_kvcr(
-    socket_path: str,
-    g3_path: str,
-    control_port: int,
-    agent_name: str,
-    framework: ctypes.Array,
-) -> KVCR:
-    """A claiming KVCR over a real NIXL agent and a real POSIX-backed G3 file."""
-    page_size = os.sysconf("SC_PAGE_SIZE")
-    pinning = FakePrimaryPinning()
-    return KVCR(
-        KVCRConfig(
-            nixl_agent_name=agent_name,
-            nixl_listen_port=0,
-            inventory_report_interval_ms=0,
-        ),
-        KVCRBindings(
-            pinning.request_pin,
-            pinning.poll_pin_results,
-            pinning.release_pin,
-            framework_control=ZmqPeerControlChannel(
-                "127.0.0.1", control_port, "127.0.0.1"
-            ),
-        ),
-        KVCRBackendConfigs(
-            framework_dram=FrameworkDramInput(
-                ctypes.addressof(framework), len(framework)
-            ),
-            g3=G3Options(
-                paths=(Path(g3_path),),
-                capacity_bytes_per_file=page_size * 2,
-                backend="POSIX",
-            ),
-            remote_fw_dram=RemoteFWDramOptions(eager_ctrl_connect=False),
-        ),
-        KVCRGuardConfig(
-            kvcr_service_socket_path=socket_path,
-            pool_index=0,
-            row_stride=page_size,
-            compatibility_digest=_DIGEST,
-        ),
-    )
-
-
 def _real_nixl_primary_child(socket_path: str, g3_path: str, control_port: str) -> None:
     """Fill the pool through a real agent, then hold the claim until killed."""
     page_size = os.sysconf("SC_PAGE_SIZE")
-    # Registered with NIXL, and every descriptor this child hands KVCR points
-    # inside it: a real agent refuses a transfer that names memory it was
-    # never told about.
     framework = ctypes.create_string_buffer(page_size * 2)
-    kvcr = _real_nixl_kvcr(
-        socket_path, g3_path, int(control_port), "real-primary", framework
+    kvcr = _make_kvcr(
+        socket_path, g3_path, control_port, "real-primary", framework=framework
     )
     _deposit_two_blocks(kvcr, ctypes.addressof(framework), page_size)
     print("ready", flush=True)

--- a/tests/unit/test_guard_protocol.py
+++ b/tests/unit/test_guard_protocol.py
@@ -5,14 +5,13 @@ import errno
 import os
 import select
 import socket
-from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import msgspec
 import pytest
 
 from kvcr import guard_protocol as protocol_module
-from kvcr.config import G3Options, LocalDramInfo
+from kvcr.config import LocalDramInfo
 from kvcr.control_channels import (
     KVCRGuardProtocolError,
     KVCRServiceError,
@@ -41,6 +40,22 @@ _DIGEST = "opaque digest: leave unchanged"
 _JOURNAL_BYTES = 2 * _JOURNAL_HEADER_BYTES
 _MAPPING_BYTES = _JOURNAL_BYTES + 8195
 _TIER_CONFIG = _TierConfig(_ROW_STRIDE, None)
+
+
+def test_close_swaps_the_pidfd_under_its_lock() -> None:
+    """Shutdown can race a failed claim's cleanup here; an unsynchronized swap
+    lets both threads close, and the second can hit a reused descriptor."""
+
+    liveness = PidfdLiveness(os.dup(0))
+    lock = MagicMock()
+    liveness._close_lock = lock
+
+    liveness.close()
+    liveness.close()
+
+    # Both closes took the lock; only the first found a descriptor to close.
+    assert lock.__enter__.call_count == 2
+    assert liveness._pidfd == -1
 
 
 def test_a_peer_pidfd_serves_polling_until_closed_then_refuses_use() -> None:
@@ -199,29 +214,10 @@ def test_g3_terms_no_claimant_could_open_are_refused_at_decode() -> None:
 
 def test_claim_and_release_round_trip_typed_messages_and_geometry(
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
 ) -> None:
-    """A claim/release round-trips typed wire messages, geometry, and g3 terms."""
-    # G3 terms a real claimant could open: page-aligned stride, whole slots.
-    g3_stride = os.sysconf("SC_PAGE_SIZE")
-    g3 = G3Options(
-        paths=(tmp_path / "g3",),
-        capacity_bytes_per_file=g3_stride * 2,
-        backend="FILE",
-        backend_options={"mode": "direct"},
-    )
-    encoded_g3 = _G3Config(
-        paths=(str(g3.paths[0]),),
-        capacity_bytes_per_file=g3_stride * 2,
-        backend="FILE",
-        backend_options={"mode": "direct"},
-    )
-    g3_tier_config = _TierConfig(g3_stride, encoded_g3)
+    """A claim/release round-trips typed wire messages, geometry, and ownership."""
     events: list[str] = []
-    connection = _RecordingConnection(
-        [_grant(), _Released(1), _grant(tier_config=g3_tier_config), _Released(1)],
-        events,
-    )
+    connection = _RecordingConnection([_grant(), _Released(1)], events)
     attachment = _Attachment(events)
     attach = Mock(return_value=attachment)
     _connect_with(monkeypatch, connection)
@@ -231,9 +227,6 @@ def test_claim_and_release_round_trip_typed_messages_and_geometry(
         _POOL_INDEX, _ROW_STRIDE, _DIGEST, ("127.0.0.1", 5555)
     )
 
-    assert connection.sent == [
-        _Claim(_POOL_INDEX, _DIGEST, _TIER_CONFIG, "127.0.0.1", 5555, 1)
-    ]
     assert msgspec.to_builtins(connection.sent[0]) == {
         "type": "claim",
         "pool_index": _POOL_INDEX,
@@ -267,44 +260,18 @@ def test_claim_and_release_round_trip_typed_messages_and_geometry(
 
     # Released rather than disowned, so the hold closes what it was given.
     assert connection.sent_fds == []
-
-    assert connection.sent[-1] == _Release(1)
     assert msgspec.to_builtins(connection.sent[-1]) == {
         "type": "release",
         "version": 1,
         "activated": True,
     }
-    assert msgspec.to_builtins(_Released(1)) == {
-        "type": "released",
-        "version": 1,
-    }
+    assert msgspec.to_builtins(_Released(1)) == {"type": "released", "version": 1}
     assert msgspec.to_builtins(_Error("failure", 1)) == {
         "type": "error",
         "message": "failure",
         "version": 1,
     }
-
-    # A fresh Guard endpoint descriptor, as a real service hands one over
-    # with every grant; this claim carries g3 terms across the wire.
-    connection.received_fd = os.open(os.devnull, os.O_RDONLY)
-    KVCRClient("/unused").claim(
-        _POOL_INDEX, g3_stride, _DIGEST, ("127.0.0.1", 5555), g3
-    ).release()
-
-    assert connection.sent[2].tier_config == g3_tier_config
-    assert msgspec.to_builtins(connection.sent[2])["tier_config"]["g3"] == {
-        "paths": (str(g3.paths[0]),),
-        "capacity_bytes_per_file": g3_stride * 2,
-        "backend": "FILE",
-        "backend_options": {"mode": "direct"},
-    }
     assert events == [
-        "send",
-        "receive",
-        "attachment.close",
-        "send",
-        "receive",
-        "connection.close",
         "send",
         "receive",
         "attachment.close",

--- a/tests/unit/test_kvcr_service.py
+++ b/tests/unit/test_kvcr_service.py
@@ -13,7 +13,7 @@ import threading
 import time
 import uuid
 from collections.abc import Iterator
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager, nullcontext, suppress
 from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -25,6 +25,7 @@ from _kvcr_test_utils import free_port, listening_socket
 from kvcr import KVCRClient, KVCRServiceError
 from kvcr.config import G3Options
 from kvcr.control_channels import FramedConnection
+from kvcr.guard import _Command, _Phase
 from kvcr.guard_protocol import (
     _CLAIM_RESPONSE_DECODER,
     _RELEASE_RESPONSE_DECODER,
@@ -45,16 +46,19 @@ from kvcr.kvcr_service import (
     _ThreadingUnixServer,
 )
 from kvcr.memory import _KVCRPoolOwner
-from kvcr.recovery_journal import RecoveryMirrorError
 
 
 def _holders_of(registry) -> dict[int, object]:
     """The pools a worker holds, in the shape the old binding map had."""
-    return {i: p.holder for i, p in registry._pools.items() if p.holder is not None}
+    return {
+        i: p._lease.liveness for i, p in registry._pools.items() if p._lease is not None
+    }
 
 
 def _listeners_of(registry) -> dict[int, object]:
-    return {i: p.listener for i, p in registry._pools.items() if p.listener is not None}
+    return {
+        i: p._listener for i, p in registry._pools.items() if p._listener is not None
+    }
 
 
 _SERVER_STOP_TIMEOUT_SECONDS = 5
@@ -66,14 +70,66 @@ _TEST_POOL_SIZE_BYTES = _TEST_JOURNAL_BYTES + 8192
 _TEST_ROW_STRIDE = 1024
 _TEST_DIGEST = "opaque digest: Preserve-Me EXACTLY"
 _TEST_TIER_CONFIG = _TierConfig(_TEST_ROW_STRIDE, None)
+# G3 terms are refused at decode unless a real claimant could open them, so
+# the one claim that carries G3 uses a page-aligned stride.
+_PAGE_STRIDE = os.sysconf("SC_PAGE_SIZE")
 
 
 class _FakeLiveness:
+    """A pollable stand-in for a claimant's pidfd.
+
+    A real pidfd reads POLLIN once its process exits; a pipe read end reads
+    POLLIN once a byte is written. kill() is that byte.
+    """
+
     def __init__(self) -> None:
+        self._read, self._write = os.pipe()
         self.closed = False
 
+    def fileno(self) -> int:
+        if self.closed:
+            raise ValueError("pidfd is closed")
+        return self._read
+
+    def kill(self) -> None:
+        os.write(self._write, b"x")
+
     def close(self) -> None:
-        self.closed = True
+        if not self.closed:
+            self.closed = True
+            os.close(self._read)
+            os.close(self._write)
+
+
+def _claim(registry, pool_index, liveness, control_bind=None):
+    """Claim through the registry, closing the granted fd the tests never send."""
+    spec, listener_fd, lease = registry.claim(
+        pool_index,
+        _TEST_TIER_CONFIG,
+        liveness,
+        control_bind or _control_bind(pool_index),
+    )
+    os.close(listener_fd)
+    return spec, lease
+
+
+def _await_phase(guard, predicate, timeout=5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not predicate(guard):
+        if time.monotonic() >= deadline:
+            pytest.fail(f"pool never reached the expected state: {guard._phase}")
+        time.sleep(0.001)
+
+
+def _kill_and_wait(registry, pool_index, liveness) -> None:
+    """Die the way a real claimant does: the pool's own actor notices."""
+    from kvcr.guard import _Phase
+
+    liveness.kill()
+    _await_phase(
+        registry._pools[pool_index],
+        lambda g: g._phase in (_Phase.STANDBY, _Phase.FAILED) or g._failure,
+    )
 
 
 @dataclass
@@ -188,42 +244,39 @@ def _channels_are_taken():
     channel = Mock()
     channel.recv.return_value = []
     with patch(
-        "kvcr.kvcr_service.ZmqPeerControlChannel.from_shared_listener",
+        "kvcr.guard.ZmqPeerControlChannel.from_shared_listener",
         side_effect=_takes(channel),
     ):
         yield
     _POOL_BINDS.clear()
 
 
-@contextmanager
-def _new_registry(
-    tmp_path: Path,
-    pool_count: int = 1,
-    guards: list | None = None,
-) -> Iterator[_PoolRegistry]:
-    """A registry whose pools come with stand-in Guards, closed on exit."""
-    supplied = list(guards or ())
+def _stand_in_pool(spec) -> Mock:
+    """The pool-tail surface a Guard reaches for, without a real mapping."""
+    attachment = Mock(address=1234, data_address=1234 + spec.journal_bytes, _spec=spec)
+    attachment.mapped_snapshot.return_value = nullcontext(None)
+    return attachment
 
-    def build(*_args, **_kwargs):
-        return supplied.pop(0) if supplied else Mock()
 
-    with patch("kvcr.kvcr_service._Guard", side_effect=build):
-        registry = _PoolRegistry(
+def _new_registry(tmp_path: Path, pool_count: int = 1) -> _PoolRegistry:
+    """A registry of real Guards over stand-in pool mappings.
+
+    A pool's lifecycle lives in its Guard now, so the seam moved: these tests
+    fake the mapping a Guard attaches, not the Guard itself.
+    """
+    journal = Mock()
+    journal.read_next.return_value = None
+    with (
+        patch("kvcr.guard.KVCRPoolAttachment.attach", side_effect=_stand_in_pool),
+        patch("kvcr.guard.RecoveryJournal", Mock(return_value=journal)),
+    ):
+        return _PoolRegistry(
             tmp_path,
             pool_count,
             _TEST_POOL_SIZE_BYTES,
             _TEST_JOURNAL_BYTES,
             _TEST_DIGEST,
         )
-    try:
-        yield registry
-    finally:
-        registry.close()
-
-
-def _assert_registry_lock_available(registry: _PoolRegistry) -> None:
-    assert registry._lock.acquire(blocking=False)
-    registry._lock.release()
 
 
 def _wait_for_connection_state(
@@ -238,71 +291,111 @@ def _wait_for_connection_state(
         time.sleep(_CONNECTION_POLL_INTERVAL_SECONDS)
 
 
-def test_a_released_pool_keeps_its_spec_and_stale_endings_are_no_ops(
-    tmp_path: Path,
-) -> None:
-    """Stale endings spend only themselves, release preserves the physical pool."""
+def test_socket_is_private(tmp_path: Path) -> None:
+    """Only the service owner can access its Unix socket."""
+    with _running_server(tmp_path) as harness:
+        assert stat.S_IMODE(harness.server.socket_path.stat().st_mode) == 0o600
+
+
+def test_release_preserves_the_physical_pool_spec(tmp_path: Path) -> None:
+    registry = _new_registry(tmp_path, 2)
     first = _FakeLiveness()
     second = _FakeLiveness()
-    other = _FakeLiveness()
-    stale = Mock()
-    with _new_registry(tmp_path, pool_count=2) as registry:
-        pool_path = Path(registry._pools[0].owner.spec.path)
-        first_spec = registry.claim(0, _TEST_TIER_CONFIG, first, _control_bind(0))
-        # Pools are claimed independently: one's geometry says nothing about
-        # another's.
-        registry.claim(
-            1, _TierConfig(_TEST_ROW_STRIDE * 2, None), other, _control_bind(1)
-        )
-        assert _holders_of(registry) == {0: first, 1: other}
+    try:
+        first_spec, first_lease = _claim(registry, 0, first)
+        registry.release(0, first_lease)
+        second_spec, second_lease = _claim(registry, 0, second)
+        registry.release(0, second_lease)
 
-        # A stale release and a stale death are no-ops on the live lease --
-        # and never reach the Guard, whose release would write a handback
-        # under the still-live primary.
-        guard = registry._pools[0].guard
-        guard.release = Mock(wraps=guard.release)
-        guard.promote_after_death = Mock(wraps=guard.promote_after_death)
-        registry.release(0, stale)
-        registry.holder_died(0, stale)
-        assert registry._pools[0].holder is first
-        guard.release.assert_not_called()
-        guard.promote_after_death.assert_not_called()
-        assert first.closed is False
-        assert stale.close.call_count == 2
-
-        # A clean release spends the lease but hands the same physical pool on.
-        registry.release(0, first)
+        assert first_spec is second_spec
         assert first.closed is True
-        second_spec = registry.claim(0, _TEST_TIER_CONFIG, second, _control_bind(0))
-        assert second_spec is first_spec
-
-        # Shutdown releases every pool, held or not, and unlinks its file.
-        assert pool_path.exists()
-        registry.close()
-        assert registry._pools == {}
-        assert _listeners_of(registry) == {}
-        assert not pool_path.exists()
         assert second.closed is True
-        assert other.closed is True
+    finally:
+        registry.close()
 
 
-def test_refused_claims_answer_typed_errors_and_do_not_bind(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Every refused or failed claim gets a typed error and leaves the pool free."""
-    # A name is refused where the claim is built, before it is sent.
+def test_pools_are_claimed_independently_of_each_other(tmp_path: Path) -> None:
+    """One pool's geometry says nothing about another's."""
+    registry = _new_registry(tmp_path, pool_count=2)
+    first = _FakeLiveness()
+    second = _FakeLiveness()
+    try:
+        _claim(registry, 0, first)
+        _spec, _fd, lease = registry.claim(
+            1, _TierConfig(_TEST_ROW_STRIDE * 2, None), second, _control_bind(1)
+        )
+        os.close(_fd)
+        del lease
+
+        assert _holders_of(registry) == {0: first, 1: second}
+    finally:
+        registry.close()
+
+
+def test_a_stale_lease_cannot_touch_a_replacement(tmp_path: Path) -> None:
+    """Identity is the authority: an ended lease is a no-op forever after."""
+    registry = _new_registry(tmp_path)
+    first = _FakeLiveness()
+    replacement = _FakeLiveness()
+    try:
+        _spec, stale = _claim(registry, 0, first)
+        registry.release(0, stale)
+        assert first.closed is True
+
+        _spec, current = _claim(registry, 0, replacement)
+        # The retried release of the old lease must not end the new one.
+        registry.release(0, stale)
+
+        assert registry._pools[0]._lease is current
+        assert replacement.closed is False
+    finally:
+        registry.close()
+
+
+def test_shutdown_releases_every_pool_and_unlinks_its_file(tmp_path: Path) -> None:
+    liveness = _FakeLiveness()
+    registry = _new_registry(tmp_path)
+    pool_path = Path(registry._pools[0]._owner.spec.path)
+    _claim(registry, 0, liveness)
+    assert pool_path.exists()
+
+    registry.close()
+
+    # The pidfd is spent either way, so this must not interrupt the shutdown.
+    assert registry._pools == {}
+    assert _listeners_of(registry) == {}
+    assert not pool_path.exists()
+
+
+def test_an_endpoint_must_be_named_by_address(tmp_path: Path) -> None:
+    """A name is refused where the claim is built, before it is sent."""
     with pytest.raises(ValueError, match="literal IPv4 address"):
         _claim_request(control_bind=("localhost", free_port()))
 
+
+def test_invalid_g3_claim_does_not_bind(tmp_path: Path) -> None:
+    with _running_server(tmp_path) as harness:
+        request = msgspec.to_builtins(_claim_request())
+        request["tier_config"]["g3"] = {
+            "paths": ["relative"],
+            "capacity_bytes_per_file": 8192,
+            "backend": "FILE",
+            "backend_options": {},
+        }
+
+        response = _send_raw_request(harness.server.socket_path, request)
+
+        assert isinstance(response, _Error)
+        harness.client.claim(
+            0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
+        ).release()
+
+
+def test_unbindable_control_endpoint_does_not_bind_the_pool(tmp_path: Path) -> None:
     # Held for the whole test: the address has to still be taken when the claim runs.
     with listening_socket() as squatter:
         taken = (str(squatter.getsockname()[0]), int(squatter.getsockname()[1]))
         with _running_server(tmp_path) as harness:
-            spec = harness.server._registry._pools[0].owner.spec
-
-            # An endpoint the service cannot bind does not bind the pool.
             with pytest.raises(KVCRServiceError, match="control listener"):
                 harness.client.claim(
                     0,
@@ -310,63 +403,16 @@ def test_refused_claims_answer_typed_errors_and_do_not_bind(
                     _TEST_DIGEST,
                     control_bind=taken,
                 )
-
-            with pytest.raises(KVCRServiceError, match="compatibility digest"):
-                harness.client.claim(
-                    0, _TEST_ROW_STRIDE, _TEST_DIGEST.swapcase(), _control_address()
-                )
-
-            # A malformed g3 config is refused in decoding, before it binds.
-            request = msgspec.to_builtins(_claim_request())
-            request["tier_config"]["g3"] = {
-                "paths": ["relative"],
-                "capacity_bytes_per_file": 8192,
-                "backend": "FILE",
-                "backend_options": {},
-            }
-            response = _send_raw_request(harness.server.socket_path, request)
-            assert isinstance(response, _Error)
-
-            with pytest.raises(KVCRServiceError, match="one complete KV row"):
-                harness.client.claim(
-                    0, _TEST_POOL_SIZE_BYTES + 1, _TEST_DIGEST, _control_address()
-                )
-            assert "Unexpected failure while handling KVCR claim" not in caplog.text
-
-            internal_error = AttributeError("internal invariant broke")
-            with monkeypatch.context() as patcher:
-                patcher.setattr(
-                    harness.server._server,
-                    "dispatch",
-                    Mock(side_effect=internal_error),
-                )
-                with pytest.raises(
-                    KVCRServiceError, match="internal KVCR service error"
-                ):
-                    harness.client.claim(
-                        0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
-                    )
-
-            log_record = next(
-                record
-                for record in caplog.records
-                if record.message == "Unexpected failure while handling KVCR claim"
-            )
-            assert log_record.exc_info is not None
-            assert log_record.exc_info[1] is internal_error
-            # None of it bound: the pool still serves a normal claim and release.
-            assert harness.server._registry._pools[0].owner.spec is spec
-            assert _holders_of(harness.server._registry) == {}
+            # A rejected claim must leave the pool free to take normally.
             harness.client.claim(
                 0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
             ).release()
 
 
-def test_a_held_connection_accepts_only_release_and_ignores_unknown_fields(
+def test_recognized_messages_ignore_unknown_fields(
     tmp_path: Path,
 ) -> None:
-    """A hold refuses a second claim but honours a release, unknown fields aside."""
-    with _running_server(tmp_path, pool_count=1) as harness:
+    with _running_server(tmp_path) as harness:
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as connection:
             connection.connect(str(harness.server.socket_path))
             channel = FramedConnection(connection)
@@ -377,11 +423,6 @@ def test_a_held_connection_accepts_only_release_and_ignores_unknown_fields(
             assert isinstance(response, _Granted)
             assert 0 in _holders_of(harness.server._registry)
 
-            # Mid-hold, a second claim on the same connection is an error reply.
-            channel.send(_claim_request())
-            assert isinstance(channel.receive(_RELEASE_RESPONSE_DECODER), _Error)
-            assert 0 in _holders_of(harness.server._registry)
-
             channel.send({"type": "release", "version": 1, "future": True})
             assert channel.receive(_RELEASE_RESPONSE_DECODER) == _Released(1)
             assert _holders_of(harness.server._registry) == {}
@@ -390,8 +431,7 @@ def test_a_held_connection_accepts_only_release_and_ignores_unknown_fields(
 def test_a_grant_tells_the_pools_guard_and_a_clean_release_stands_it_down(
     tmp_path: Path,
 ) -> None:
-    """A grant tells the pool's Guard; rivals are refused; release stands it down."""
-    guard = Mock()
+    """The Guard is the pool's, so a grant configures it and a release parks it."""
     control = Mock()
     taken: list[tuple[int, int, object]] = []
 
@@ -401,432 +441,490 @@ def test_a_grant_tells_the_pools_guard_and_a_clean_release_stands_it_down(
         duplicate.close()
         return control
 
-    # G3 terms a real claimant could open: page-aligned stride, whole slots.
-    g3_stride = os.sysconf("SC_PAGE_SIZE")
     g3 = G3Options(
         paths=((tmp_path / "g3").resolve(),),
-        capacity_bytes_per_file=g3_stride * 2,
+        capacity_bytes_per_file=2 * _PAGE_STRIDE,
         backend="FILE",
         backend_options={"mode": "direct"},
     )
     with (
-        patch("kvcr.kvcr_service._Guard", return_value=guard),
         patch(
-            "kvcr.kvcr_service.ZmqPeerControlChannel.from_shared_listener",
+            "kvcr.guard.ZmqPeerControlChannel.from_shared_listener",
             side_effect=_take_and_record,
         ),
         _running_server(tmp_path) as harness,
     ):
+        guard = harness.server._registry._pools[1]
         # Built and started with the pool, before any claim named it.
-        guard.start.assert_called_with()
-        guard.adopt.assert_not_called()
+        assert guard._phase is _Phase.UNCONFIGURED
 
-        hold = harness.client.claim(1, g3_stride, _TEST_DIGEST, _control_address(), g3)
-        assert guard.adopt.call_args.args == (
-            control,
-            _TierConfig(
-                g3_stride,
-                _G3Config(
-                    paths=(str(g3.paths[0]),),
-                    capacity_bytes_per_file=g3.capacity_bytes_per_file,
-                    backend=g3.backend,
-                    backend_options=dict(g3.backend_options),
-                ),
+        hold = harness.client.claim(
+            1, _PAGE_STRIDE, _TEST_DIGEST, _control_address(), g3
+        )
+        assert guard._phase is _Phase.PRIMARY
+        assert guard._control is control
+        assert guard._configured.tier_config == _TierConfig(
+            _PAGE_STRIDE,
+            _G3Config(
+                paths=(str(g3.paths[0]),),
+                capacity_bytes_per_file=g3.capacity_bytes_per_file,
+                backend=g3.backend,
+                backend_options=dict(g3.backend_options),
             ),
         )
         (family, taken_fd, taken_name) = taken[0]
         assert family == socket.AF_INET
-        # The Guard is handed a duplicate; the service keeps the original.
-        owned = harness.server._registry._pools[1].listener
+        # The Guard is handed a duplicate; the pool keeps the original.
+        owned = guard._listener
         assert taken_fd != owned.fileno()
         assert taken_name == owned.getsockname()
 
-        # A live holder makes a second claim busy, immediately.
-        with pytest.raises(KVCRServiceError, match="held"):
-            harness.client.claim(1, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address())
-
         hold.release()
 
-        guard.release.assert_called_once_with()
-        guard.close.assert_not_called()
-        guard.promote_after_death.assert_not_called()
-        assert _holders_of(harness.server._registry) == {}
-        # Both stay with the pool: the primary left, the pool did not.
-        assert harness.server._registry._pools[1].guard is guard
-        assert harness.server._registry._pools[1].listener is not None
-
-        # A claimant that never served says so; the service routes its
-        # release through the Guard's abort, which may resume serving.
-        aborted = harness.client.claim(
-            1, g3_stride, _TEST_DIGEST, _control_address(), g3
-        )
-        aborted.release(activated=False)
-        guard.abort_grant.assert_called_once_with()
-        guard.release.assert_called_once_with()
-        assert _holders_of(harness.server._registry) == {}
+        assert guard._phase is _Phase.IDLE
+        assert guard._lease is None
+        # The adopted channel went with the lease; the endpoint did not.
+        control.close.assert_called_once_with()
+        assert guard._listener is not None
 
 
-def test_uncontained_guard_failures_stop_the_service_before_freeing_the_pool(
+def test_a_claim_that_cannot_give_its_endpoint_back_is_fatal(
     tmp_path: Path,
 ) -> None:
-    """Uncontained Guard failures stop the service while the pool is unclaimable."""
-    guard = Mock()
-    liveness = _FakeLiveness()
-    with _new_registry(tmp_path, guards=[guard]) as registry:
-        uncontained: list[BaseException] = []
-        registry.on_uncontained_failure = uncontained.append
-        registry.claim(0, _TEST_TIER_CONFIG, liveness, _control_bind(0))
-
-        # A pool without its standby is a pool the service cannot honour.
-        guard_failure = RuntimeError("core close failed")
-        registry._guard_failed(0, guard, guard_failure)
-        assert uncontained == [guard_failure]
-        # Closing the registry's copy would not reach the Guard's duplicate.
-        assert registry._pools[0].listener is not None
-
-        # A failed hand-back is reported before the pool is exposed, then raised.
-        claimable_when_reported: list[bool] = []
-
-        def record_claimable(_error: BaseException) -> None:
-            claimable_when_reported.append(
-                registry._pools[0].holder is None
-                and not registry._pools[0].in_transition
-            )
-
-        registry.on_uncontained_failure = record_claimable
-        release_failure = RuntimeError("hand-back failed")
-        guard.release.side_effect = release_failure
-
-        with pytest.raises(RuntimeError) as raised:
-            registry.release(0, liveness)
-
-        assert raised.value is release_failure
-        # Reported while the pool was still held, so nothing could claim it.
-        assert claimable_when_reported == [False]
-
-
-def test_a_claim_that_cannot_give_its_endpoint_back_frees_the_pool_and_is_fatal(
-    tmp_path: Path,
-) -> None:
-    """A rollback that cannot prove the address is gone still ends the transition."""
-    guard = Mock()
+    """A rollback that cannot prove the address is gone must stop the service."""
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
     adopt_failure = RuntimeError("adopt failed")
-    guard.adopt.side_effect = adopt_failure
     unbind_failure = OSError("close failed")
-    with _new_registry(tmp_path, guards=[guard]) as registry:
-        uncontained: list[tuple[BaseException, bool, bool]] = []
+    uncontained: list[BaseException] = []
+    registry.on_uncontained_failure = uncontained.append
+    guard._adopt = Mock(side_effect=adopt_failure)
+    real_bind = guard._bind_listener
+    bound: list[socket.socket] = []
 
-        def report(error: BaseException) -> None:
-            # Reported from outside the registry lock, which refuse_claims retakes.
-            unlocked = registry._condition.acquire(blocking=False)
-            if unlocked:
-                registry._condition.release()
-            uncontained.append((error, registry._closed, unlocked))
-
-        registry.on_uncontained_failure = report
-        bind_locked = registry._bind_control_listener_locked
-        bound: list[socket.socket] = []
-
-        def bind_a_listener_that_will_not_close(pool, pool_index, control_bind):  # type: ignore[no-untyped-def]
-            listener = bind_locked(pool, pool_index, control_bind)
-            bound.append(listener)
-            pool.listener = Mock(
-                fileno=listener.fileno, close=Mock(side_effect=unbind_failure)
-            )
-            return pool.listener
-
-        try:
-            with patch.object(
-                registry,
-                "_bind_control_listener_locked",
-                bind_a_listener_that_will_not_close,
-            ):
-                with pytest.raises(RuntimeError) as raised:
-                    registry.claim(
-                        0, _TEST_TIER_CONFIG, _FakeLiveness(), _control_bind(0)
-                    )
-
-            # The claim's own error, not the one its cleanup hit.
-            assert raised.value is adopt_failure
-            # Refused before the pool was let go, so nothing could claim the address
-            # this failed to unbind.
-            assert uncontained == [(unbind_failure, True, True)]
-            assert not registry._pools[0].in_transition
-        finally:
-            for listener in bound:
-                listener.close()
-
-
-def test_a_failed_grant_delivery_retracts_through_the_guard(tmp_path: Path) -> None:
-    """The Guard decides whether a dead grant resumes serving or releases."""
-    guard = Mock()
-    liveness = _FakeLiveness()
-    with _new_registry(tmp_path, guards=[guard]) as registry:
-        registry.claim(0, _TEST_TIER_CONFIG, liveness, _control_bind(0))
-
-        registry.abort_grant(0, liveness)
-
-        guard.abort_grant.assert_called_once_with()
-        guard.release.assert_not_called()
-        assert _holders_of(registry) == {}
-        assert liveness.closed is True
-
-
-def test_a_rollback_that_cannot_stop_a_guard_leaves_its_pool_in_place(
-    tmp_path: Path,
-) -> None:
-    """Unlinking under a Guard that would not close would fault the mapping."""
-    wedged, failing = Mock(), Mock()
-    wedged.close.side_effect = RuntimeError("still holding the mapping")
-    failing.start.side_effect = RuntimeError("attach failed")
-
-    with (
-        patch("kvcr.kvcr_service._Guard", side_effect=[wedged, failing]),
-        pytest.raises(RuntimeError, match="attach failed"),
-    ):
-        _PoolRegistry(
-            tmp_path,
-            2,
-            _TEST_POOL_SIZE_BYTES,
-            _TEST_JOURNAL_BYTES,
-            _TEST_DIGEST,
+    def bind_a_listener_that_will_not_close(control_bind):
+        listener = real_bind(control_bind)
+        bound.append(listener)
+        guard._listener = Mock(
+            fileno=listener.fileno, close=Mock(side_effect=unbind_failure)
         )
+        return guard._listener
 
-    # The wedged pool's file is left for the next start's purge; the pool
-    # whose Guard closed is gone with its owner.
-    assert len(list(tmp_path.iterdir())) == 1
+    guard._bind_listener = bind_a_listener_that_will_not_close
+    try:
+        with pytest.raises(RuntimeError) as raised:
+            _claim(registry, 0, _FakeLiveness())
+
+        # The claim's own error, not the one its cleanup hit.
+        assert raised.value is adopt_failure
+        assert uncontained == [unbind_failure]
+        # The transition ended: nothing is left reserved against this pool.
+        assert guard._reserved is None
+        assert guard._lease is None
+    finally:
+        guard._listener = None
+        for listener in bound:
+            listener.close()
+        registry.close()
 
 
-def test_a_dead_holder_stays_busy_until_its_watcher_promotes_the_guard(
+@pytest.mark.parametrize(
+    "promotion_error",
+    [None, RuntimeError("promotion failed")],
+    ids=["promoted", "promotion_failed"],
+)
+def test_holder_death_retains_guard_and_pool_stays_busy(
     tmp_path: Path,
+    promotion_error: RuntimeError | None,
 ) -> None:
-    """Only the watcher's promotion frees a dead holder; its Guard then serves on."""
-    guard = Mock()
-    failing = Mock()
-    promotion_failure = RuntimeError("promotion failed")
-    failing.promote_after_death.side_effect = promotion_failure
-    child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
-    first = PidfdLiveness(os.pidfd_open(child.pid))
-    replacement = _FakeLiveness()
-    with _new_registry(tmp_path, pool_count=2, guards=[guard, failing]) as registry:
-        try:
-            registry.claim(0, _TEST_TIER_CONFIG, first, _control_bind(0))
-            child.terminate()
-            child.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    uncontained: list[BaseException] = []
+    registry.on_uncontained_failure = uncontained.append
+    promote = Mock(side_effect=promotion_error)
+    guard._promote = promote
+    liveness = _FakeLiveness()
+    try:
+        _claim(registry, 0, liveness)
 
-            # Dead but busy: its watcher is the sole promotion authority, and a
-            # second claim is answered immediately rather than queued.
-            with pytest.raises(KVCRServiceError, match="busy"):
-                registry.claim(0, _TEST_TIER_CONFIG, replacement, _control_bind(0))
-            assert first.fileno() >= 0
-            guard.promote_after_death.assert_not_called()
+        _kill_and_wait(registry, 0, liveness)
 
-            registry.holder_died(0, first)
-
-            # The death freed the pool; the Guard stayed and the pidfd is spent.
-            guard.promote_after_death.assert_called_once_with()
-            assert _holders_of(registry) == {}
-            assert registry._pools[0].guard is guard
-            with pytest.raises(ValueError, match="pidfd is closed"):
-                first.fileno()
-
-            # A guarded reclaim adopts onto the serving Guard, on the pool's own
-            # endpoint. Constructing a second Guard would rebuild records this
-            # one still has.
-            with patch("kvcr.kvcr_service._Guard", side_effect=AssertionError):
-                registry.claim(0, _TEST_TIER_CONFIG, replacement, _control_bind(0))
-            assert guard.adopt.call_count == 2
-            assert registry._pools[0].listener.getsockname() == _control_bind(0)
-            guard.close.assert_not_called()
-            assert registry._pools[0].holder is replacement
-
-            # The watcher routes a failed promotion to server.fail(): it is fatal,
-            # but the pool is still freed for a later claimant.
-            doomed = _FakeLiveness()
-            registry.claim(1, _TEST_TIER_CONFIG, doomed, _control_bind(1))
-            with pytest.raises(RuntimeError) as raised:
-                registry.holder_died(1, doomed)
-            assert raised.value is promotion_failure
-            failing.promote_after_death.assert_called_once_with()
-            assert doomed.closed is True
-            assert registry._pools[1].guard is failing
-            late = _FakeLiveness()
-            registry.claim(1, _TEST_TIER_CONFIG, late, _control_bind(1))
-            assert registry._pools[1].holder is late
-        finally:
-            if child.poll() is None:
-                child.kill()
-                child.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-            first.close()
-            replacement.close()
+        promote.assert_called_once_with()
+        assert liveness.closed is True
+        assert _holders_of(registry) == {}
+        if promotion_error is None:
+            assert uncontained == []
+            assert guard._phase is _Phase.STANDBY
+            # Claimable again: the pool waits for a replacement primary.
+            replacement = _FakeLiveness()
+            _spec, lease = _claim(registry, 0, replacement)
+            assert guard._lease is lease
+        else:
+            # Promotion is fatal, on purpose: escalated, and the pool refuses.
+            assert uncontained == [promotion_error]
+            assert guard._phase is _Phase.FAILED
+            with pytest.raises(RuntimeError, match="promotion failed"):
+                _claim(registry, 0, _FakeLiveness())
+    finally:
+        registry.close()
 
 
 def _claim_after_promotion(
-    registry: _PoolRegistry, guard: Mock, control_bind: tuple[str, int]
+    registry: _PoolRegistry, control_bind: tuple[str, int]
 ) -> _FakeLiveness:
-    """Leave one Guard serving pool 0 with nobody holding it."""
+    """Leave pool 0 standing by, with nobody holding it.
+
+    The promotion itself is stubbed: what these tests exercise is the
+    lifecycle around a standby, not the recovery machinery inside one.
+    """
+    guard = registry._pools[0]
+    guard._promote = Mock()
     liveness = _FakeLiveness()
-    registry.claim(0, _TEST_TIER_CONFIG, liveness, control_bind)
-    registry.holder_died(0, liveness)
+    _spec, _fd, _lease = registry.claim(0, _TEST_TIER_CONFIG, liveness, control_bind)
+    os.close(_fd)
+    _kill_and_wait(registry, 0, liveness)
     assert _holders_of(registry) == {}
     return liveness
 
 
-def test_a_failed_hand_over_costs_the_claim_and_never_the_serving_guard(
+def test_a_standby_pool_hands_itself_to_a_replacement(tmp_path: Path) -> None:
+    control_bind = _control_bind(0)
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    try:
+        _claim_after_promotion(registry, control_bind)
+        replacement = _FakeLiveness()
+
+        _spec, lease = _claim(registry, 0, replacement, control_bind)
+
+        assert guard._phase is _Phase.PRIMARY
+        assert guard._lease is lease
+        # The same endpoint, never rebound: the replacement inherits it.
+        assert guard._listener.getsockname() == (control_bind[0], control_bind[1])
+    finally:
+        registry.close()
+
+
+def test_a_claim_that_fails_before_the_hand_over_leaves_the_guard_serving(
     tmp_path: Path,
 ) -> None:
-    """Each failed hand-over refuses that claim; the Guard keeps pool and endpoint."""
-    serving = Mock()
+    """Only a hand-over that actually began costs the standby its endpoint."""
     control_bind = _control_bind(0)
-    with _new_registry(tmp_path, guards=[serving]) as registry:
-        _claim_after_promotion(registry, serving, control_bind)
-
-        # Only a hand-over that actually began could cost the Guard its endpoint.
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    try:
+        _claim_after_promotion(registry, control_bind)
         with patch(
-            "kvcr.kvcr_service.ZmqPeerControlChannel.from_shared_listener",
+            "kvcr.guard.ZmqPeerControlChannel.from_shared_listener",
             side_effect=ValueError("cannot share this listener"),
         ):
             with pytest.raises(KVCRServiceError, match="cannot share this listener"):
-                registry.claim(0, _TEST_TIER_CONFIG, _FakeLiveness(), control_bind)
-        serving.close.assert_not_called()
-        assert registry._pools[0].listener is not None
+                _claim(registry, 0, _FakeLiveness(), control_bind)
 
-        # A Guard that cannot adopt fails the claim with the Guard's own error.
-        adopt_failure = RuntimeError("adopt failed")
-        serving.adopt.side_effect = adopt_failure
+        assert guard._phase is _Phase.STANDBY
+        assert guard._reserved is None
+        assert guard._listener is not None
+    finally:
+        registry.close()
+
+
+def test_a_guard_that_cannot_adopt_a_replacement_fails_the_claim(
+    tmp_path: Path,
+) -> None:
+    """A refused claim costs the pool nothing -- not its standby, not its address."""
+    control_bind = _control_bind(0)
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    failure = RuntimeError("adopt failed")
+    try:
+        _claim_after_promotion(registry, control_bind)
+        real_adopt = guard._adopt
+        guard._adopt = Mock(side_effect=failure)
         with pytest.raises(RuntimeError) as raised:
-            registry.claim(0, _TEST_TIER_CONFIG, _FakeLiveness(), control_bind)
-        assert raised.value is adopt_failure
+            _claim(registry, 0, _FakeLiveness(), control_bind)
+        assert raised.value is failure
+        assert guard._phase is _Phase.STANDBY
         assert _holders_of(registry) == {}
-        assert registry._pools[0].listener is not None
+        assert guard._listener is not None
 
-        # Tiers are fixed at build time; a mismatched claimant could not promote.
-        serving.adopt.side_effect = RecoveryMirrorError(
-            "KVCR pool holds recovered state for different tiers"
-        )
-        with pytest.raises(KVCRServiceError, match="different tiers"):
-            registry.claim(0, _TEST_TIER_CONFIG, _FakeLiveness(), control_bind)
-        serving.release.assert_not_called()
-        assert registry._pools[0].guard is serving
-
-        # The failures fenced the claims rather than the pool.
-        serving.adopt.side_effect = None
+        # The failure fenced the claim rather than the pool.
+        guard._adopt = real_adopt
         replacement = _FakeLiveness()
-        registry.claim(0, _TEST_TIER_CONFIG, replacement, control_bind)
-        assert registry._pools[0].guard is serving
-        assert registry._pools[0].holder is replacement
+        _spec, lease = _claim(registry, 0, replacement, control_bind)
+        assert guard._lease is lease
+    finally:
+        registry.close()
+
+
+def test_a_guard_will_not_hand_a_pool_to_differently_configured_tiers(
+    tmp_path: Path,
+) -> None:
+    control_bind = _control_bind(0)
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    try:
+        _claim_after_promotion(registry, control_bind)
+        # Tiers are fixed by the first claim; a mismatched replacement is refused
+        # by the real predicate, and the standby keeps serving.
+        with pytest.raises(KVCRServiceError, match="another tier configuration"):
+            registry.claim(
+                0,
+                _TierConfig(_TEST_ROW_STRIDE * 2, None),
+                _FakeLiveness(),
+                control_bind,
+            )
+        assert guard._phase is _Phase.STANDBY
+        assert _holders_of(registry) == {}
+    finally:
+        registry.close()
+
+
+def test_dead_guarded_holder_stays_busy_until_the_actor_promotes(
+    tmp_path: Path,
+) -> None:
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    guard._promote = Mock()
+    # Hold the actor's own observation back, so the dead-but-not-yet-promoted
+    # window is stable enough to assert against.
+    guard._observe_holder = lambda: None
+    child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    first = PidfdLiveness(os.pidfd_open(child.pid))
+    try:
+        _claim(registry, 0, first)
+        child.terminate()
+        child.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+
+        # Dead, but the actor has not promoted: busy, not "held".
+        with pytest.raises(KVCRServiceError, match="busy"):
+            _claim(registry, 0, _FakeLiveness())
+        assert first.fileno() >= 0
+        guard._promote.assert_not_called()
+
+        del guard._observe_holder
+        _await_phase(registry._pools[0], lambda g: g._phase is _Phase.STANDBY)
+
+        guard._promote.assert_called_once_with()
+        assert _holders_of(registry) == {}
+        with pytest.raises(ValueError, match="pidfd is closed"):
+            first.fileno()
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+        first.close()
+        registry.close()
 
 
 def test_slow_promotion_does_not_block_other_pools_or_shutdown(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """One pool's slow promotion blocks neither other pools' claims nor shutdown."""
+    registry = _new_registry(tmp_path, pool_count=2)
+    guard = registry._pools[0]
     promotion_started = threading.Event()
     continue_promotion = threading.Event()
-    promotion_errors: list[BaseException] = []
-    claim_done = threading.Event()
-    claim_errors: list[BaseException] = []
-    guard = Mock()
     first = _FakeLiveness()
     second = _FakeLiveness()
-    promotion_thread: threading.Thread | None = None
-    claim_thread: threading.Thread | None = None
 
-    with _new_registry(tmp_path, pool_count=2, guards=[guard]) as registry:
+    def promote() -> None:
+        promotion_started.set()
+        assert continue_promotion.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
 
-        def promote() -> None:
-            _assert_registry_lock_available(registry)
-            promotion_started.set()
-            assert continue_promotion.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+    guard._promote = Mock(side_effect=promote)
+    try:
+        _claim(registry, 0, first)
+        first.kill()
+        assert promotion_started.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
 
-        guard.promote_after_death.side_effect = promote
-        try:
-            registry.claim(0, _TEST_TIER_CONFIG, first, _control_bind(0))
+        # The other pool progresses while pool 0 promotes...
+        _spec, second_lease = _claim(registry, 1, second)
+        # ...and pool 0 answers busy immediately instead of queueing.
+        with pytest.raises(KVCRServiceError, match="busy"):
+            _claim(registry, 0, _FakeLiveness())
 
-            def holder_died() -> None:
-                try:
-                    registry.holder_died(0, first)
-                except BaseException as error:
-                    promotion_errors.append(error)
+        # Small but not zero: the deadline is absolute, so the healthy pool's
+        # actor finishes well inside it while the wedged one burns it.
+        monkeypatch.setattr(
+            "kvcr.kvcr_service._REGISTRY_TRANSITION_TIMEOUT_SECONDS", 1.0
+        )
+        with pytest.raises(TimeoutError, match="pool transitions"):
+            registry.close()
+        # The wedged pool is kept and named; its neighbour still went.
+        assert registry._pools.keys() == {0}
+        assert second.closed is True
+    finally:
+        continue_promotion.set()
+        monkeypatch.undo()
+        registry.close()
 
-            promotion_thread = threading.Thread(target=holder_died)
-            promotion_thread.start()
-            assert promotion_started.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-
-            def claim_other_pool() -> None:
-                try:
-                    registry.claim(1, _TEST_TIER_CONFIG, second, _control_bind(1))
-                except BaseException as error:
-                    claim_errors.append(error)
-                finally:
-                    claim_done.set()
-
-            claim_thread = threading.Thread(target=claim_other_pool)
-            claim_thread.start()
-            assert claim_done.wait(timeout=1)
-            claim_thread.join(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-            assert not claim_thread.is_alive()
-            assert claim_errors == []
-            with pytest.raises(KVCRServiceError, match="busy"):
-                registry.claim(0, _TEST_TIER_CONFIG, _FakeLiveness(), _control_bind(0))
-
-            monkeypatch.setattr(
-                "kvcr.kvcr_service._REGISTRY_TRANSITION_TIMEOUT_SECONDS", 0
-            )
-            with pytest.raises(TimeoutError, match="pool transitions"):
-                registry.close()
-            assert registry._pools[0].guard is guard
-            assert registry._pools[0].holder is first
-            assert registry._pools.keys() == {0}
-            assert second.closed is True
-        finally:
-            continue_promotion.set()
-            for thread in (claim_thread, promotion_thread):
-                if thread is not None:
-                    thread.join(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-                    assert not thread.is_alive()
-
-    assert promotion_errors == []
     assert first.closed is True
 
 
 def test_shutdown_leaks_only_the_pool_it_cannot_release(tmp_path: Path) -> None:
     """One pool that will not go keeps its own file, and nobody else's."""
     failure = RuntimeError("close failed")
-    guard = Mock()
-    guard.close.side_effect = failure
+    registry = _new_registry(tmp_path, pool_count=2)
+    stuck = registry._pools[0]
+    stuck._close_resources = Mock(side_effect=failure)
     first = _FakeLiveness()
     second = _FakeLiveness()
-    with _new_registry(tmp_path, pool_count=2, guards=[guard]) as registry:
-        registry.claim(0, _TEST_TIER_CONFIG, first, _control_bind(0))
-        registry.claim(1, _TEST_TIER_CONFIG, second, _control_bind(1))
-        first_path = Path(registry._pools[0].owner.spec.path)
-        second_path = Path(registry._pools[1].owner.spec.path)
+    _claim(registry, 0, first)
+    _claim(registry, 1, second)
+    first_path = Path(registry._pools[0]._owner.spec.path)
+    second_path = Path(registry._pools[1]._owner.spec.path)
 
-        with pytest.raises(RuntimeError, match="close failed") as raised:
-            registry.close()
+    with pytest.raises(RuntimeError, match="close failed") as raised:
+        registry.close()
 
-        assert raised.value is failure
-        # The stuck pool keeps its file and lease; the one behind it still goes.
-        assert registry._pools.keys() == {0}
-        assert first.closed is False
-        assert first_path.exists()
-        assert second.closed is True
-        assert not second_path.exists()
+    assert raised.value is failure
+    # The stuck pool keeps its file and lease; the one behind it still goes.
+    assert registry._pools.keys() == {0}
+    assert first.closed is False
+    assert first_path.exists()
+    assert second.closed is True
+    assert not second_path.exists()
 
-        # Clean up the pool this test deliberately leaves behind, so the exit
-        # close finds nothing left to fail on.
-        pool = registry._pools.pop(0)
-        if pool.listener is not None:
-            pool.listener.close()
-        pool.owner.close()
+    # Clean up the pool this test deliberately leaves behind.
+    type(stuck)._close_resources(stuck)
+
+
+def test_claim_refusals_and_internal_failures_do_not_bind(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with _running_server(tmp_path) as harness:
+        spec = harness.server._registry._pools[0]._owner.spec
+        with pytest.raises(KVCRServiceError, match="compatibility digest"):
+            harness.client.claim(
+                0, _TEST_ROW_STRIDE, _TEST_DIGEST.swapcase(), _control_address()
+            )
+        with pytest.raises(KVCRServiceError, match="one complete KV row"):
+            harness.client.claim(
+                0, _TEST_POOL_SIZE_BYTES + 1, _TEST_DIGEST, _control_address()
+            )
+        assert "Unexpected failure while handling KVCR claim" not in caplog.text
+
+        internal_error = AttributeError("internal invariant broke")
+        with monkeypatch.context() as patcher:
+            patcher.setattr(
+                harness.server._server,
+                "dispatch",
+                Mock(side_effect=internal_error),
+            )
+            with pytest.raises(KVCRServiceError, match="internal KVCR service error"):
+                harness.client.claim(
+                    0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
+                )
+
+        log_record = next(
+            record
+            for record in caplog.records
+            if record.message == "Unexpected failure while handling KVCR claim"
+        )
+        assert log_record.exc_info is not None
+        assert log_record.exc_info[1] is internal_error
+        assert harness.server._registry._pools[0]._owner.spec is spec
+        assert _holders_of(harness.server._registry) == {}
+        harness.client.claim(
+            0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
+        ).release()
+
+
+def test_live_holder_makes_a_second_claim_busy(tmp_path: Path) -> None:
+    with _running_server(tmp_path) as harness:
+        hold = harness.client.claim(
+            0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
+        )
+        try:
+            with pytest.raises(KVCRServiceError, match="held"):
+                harness.client.claim(
+                    0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
+                )
+        finally:
+            hold.release()
+
+
+def test_held_connection_accepts_only_release(tmp_path: Path) -> None:
+    with _running_server(tmp_path, pool_count=1) as harness:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as connection:
+            connection.connect(str(harness.server.socket_path))
+            channel = FramedConnection(connection)
+            channel.send(_claim_request())
+            assert isinstance(channel.receive(_CLAIM_RESPONSE_DECODER), _Granted)
+
+            channel.send(_claim_request())
+            assert isinstance(channel.receive(_RELEASE_RESPONSE_DECODER), _Error)
+            assert 0 in _holders_of(harness.server._registry)
+
+            channel.send({"type": "release", "version": 1, "future": True})
+            response = channel.receive(_RELEASE_RESPONSE_DECODER)
+            assert response == _Released(1)
+            assert _holders_of(harness.server._registry) == {}
+
+
+def test_a_release_racing_a_death_is_stale_after_promotion(tmp_path: Path) -> None:
+    """Whichever ending reserves first wins; the loser is a no-op forever."""
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    guard._promote = Mock()
+    liveness = _FakeLiveness()
+    try:
+        _spec, lease = _claim(registry, 0, liveness)
+        _kill_and_wait(registry, 0, liveness)
+
+        # The claimant's release arrives after its death already promoted.
+        registry.release(0, lease)
+
+        assert guard._phase is _Phase.STANDBY
+        guard._promote.assert_called_once_with()
+    finally:
+        registry.close()
+
+
+def test_the_first_fatal_failure_is_the_one_reported() -> None:
+    """Shutdown ends other pools' work, and those endings fail too."""
+    server = object.__new__(_ThreadingUnixServer)
+    server._fatal_error = None
+    server._fatal_lock = threading.Lock()
+    server.registry = Mock()
+    server.shutdown = Mock()
+    first = RuntimeError("Guard failed")
+
+    server.fail(first)
+    server.fail(RuntimeError("and then the shutdown did too"))
+
+    assert server._fatal_error is first
+
+
+def test_unexpected_release_failure_stops_the_service() -> None:
+    error = RuntimeError("registry invariant failed")
+    handler = object.__new__(_RequestHandler)
+    handler.server = Mock()
+    handler.server.registry.release.side_effect = error
+
+    assert handler._release_or_fail(0, Mock()) is False
+
+    handler.server.fail.assert_called_once_with(error)
+
+
+def test_a_release_refused_by_a_closing_registry_is_not_fatal() -> None:
+    """The claimant learns its release did not commit; the service does not die."""
+    handler = object.__new__(_RequestHandler)
+    handler.server = Mock()
+    handler.channel = Mock()
+    handler.server.registry.release.side_effect = KVCRServiceError("closed")
+
+    assert handler._release_or_fail(0, Mock()) is False
+
+    handler.server.fail.assert_not_called()
+    handler.channel.send.assert_called_once()
 
 
 def test_fork_and_exec_do_not_preserve_claimant_access(
     tmp_path: Path,
 ) -> None:
-    """Neither a fork nor an exec inherits the mapping, and the lease holds on."""
     with _running_server(tmp_path) as harness:
         exec_program = "import time; print('execed', flush=True); time.sleep(60)"
         program = "\n".join(
@@ -863,7 +961,7 @@ def test_fork_and_exec_do_not_preserve_claimant_access(
             forked_pidfd = os.pidfd_open(forked_pid)
             forked_poller = select.poll()
             forked_poller.register(forked_pidfd, select.POLLIN)
-            spec = harness.server._registry._pools[0].owner.spec
+            spec = harness.server._registry._pools[0]._owner.spec
             assert spec is not None
             assert spec.path not in Path(f"/proc/{forked_pid}/maps").read_text()
             with pytest.raises(KVCRServiceError, match="held"):
@@ -889,16 +987,22 @@ def test_fork_and_exec_do_not_preserve_claimant_access(
                 child.stdout.close()
 
 
-def test_a_startup_failure_rolls_back_everything_already_built(
-    tmp_path: Path,
-) -> None:
-    """A startup that cannot finish gives back every Guard, owner, and pool file."""
-    # The rank that failed is rolled back too, not just the ones before it.
-    first, failing = Mock(), Mock()
-    failing.start.side_effect = RuntimeError("attach failed")
+def test_a_guard_that_cannot_prepare_gives_its_pool_back(tmp_path: Path) -> None:
+    """The rank that failed is rolled back too, not just the ones before it."""
+    attached: list[object] = []
 
+    def attach(spec):
+        if attached:
+            raise RuntimeError("attach failed")
+        pool = _stand_in_pool(spec)
+        attached.append(pool)
+        return pool
+
+    journal = Mock()
+    journal.read_next.return_value = None
     with (
-        patch("kvcr.kvcr_service._Guard", side_effect=[first, failing]),
+        patch("kvcr.guard.KVCRPoolAttachment.attach", side_effect=attach),
+        patch("kvcr.guard.RecoveryJournal", Mock(return_value=journal)),
         pytest.raises(RuntimeError, match="attach failed"),
     ):
         _PoolRegistry(
@@ -909,21 +1013,30 @@ def test_a_startup_failure_rolls_back_everything_already_built(
             _TEST_DIGEST,
         )
 
-    first.close.assert_called_once_with()
-    failing.close.assert_called_once_with()
+    # Both pool files are gone: the one that prepared and the one that failed.
     assert list(tmp_path.iterdir()) == []
+    attached[0].close.assert_called_once_with()
 
-    # An allocation failure rolls back the owners before the listener exists.
-    owners = [Mock(), Mock()]
+
+def test_startup_allocation_failure_rolls_back_before_listener(
+    tmp_path: Path,
+) -> None:
     allocation_error = OSError("allocation failed")
+    real_allocate = _KVCRPoolOwner.allocate.__func__
+    calls: list[int] = []
 
+    def allocate(cls, **kwargs):
+        calls.append(1)
+        if len(calls) == 3:
+            raise allocation_error
+        return real_allocate(cls, **kwargs)
+
+    journal = Mock()
+    journal.read_next.return_value = None
     with (
-        patch("kvcr.kvcr_service._Guard"),
-        patch.object(
-            _KVCRPoolOwner,
-            "allocate",
-            side_effect=[*owners, allocation_error],
-        ),
+        patch("kvcr.guard.KVCRPoolAttachment.attach", side_effect=_stand_in_pool),
+        patch("kvcr.guard.RecoveryJournal", Mock(return_value=journal)),
+        patch.object(_KVCRPoolOwner, "allocate", classmethod(allocate)),
         patch("kvcr.kvcr_service._ThreadingUnixServer") as listener,
         pytest.raises(OSError) as raised,
     ):
@@ -933,64 +1046,73 @@ def test_a_startup_failure_rolls_back_everything_already_built(
             pool_count=3,
             pool_size_bytes=_TEST_POOL_SIZE_BYTES,
             compatibility_digest=_TEST_DIGEST,
+            journal_bytes=_TEST_JOURNAL_BYTES,
         )
 
     assert raised.value is allocation_error
     listener.assert_not_called()
-    for owner in owners:
-        owner.close.assert_called_once_with()
+    # The two pools that were built are given back, files and all.
+    assert list(tmp_path.iterdir()) == []
 
 
-def test_shutdown_drains_connections_and_unlinks_every_pool_and_the_socket(
-    tmp_path: Path,
-) -> None:
-    """Connections never block shutdown, which unlinks its files and refuses claims."""
+def test_shutdown_unlinks_eager_pools_and_socket(tmp_path: Path) -> None:
+    with _running_server(tmp_path) as harness:
+        pool_paths = list((tmp_path / "pools").glob("kvcr-pool_*-*"))
+        socket_path = harness.server.socket_path
+        assert len(pool_paths) == _TEST_POOL_COUNT
+        harness.stop()
+        assert all(not path.exists() for path in pool_paths)
+        assert not socket_path.exists()
+
+
+def test_claim_after_shutdown_is_rejected(tmp_path: Path) -> None:
     request = _claim_request()
+
+    with _running_server(tmp_path) as harness:
+        pool_dir = tmp_path / "pools"
+        harness.stop()
+        with pytest.raises(RuntimeError, match="registry is closed"):
+            harness.server._server.dispatch(request, _FakeLiveness())
+        assert not list(pool_dir.iterdir())
+
+
+def test_shutdown_does_not_unlink_replaced_socket_path(tmp_path: Path) -> None:
+    replacement = b"replacement"
     with _running_server(tmp_path) as harness:
         socket_path = harness.server.socket_path
-        # Private from the start: only the service owner can reach its socket.
-        assert stat.S_IMODE(socket_path.stat().st_mode) == 0o600
-        # Eagerly committed: every pool file exists before any claim names it.
-        pool_paths = list((tmp_path / "pools").glob("kvcr-pool_*-*"))
-        assert len(pool_paths) == _TEST_POOL_COUNT
+        socket_path.unlink()
+        socket_path.write_bytes(replacement)
+        harness.stop()
+        assert socket_path.read_bytes() == replacement
+        socket_path.unlink()
 
+
+def test_idle_client_does_not_block_shutdown_cleanup(tmp_path: Path) -> None:
+    with _running_server(tmp_path) as harness:
+        pool_path = next((tmp_path / "pools").glob("kvcr-pool_0-*"))
+        socket_path = harness.server.socket_path
         _wait_for_connection_state(harness.server, connected=False)
         idle_connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         idle_connection.connect(str(socket_path))
         _wait_for_connection_state(harness.server, connected=True)
-        hold = harness.client.claim(
-            0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
-        )
 
         harness.stop()
-
-        _wait_for_connection_state(harness.server, connected=False)
-        hold._attachment.close()
-        hold._connection.close()
         idle_connection.close()
-        assert all(not path.exists() for path in pool_paths)
+
+        assert not pool_path.exists()
         assert not socket_path.exists()
-        # A claim that arrives after shutdown gets a typed error, never a grant.
-        with pytest.raises(RuntimeError, match="registry is closed"):
-            harness.server._server.dispatch(request, _FakeLiveness())
-        assert not list((tmp_path / "pools").iterdir())
 
 
-def test_shutdown_survives_cleanup_errors_and_spares_a_replaced_socket(
+def test_shutdown_continues_after_connection_cleanup_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A cleanup error does not stop pool teardown, and a replaced path is kept."""
-    replacement = b"replacement"
-
     def fail_connection_cleanup() -> None:
         raise OSError("connection cleanup failed")
 
     with _running_server(tmp_path) as harness:
         pool_path = next((tmp_path / "pools").glob("kvcr-pool_0-*"))
         socket_path = harness.server.socket_path
-        socket_path.unlink()
-        socket_path.write_bytes(replacement)
         harness.server.shutdown()
         harness.thread.join(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
         with monkeypatch.context() as patcher:
@@ -1002,62 +1124,61 @@ def test_shutdown_survives_cleanup_errors_and_spares_a_replaced_socket(
             with pytest.raises(OSError, match="connection cleanup failed"):
                 harness.server.close()
         assert not pool_path.exists()
-        assert socket_path.read_bytes() == replacement
-        socket_path.unlink()
+        assert not socket_path.exists()
 
 
-def test_grant_send_failure_rolls_back_the_exact_binding(tmp_path: Path) -> None:
-    """A grant that cannot be delivered frees its pool for the next claimant."""
+def test_a_failed_grant_delivery_retracts_through_the_guard(tmp_path: Path) -> None:
+    """A held undelivered grant is retracted by the claimant's own word: an
+    unactivated release routes through abort_grant, and the pool is free."""
+    registry = _new_registry(tmp_path)
     accepted, peer = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
 
     class _Channel:
         def __init__(self) -> None:
-            self.receives = 0
+            self.sent: list[object] = []
+            self.messages = [_claim_request(), _Release(1, activated=False)]
 
         def receive(self, _decoder: object):
-            # First the claim; then, with the delivery failed and the lease
-            # held, the claimant's own word that it never served -- the one
-            # signal besides death that may free this pool.
-            self.receives += 1
-            if self.receives == 1:
-                return _claim_request()
-            return _Release(1, activated=False)
+            return self.messages.pop(0)
 
         def send(self, response: object) -> None:
-            if isinstance(response, _Granted):
-                raise AssertionError("a guarded grant travels with its descriptor")
-            assert isinstance(response, _Released)
+            self.sent.append(response)
 
-        def send_with_fd(self, response: object, _descriptor: int) -> None:
+        def send_with_fd(self, response: object, listener_fd: int) -> None:
             assert isinstance(response, _Granted)
+            assert listener_fd >= 0
             raise RuntimeError("grant could not be delivered")
 
-    with _new_registry(tmp_path) as registry:
+    class _Server:
+        def __init__(self) -> None:
+            self.registry = registry
+            self.compatibility_digest = _TEST_DIGEST
 
-        class _Server:
-            def __init__(self) -> None:
-                self.registry = registry
-                self.compatibility_digest = _TEST_DIGEST
+        def dispatch(self, request, liveness):
+            return _ThreadingUnixServer.dispatch(self, request, liveness)
 
-            def dispatch(self, request, liveness):
-                return _ThreadingUnixServer.dispatch(self, request, liveness)
-
-        handler = object.__new__(_RequestHandler)
-        handler.request = accepted
-        handler.channel = _Channel()
-        handler.server = _Server()
-        try:
-            # The peer's end is closed so the held socket polls ready; what
-            # frees the pool is the unactivated release, never the EOF.
-            peer.close()
-            handler.handle()
-            assert _holders_of(registry) == {}
-            replacement = _FakeLiveness()
-            registry.claim(0, _TEST_TIER_CONFIG, replacement, _control_bind(0))
-            registry.release(0, replacement)
-        finally:
-            peer.close()
-            accepted.close()
+    handler = object.__new__(_RequestHandler)
+    handler.request = accepted
+    handler.channel = _Channel()
+    handler.server = _Server()
+    guard = registry._pools[0]
+    guard.abort_grant = Mock(wraps=guard.abort_grant)
+    guard.release = Mock(wraps=guard.release)
+    try:
+        handler.handle()
+        assert handler.channel.sent == [_Released(1)]
+        # Routed as a retraction, not an ordinary release: the Guard is the
+        # one that knows whether this grant stood a serving Guard down.
+        guard.abort_grant.assert_called_once()
+        guard.release.assert_not_called()
+        assert _holders_of(registry) == {}
+        replacement = _FakeLiveness()
+        _spec, lease = _claim(registry, 0, replacement)
+        registry.release(0, lease)
+    finally:
+        peer.close()
+        accepted.close()
+        registry.close()
 
 
 def test_an_undelivered_grants_lease_survives_its_connection(
@@ -1067,181 +1188,381 @@ def test_an_undelivered_grants_lease_survives_its_connection(
     its connection while alive, so only its word or its death frees the lease."""
     accepted, peer = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
     child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    registry = _new_registry(tmp_path)
+    # Promotion's serving core is not under test; the freed lease is.
+    registry._pools[0]._promote = Mock()
 
-    with _new_registry(tmp_path) as registry:
+    class _Server:
+        def __init__(self) -> None:
+            self.registry = registry
+            self.compatibility_digest = _TEST_DIGEST
 
-        class _Server:
-            def __init__(self) -> None:
-                self.registry = registry
-                self.compatibility_digest = _TEST_DIGEST
+        def dispatch(self, request, liveness):
+            return _ThreadingUnixServer.dispatch(self, request, liveness)
 
-            def dispatch(self, request, liveness):
-                return _ThreadingUnixServer.dispatch(self, request, liveness)
+    monkeypatch.setattr(
+        PidfdLiveness,
+        "from_peer_socket",
+        classmethod(lambda _cls, _sock: PidfdLiveness(os.pidfd_open(child.pid))),
+    )
+    handler = object.__new__(_RequestHandler)
+    handler.request = accepted
+    handler.server = _Server()
+    handler.channel = Mock()
+    handler.channel.receive.side_effect = [_claim_request(), EOFError()]
+    handler.channel.send_with_fd.side_effect = RuntimeError("undelivered")
+    try:
+        # Delivery fails and the connection then EOFs; handle() returns with
+        # the lease still held.
+        handler.handle()
+        rival = _FakeLiveness()
+        with pytest.raises(KVCRServiceError, match="held by another worker"):
+            _claim(registry, 0, rival)
 
-        monkeypatch.setattr(
-            PidfdLiveness,
-            "from_peer_socket",
-            classmethod(lambda _cls, _sock: PidfdLiveness(os.pidfd_open(child.pid))),
-        )
-        handler = object.__new__(_RequestHandler)
-        handler.request = accepted
-        handler.server = _Server()
-        handler.channel = Mock()
-        handler.channel.receive.side_effect = [_claim_request(), EOFError()]
-        delivery_attempted = threading.Event()
-
-        def undelivered(_response: object, _descriptor: int) -> None:
-            # The lease is committed before delivery is attempted, so this is
-            # the moment the rival's refusal becomes the property under test.
-            delivery_attempted.set()
-            raise RuntimeError("undelivered")
-
-        handler.channel.send_with_fd.side_effect = undelivered
-        held = threading.Thread(target=handler.handle)
-        try:
-            peer.close()
-            held.start()
-            assert delivery_attempted.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-            # The connection died; the lease did not. A rival is still refused.
-            rival = _FakeLiveness()
-            with pytest.raises(KVCRServiceError, match="busy|held"):
-                registry.claim(0, _TEST_TIER_CONFIG, rival, _control_bind(0))
-
+        child.kill()
+        child.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+        # Death freed it: the pool's own actor promotes, and the lease is gone.
+        _await_phase(registry._pools[0], lambda g: g._phase is _Phase.STANDBY)
+        assert _holders_of(registry) == {}
+    finally:
+        if child.poll() is None:
             child.kill()
             child.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-            held.join(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-            assert not held.is_alive()
-            # Death freed it: the pool is claimable again.
-            assert _holders_of(registry) == {}
-        finally:
-            if child.poll() is None:
-                child.kill()
-            child.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-            if held.is_alive():
-                held.join(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-            accepted.close()
+        peer.close()
+        accepted.close()
+        registry.close()
 
 
-def test_a_release_racing_death_wins_and_a_failed_release_stops_the_service() -> None:
-    """A valid release outranks a simultaneous death; a refused one is fatal."""
-    socket_fd = 10
-    pidfd = 11
-    poller = Mock()
-    poller.poll.return_value = [
-        (pidfd, select.POLLIN),
-        (socket_fd, select.POLLIN),
-    ]
-    liveness = Mock()
-    liveness.fileno.return_value = pidfd
-    registry = Mock()
-    handler = object.__new__(_RequestHandler)
-    handler.request = Mock()
-    handler.request.fileno.return_value = socket_fd
-    handler.channel = Mock()
-    handler.channel.receive.return_value = _Release(1)
-    handler.server = Mock(registry=registry)
-
-    with patch("kvcr.kvcr_service.select.poll", return_value=poller):
-        handler._hold(0, liveness)
-
-    registry.release.assert_called_once_with(0, liveness)
-    registry.holder_died.assert_not_called()
-    handler.channel.send.assert_called_once_with(_Released(1))
-    handler.server.fail.assert_not_called()
-
-    # The same release, when the registry cannot honour it, stops the service.
-    error = RuntimeError("registry invariant failed")
-    registry.release.side_effect = error
-
-    assert handler._release_or_fail(0, liveness) is False
-
-    handler.server.fail.assert_called_once_with(error)
-
-
-@pytest.mark.parametrize(
-    ("failure", "registry_closed"),
-    [
-        ("setup", False),
-        ("poll", False),
-        ("pidfd", False),
-        ("promotion", False),
-        ("closed-fileno", True),
-        ("closed-poll", True),
-    ],
-)
-def test_hold_failures_stop_the_service_and_retain_the_binding(
+def test_a_rollback_that_cannot_stop_a_guard_leaves_its_pool_in_place(
     tmp_path: Path,
-    failure: str,
-    registry_closed: bool,
 ) -> None:
-    """Fatal hold failures stop the service, binding kept; shutdown latches nothing."""
-    liveness = Mock()
-    liveness.fileno.return_value = 11
-    with _new_registry(tmp_path, 1) as registry:
-        registry.claim(0, _TEST_TIER_CONFIG, liveness, _control_bind(0))
+    """Unlinking under a Guard that would not close would fault the mapping."""
+    wedged, failing = Mock(), Mock()
+    wedged.close.side_effect = RuntimeError("still holding the mapping")
+    failing.start.side_effect = RuntimeError("attach failed")
 
-        server = object.__new__(_ThreadingUnixServer)
-        server.registry = registry
-        server._fatal_error = None
-        server._fatal_lock = threading.Lock()
-        server.shutdown = Mock()
-        handler = object.__new__(_RequestHandler)
-        handler.request = Mock()
-        handler.request.fileno.return_value = 10
-        handler.server = server
-        poller = Mock()
-        promotion_failure: RuntimeError | None = None
-        if failure == "setup":
-            poller.register.side_effect = OSError("setup failed")
-        elif failure == "poll":
-            poller.poll.side_effect = OSError("poll failed")
-        elif failure in ("pidfd", "closed-poll"):
-            poller.poll.return_value = [(11, select.POLLERR | select.POLLNVAL)]
-        elif failure == "closed-fileno":
-            # What an already-closed pidfd raises when _hold first asks for it.
-            liveness.fileno.side_effect = ValueError("pidfd is closed")
-        else:
-            # A Guard that cannot be promoted is fatal, on purpose.
-            promotion_failure = RuntimeError("promotion failed")
-            registry.holder_died = Mock(side_effect=promotion_failure)
-            poller.poll.return_value = [(11, select.POLLIN)]
+    def build(spec, _callback, *, pool_index, owner, **_kwargs):
+        guard = wedged if pool_index == 0 else failing
+        guard._spec = spec
+        if guard is failing:
+            # A Guard that closes gives its pool back with everything else.
+            failing.close.side_effect = owner.close
+        return guard
 
-        if registry_closed:
-            registry.close()
-        with patch("kvcr.kvcr_service.select.poll", return_value=poller):
-            handler._hold(0, liveness)
+    with (
+        patch("kvcr.kvcr_service._Guard", side_effect=build),
+        pytest.raises(RuntimeError, match="attach failed"),
+    ):
+        _PoolRegistry(
+            tmp_path,
+            2,
+            _TEST_POOL_SIZE_BYTES,
+            _TEST_JOURNAL_BYTES,
+            _TEST_DIGEST,
+        )
 
-        if registry_closed:
-            # Whichever end noticed, the shutdown is the cause and already
-            # under way; neither end may latch a failure.
-            assert server._fatal_error is None
-            server.shutdown.assert_not_called()
-            return
+    # The wedged pool's file is left for the next start's purge; the pool
+    # whose Guard closed is gone with its owner.
+    assert len(list(tmp_path.iterdir())) == 1
 
-        fatal_error = server._fatal_error
-        if promotion_failure is not None:
-            assert fatal_error is promotion_failure
-        else:
-            assert isinstance(fatal_error, OSError)
-            assert failure in str(fatal_error)
+
+def test_promotion_failure_stops_the_whole_service(tmp_path: Path) -> None:
+    """A pool that cannot be promoted is fatal, on purpose."""
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    failure = RuntimeError("promotion failed")
+    guard._promote = Mock(side_effect=failure)
+
+    server = object.__new__(_ThreadingUnixServer)
+    server.registry = registry
+    server._fatal_error = None
+    server._fatal_lock = threading.Lock()
+    server.shutdown = Mock()
+    registry.on_uncontained_failure = server.fail
+    liveness = _FakeLiveness()
+    try:
+        _claim(registry, 0, liveness)
+
+        _kill_and_wait(registry, 0, liveness)
+
+        assert server._fatal_error is failure
         server.shutdown.assert_called_once_with()
-        assert registry._pools[0].holder is liveness
-        liveness.close.assert_not_called()
-        # Now refused for the stronger reason: failing closes the registry first.
-        with pytest.raises(RuntimeError, match="closed"):
+        assert registry.is_closed() is True
+    finally:
+        registry.close()
+
+
+def test_a_lease_older_than_the_idle_timeout_still_releases_cleanly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The accept-time idle timeout must not sever a held connection."""
+    monkeypatch.setattr("kvcr.kvcr_service._CLIENT_IDLE_TIMEOUT_SECONDS", 0.2)
+    with _running_server(tmp_path) as harness:
+        hold = harness.client.claim(
+            0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
+        )
+        time.sleep(0.5)
+
+        hold.release()
+
+        guard = harness.server._registry._pools[0]
+        assert guard._lease is None
+
+
+def test_refuse_claims_returns_only_after_inflight_commits_are_decided(
+    tmp_path: Path,
+) -> None:
+    """The barrier: refuse_claims passes every pool's phase lock on its way out."""
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    returned = threading.Event()
+    with guard._phase_lock:
+        refuser = threading.Thread(
+            target=lambda: (registry.refuse_claims(), returned.set())
+        )
+        refuser.start()
+        # Held by us, exactly as a commit in flight would hold it.
+        assert not returned.wait(timeout=0.3)
+    assert returned.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+    refuser.join(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+    registry.close()
+
+
+def test_a_release_that_times_out_reports_the_timeout(tmp_path: Path) -> None:
+    """A handler's own TimeoutError is the answer, not a wait to keep waiting."""
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    liveness = _FakeLiveness()
+    try:
+        _spec, lease = _claim(registry, 0, liveness)
+        guard._release = Mock(side_effect=TimeoutError("hand-back timed out"))
+
+        started = time.monotonic()
+        with pytest.raises(TimeoutError, match="hand-back timed out"):
+            registry.release(0, lease)
+
+        assert time.monotonic() - started < 2
+    finally:
+        registry.close()
+
+
+def test_a_dup_failure_on_a_fresh_bind_does_not_pin_the_endpoint(
+    tmp_path: Path,
+) -> None:
+    """A claim that bound the address and then failed must give it back."""
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    try:
+        with patch("kvcr.guard.os.dup", side_effect=OSError("dup failed")):
+            with pytest.raises(OSError, match="dup failed"):
+                registry.claim(0, _TEST_TIER_CONFIG, _FakeLiveness(), _control_bind(0))
+        assert guard._listener is None
+
+        # In particular, a retry on a DIFFERENT address must be honoured.
+        replacement = _FakeLiveness()
+        other_bind = _control_bind(0)
+        _spec, lease = _claim(registry, 0, replacement, other_bind)
+        assert guard._bind == other_bind
+        assert guard._lease is lease
+    finally:
+        registry.close()
+
+
+def test_a_listener_that_will_not_close_stays_visible_on_the_kept_pool(
+    tmp_path: Path,
+) -> None:
+    """A kept pool must still name what it leaked, or nobody can ever retry."""
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    _claim(registry, 0, _FakeLiveness())
+    real_listener = guard._listener
+    stubborn = Mock(
+        fileno=real_listener.fileno, close=Mock(side_effect=OSError("will not close"))
+    )
+    guard._listener = stubborn
+    try:
+        with pytest.raises(OSError, match="will not close"):
+            registry.close()
+
+        # The pool is kept, and the resource that failed is still reachable.
+        assert registry._pools.keys() == {0}
+        assert registry._pools[0]._listener is stubborn
+    finally:
+        guard._listener = real_listener
+        type(guard)._close_resources(guard)
+
+
+def test_a_pidfd_that_breaks_while_its_process_lives_is_service_fatal(
+    tmp_path: Path,
+) -> None:
+    """Promotion on a broken descriptor could seat a second server on the pool."""
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    guard._promote = Mock()
+    uncontained: list[BaseException] = []
+    registry.on_uncontained_failure = uncontained.append
+    liveness = _FakeLiveness()
+    try:
+        _claim(registry, 0, liveness)
+        poller = Mock()
+        poller.poll.return_value = [(liveness.fileno(), select.POLLNVAL)]
+        with patch("kvcr.guard.select.poll", return_value=poller):
+            _await_phase(guard, lambda g: g._phase is _Phase.FAILED)
+
+        guard._promote.assert_not_called()
+        assert len(uncontained) == 1
+        assert isinstance(uncontained[0], OSError)
+        assert "without POLLIN" in str(uncontained[0])
+    finally:
+        registry.close()
+
+
+def test_a_release_racing_shutdown_is_absorbed(tmp_path: Path) -> None:
+    """Once close has begun, a release is the close's problem, not a new fatal."""
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    liveness = _FakeLiveness()
+    _spec, lease = _claim(registry, 0, liveness)
+    gate = threading.Event()
+    entered = threading.Event()
+    real_close_resources = guard._close_resources
+
+    def slow_close() -> None:
+        entered.set()
+        assert gate.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+        real_close_resources()
+
+    guard._close_resources = slow_close
+    guard._promote = Mock()
+    try:
+        registry.refuse_claims()
+        guard.begin_close()
+        assert entered.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+
+        # Silently absorbed, exactly as the old registry did under its lock.
+        registry.release(0, lease)
+
+        # A death in the same window is the close's to clean up, not a
+        # promotion: the pool is being torn down, not failed over.
+        liveness.kill()
+
+        # And a claim in the same window is refused with a typed error.
+        with pytest.raises(KVCRServiceError, match="closed"):
             registry.claim(0, _TEST_TIER_CONFIG, _FakeLiveness(), _control_bind(0))
+    finally:
+        gate.set()
+        registry.close()
+    guard._promote.assert_not_called()
+    assert liveness.closed is True
 
-        # Shutdown ends other pools' work, and those endings fail too; the
-        # first failure is the one kept and reported.
-        server.fail(RuntimeError("and then the shutdown did too"))
-        assert server._fatal_error is fatal_error
 
-        service = object.__new__(_KVCRService)
-        service._server = server
-        server.serve_forever = Mock()
-        with pytest.raises((OSError, RuntimeError)) as raised:
-            service.serve_forever()
-        assert raised.value is fatal_error
+def test_a_command_queued_behind_close_is_answered_not_abandoned(
+    tmp_path: Path,
+) -> None:
+    """Every exit of the actor loop answers what is still queued."""
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    gate = threading.Event()
+    entered = threading.Event()
+    real_close_resources = guard._close_resources
+
+    def slow_close() -> None:
+        entered.set()
+        assert gate.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+        real_close_resources()
+
+    guard._close_resources = slow_close
+    guard.begin_close()
+    assert entered.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+    # A raw command that slipped in behind the close, bypassing every gate.
+    stray = _Command("release", (object(),))
+    guard._commands.put(stray)
+    gate.set()
+
+    assert guard.finish_close(time.monotonic() + _SERVER_STOP_TIMEOUT_SECONDS) is False
+    assert stray.future.done()
+    assert isinstance(stray.future.exception(), KVCRServiceError)
+    registry.close()
+
+
+def test_a_grant_that_cannot_dup_its_endpoint_leaves_the_pool_claimable(
+    tmp_path: Path,
+) -> None:
+    """Everything fallible runs before the lease exists."""
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    liveness = _FakeLiveness()
+    try:
+        with patch("kvcr.guard.os.dup", side_effect=OSError("dup failed")):
+            with pytest.raises(OSError, match="dup failed"):
+                registry.claim(0, _TEST_TIER_CONFIG, liveness, _control_bind(0))
+
+        assert guard._lease is None
+        assert guard._phase is not _Phase.PRIMARY
+        assert guard._reserved is None
+
+        # The pool survived its failed grant: the next claim simply works.
+        replacement = _FakeLiveness()
+        _spec, lease = _claim(registry, 0, replacement)
+        assert guard._lease is lease
+    finally:
+        registry.close()
+
+
+def test_no_grant_is_produced_after_refuse_claims_returns(tmp_path: Path) -> None:
+    """The grant commits under the same lock the refusal is read under."""
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    in_adopt = threading.Event()
+    resume = threading.Event()
+    real_adopt = guard._adopt
+
+    def gated_adopt(control, tier_config) -> None:
+        real_adopt(control, tier_config)
+        in_adopt.set()
+        assert resume.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+
+    guard._adopt = gated_adopt
+    outcome: dict = {}
+
+    def claim() -> None:
+        try:
+            outcome["grant"] = registry.claim(
+                0, _TEST_TIER_CONFIG, _FakeLiveness(), _control_bind(0)
+            )
+        except BaseException as error:  # noqa: BLE001 - recorded for the assert
+            outcome["error"] = error
+
+    claimant = threading.Thread(target=claim)
+    claimant.start()
+    try:
+        assert in_adopt.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+        registry.refuse_claims()
+        # refuse_claims has RETURNED; the claim past every earlier check must
+        # still be refused at its commit.
+        resume.set()
+        claimant.join(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+        assert not claimant.is_alive()
+
+        assert "grant" not in outcome
+        assert isinstance(outcome["error"], KVCRServiceError)
+        assert guard._lease is None
+        assert guard._reserved is None
+    finally:
+        resume.set()
+        registry.close()
+
+
+def test_shutdown_drains_a_held_connection(tmp_path: Path) -> None:
+    with _running_server(tmp_path) as harness:
+        hold = harness.client.claim(
+            0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
+        )
+        harness.stop()
+        _wait_for_connection_state(harness.server, connected=False)
+        hold._attachment.close()
+        hold._connection.close()
 
 
 def test_a_pool_no_bigger_than_its_journal_is_rejected_at_the_flag() -> None:
@@ -1268,40 +1589,30 @@ def test_a_pool_no_bigger_than_its_journal_is_rejected_at_the_flag() -> None:
     assert parse("0.2").pool_size_bytes > 100 * (1 << 20)
 
 
-def test_a_claim_that_loses_a_race_with_shutdown_leaves_no_transition(
+def test_a_failed_release_refuses_claims_before_it_frees_the_pool(
     tmp_path: Path,
 ) -> None:
-    """Closing while a pool is mid-adoption must not strand it in transition."""
-    adopting = threading.Event()
-    finish_adopt = threading.Event()
-    guard = Mock()
-    guard.adopt.side_effect = lambda *_args: (
-        adopting.set(),
-        finish_adopt.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS),
+    """The window between a failed hand-back and the shutdown it causes."""
+    registry = _new_registry(tmp_path)
+    guard = registry._pools[0]
+    failure = RuntimeError("hand-back failed")
+    guard._release = Mock(side_effect=failure)
+    claimable_when_reported: list[bool] = []
+    registry.on_uncontained_failure = lambda _error: claimable_when_reported.append(
+        guard._lease is None and guard._failure is None
     )
-    with _new_registry(tmp_path, guards=[guard]) as registry:
-        liveness = _FakeLiveness()
-        failures: list[BaseException] = []
+    liveness = _FakeLiveness()
+    try:
+        _spec, lease = _claim(registry, 0, liveness)
 
-        def claim() -> None:
-            try:
-                registry.claim(0, _TEST_TIER_CONFIG, liveness, _control_bind(0))
-            except BaseException as error:  # noqa: BLE001 - recorded for the assert
-                failures.append(error)
+        with pytest.raises(RuntimeError) as raised:
+            registry.release(0, lease)
 
-        claimant = threading.Thread(target=claim)
-        claimant.start()
-        try:
-            assert adopting.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-            registry._closed = True
-            finish_adopt.set()
-            claimant.join(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-            assert not claimant.is_alive()
-
-            # Refused, so nothing was granted -- but the pool is not left mid-flight.
-            assert failures and isinstance(failures[0], KVCRServiceError)
-            assert registry._pools[0].in_transition is False
-            assert registry._pools[0].holder is liveness
-        finally:
-            finish_adopt.set()
-            registry._closed = False
+        assert raised.value is failure
+        # Reported while the pool was already fenced, so nothing could claim it.
+        assert claimable_when_reported == [False]
+        assert guard._phase is _Phase.FAILED
+        with pytest.raises(RuntimeError, match="hand-back failed"):
+            _claim(registry, 0, _FakeLiveness())
+    finally:
+        registry.close()

--- a/tests/unit/test_kvcr_service.py
+++ b/tests/unit/test_kvcr_service.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-import argparse
 import os
 import select
 import signal
@@ -20,7 +19,7 @@ from unittest.mock import Mock, patch
 
 import msgspec
 import pytest
-from _kvcr_test_utils import free_port, listening_socket
+from _kvcr_test_utils import _wait_until, free_port, listening_socket
 
 from kvcr import KVCRClient, KVCRServiceError
 from kvcr.config import G3Options
@@ -50,15 +49,7 @@ from kvcr.memory import _KVCRPoolOwner
 
 def _holders_of(registry) -> dict[int, object]:
     """The pools a worker holds, in the shape the old binding map had."""
-    return {
-        i: p._lease.liveness for i, p in registry._pools.items() if p._lease is not None
-    }
-
-
-def _listeners_of(registry) -> dict[int, object]:
-    return {
-        i: p._listener for i, p in registry._pools.items() if p._listener is not None
-    }
+    return {i: p._lease for i, p in registry._pools.items() if p._lease is not None}
 
 
 _SERVER_STOP_TIMEOUT_SECONDS = 5
@@ -76,11 +67,7 @@ _PAGE_STRIDE = os.sysconf("SC_PAGE_SIZE")
 
 
 class _FakeLiveness:
-    """A pollable stand-in for a claimant's pidfd.
-
-    A real pidfd reads POLLIN once its process exits; a pipe read end reads
-    POLLIN once a byte is written. kill() is that byte.
-    """
+    """A pollable pidfd stand-in: a pipe that reads POLLIN once killed."""
 
     def __init__(self) -> None:
         self._read, self._write = os.pipe()
@@ -113,22 +100,13 @@ def _claim(registry, pool_index, liveness, control_bind=None):
     return spec, lease
 
 
-def _await_phase(guard, predicate, timeout=5.0) -> None:
-    deadline = time.monotonic() + timeout
-    while not predicate(guard):
-        if time.monotonic() >= deadline:
-            pytest.fail(f"pool never reached the expected state: {guard._phase}")
-        time.sleep(0.001)
-
-
 def _kill_and_wait(registry, pool_index, liveness) -> None:
     """Die the way a real claimant does: the pool's own actor notices."""
-    from kvcr.guard import _Phase
-
     liveness.kill()
-    _await_phase(
-        registry._pools[pool_index],
-        lambda g: g._phase in (_Phase.STANDBY, _Phase.FAILED) or g._failure,
+    guard = registry._pools[pool_index]
+    _wait_until(
+        lambda: guard._phase in (_Phase.STANDBY, _Phase.FAILED) or guard._failure,
+        timeout=5,
     )
 
 
@@ -192,23 +170,6 @@ def _send_raw_request(
         return channel.receive(_CLAIM_RESPONSE_DECODER)
 
 
-def _control_address() -> tuple[str, int]:
-    """A free address a client can ask the service to bind."""
-    bind = _control_bind()
-    return bind
-
-
-def _takes(*channels):
-    """Stand in for from_shared_listener, which detaches what it is given."""
-    remaining = list(channels)
-
-    def _take(duplicate: socket.socket):
-        duplicate.close()
-        return remaining.pop(0) if len(remaining) > 1 else remaining[0]
-
-    return _take
-
-
 _POOL_BINDS: dict[int, tuple[str, int]] = {}
 
 
@@ -219,20 +180,13 @@ def _control_bind(pool_index: int = 0) -> tuple[str, int]:
     return _POOL_BINDS[pool_index]
 
 
+# A free address a client can ask the service to bind.
 def _claim_request(
     compatibility_digest: str = _TEST_DIGEST,
-    g3: _G3Config | None = None,
     control_bind: tuple[str, int] | None = None,
 ) -> _Claim:
     host, port = control_bind or _control_bind(0)
-    return _Claim(
-        0,
-        compatibility_digest,
-        _TierConfig(_TEST_ROW_STRIDE, g3),
-        host,
-        port,
-        1,
-    )
+    return _Claim(0, compatibility_digest, _TEST_TIER_CONFIG, host, port, 1)
 
 
 @pytest.fixture(autouse=True)
@@ -241,11 +195,15 @@ def _channels_are_taken():
     # Within a test a pool's endpoint never moves; across tests it is gone.
     _POOL_BINDS.clear()
     # A promoted Guard's poll loop drains this, so recv() must be iterable.
-    channel = Mock()
-    channel.recv.return_value = []
+    channel = Mock(recv=Mock(return_value=[]))
+
+    def _take(duplicate: socket.socket):
+        duplicate.close()
+        return channel
+
     with patch(
         "kvcr.guard.ZmqPeerControlChannel.from_shared_listener",
-        side_effect=_takes(channel),
+        side_effect=_take,
     ):
         yield
     _POOL_BINDS.clear()
@@ -259,11 +217,7 @@ def _stand_in_pool(spec) -> Mock:
 
 
 def _new_registry(tmp_path: Path, pool_count: int = 1) -> _PoolRegistry:
-    """A registry of real Guards over stand-in pool mappings.
-
-    A pool's lifecycle lives in its Guard now, so the seam moved: these tests
-    fake the mapping a Guard attaches, not the Guard itself.
-    """
+    """A registry of real Guards over stand-in pool mappings."""
     journal = Mock()
     journal.read_next.return_value = None
     with (
@@ -297,84 +251,66 @@ def test_socket_is_private(tmp_path: Path) -> None:
         assert stat.S_IMODE(harness.server.socket_path.stat().st_mode) == 0o600
 
 
-def test_release_preserves_the_physical_pool_spec(tmp_path: Path) -> None:
-    registry = _new_registry(tmp_path, 2)
-    first = _FakeLiveness()
-    second = _FakeLiveness()
-    try:
-        first_spec, first_lease = _claim(registry, 0, first)
-        registry.release(0, first_lease)
-        second_spec, second_lease = _claim(registry, 0, second)
-        registry.release(0, second_lease)
-
-        assert first_spec is second_spec
-        assert first.closed is True
-        assert second.closed is True
-    finally:
-        registry.close()
-
-
-def test_pools_are_claimed_independently_of_each_other(tmp_path: Path) -> None:
-    """One pool's geometry says nothing about another's."""
+def test_registry_lifecycle_from_independent_leases_to_a_wedged_close(
+    tmp_path: Path,
+) -> None:
+    """Pools lease independently; close keeps, names, and can retry a wedged one."""
     registry = _new_registry(tmp_path, pool_count=2)
-    first = _FakeLiveness()
-    second = _FakeLiveness()
-    try:
-        _claim(registry, 0, first)
-        _spec, _fd, lease = registry.claim(
-            1, _TierConfig(_TEST_ROW_STRIDE * 2, None), second, _control_bind(1)
-        )
-        os.close(_fd)
-        del lease
+    guard = registry._pools[0]
+    first, second, third = _FakeLiveness(), _FakeLiveness(), _FakeLiveness()
+    first_spec, stale = _claim(registry, 0, first)
+    _spec, _fd, _lease = registry.claim(
+        1, _TierConfig(_TEST_ROW_STRIDE * 2, None), second, _control_bind(1)
+    )
+    os.close(_fd)
+    # One pool's geometry says nothing about another's.
+    assert _holders_of(registry) == {0: first, 1: second}
 
-        assert _holders_of(registry) == {0: first, 1: second}
-    finally:
+    registry.release(0, stale)
+    assert first.closed is True
+    second_spec, current = _claim(registry, 0, third)
+    assert second_spec is first_spec
+
+    # The retried release of the old lease must not end the new one.
+    registry.release(0, stale)
+    assert registry._pools[0]._lease is current
+    assert third.closed is False
+
+    first_path = Path(guard._owner.spec.path)
+    second_path = Path(registry._pools[1]._owner.spec.path)
+    # An unclosable mapping keeps its file: unlinking would hide committed RAM.
+    guard._attachment.close.side_effect = RuntimeError("still holding the mapping")
+    with pytest.raises(RuntimeError, match="still holding the mapping"):
         registry.close()
+    assert registry._pools.keys() == {0}
+    assert registry._pools[0]._attachment is not None
+    assert first_path.exists()
+    # The pool behind it still went, files and all.
+    assert second.closed is True and not second_path.exists()
 
-
-def test_a_stale_lease_cannot_touch_a_replacement(tmp_path: Path) -> None:
-    """Identity is the authority: an ended lease is a no-op forever after."""
-    registry = _new_registry(tmp_path)
-    first = _FakeLiveness()
-    replacement = _FakeLiveness()
-    try:
-        _spec, stale = _claim(registry, 0, first)
-        registry.release(0, stale)
-        assert first.closed is True
-
-        _spec, current = _claim(registry, 0, replacement)
-        # The retried release of the old lease must not end the new one.
-        registry.release(0, stale)
-
-        assert registry._pools[0]._lease is current
-        assert replacement.closed is False
-    finally:
+    # The kept pool must still name what it leaked, or nobody could retry it.
+    guard._attachment.close.side_effect = None
+    stubborn = Mock(close=Mock(side_effect=OSError("will not close")))
+    guard._listener = stubborn
+    with pytest.raises(OSError, match="will not close"):
         registry.close()
+    assert registry._pools.keys() == {0}
+    assert registry._pools[0]._listener is stubborn
 
-
-def test_shutdown_releases_every_pool_and_unlinks_its_file(tmp_path: Path) -> None:
-    liveness = _FakeLiveness()
-    registry = _new_registry(tmp_path)
-    pool_path = Path(registry._pools[0]._owner.spec.path)
-    _claim(registry, 0, liveness)
-    assert pool_path.exists()
-
+    # With nothing left refusing, the retried close finally takes the pool.
+    guard._listener = None
     registry.close()
-
-    # The pidfd is spent either way, so this must not interrupt the shutdown.
-    assert registry._pools == {}
-    assert _listeners_of(registry) == {}
-    assert not pool_path.exists()
+    assert registry._pools == {} and third.closed is True
 
 
-def test_an_endpoint_must_be_named_by_address(tmp_path: Path) -> None:
-    """A name is refused where the claim is built, before it is sent."""
+def test_refused_claims_do_not_bind_the_pool(tmp_path: Path) -> None:
+    """A hostname, bad G3 terms, or a taken endpoint refuse without binding."""
+    # A name is refused where the claim is built, before it is sent.
     with pytest.raises(ValueError, match="literal IPv4 address"):
         _claim_request(control_bind=("localhost", free_port()))
 
-
-def test_invalid_g3_claim_does_not_bind(tmp_path: Path) -> None:
-    with _running_server(tmp_path) as harness:
+    # Held for the whole test: the address must still be taken when the claim runs.
+    with listening_socket() as squatter, _running_server(tmp_path) as harness:
         request = msgspec.to_builtins(_claim_request())
         request["tier_config"]["g3"] = {
             "paths": ["relative"],
@@ -382,31 +318,18 @@ def test_invalid_g3_claim_does_not_bind(tmp_path: Path) -> None:
             "backend": "FILE",
             "backend_options": {},
         }
+        assert isinstance(
+            _send_raw_request(harness.server.socket_path, request), _Error
+        )
 
-        response = _send_raw_request(harness.server.socket_path, request)
-
-        assert isinstance(response, _Error)
-        harness.client.claim(
-            0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
-        ).release()
-
-
-def test_unbindable_control_endpoint_does_not_bind_the_pool(tmp_path: Path) -> None:
-    # Held for the whole test: the address has to still be taken when the claim runs.
-    with listening_socket() as squatter:
         taken = (str(squatter.getsockname()[0]), int(squatter.getsockname()[1]))
-        with _running_server(tmp_path) as harness:
-            with pytest.raises(KVCRServiceError, match="control listener"):
-                harness.client.claim(
-                    0,
-                    _TEST_ROW_STRIDE,
-                    _TEST_DIGEST,
-                    control_bind=taken,
-                )
-            # A rejected claim must leave the pool free to take normally.
-            harness.client.claim(
-                0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
-            ).release()
+        with pytest.raises(KVCRServiceError, match="control listener"):
+            harness.client.claim(0, _TEST_ROW_STRIDE, _TEST_DIGEST, control_bind=taken)
+
+        # The rejected claims left the pool free to take normally.
+        harness.client.claim(
+            0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_bind()
+        ).release()
 
 
 def test_recognized_messages_ignore_unknown_fields(
@@ -433,11 +356,11 @@ def test_a_grant_tells_the_pools_guard_and_a_clean_release_stands_it_down(
 ) -> None:
     """The Guard is the pool's, so a grant configures it and a release parks it."""
     control = Mock()
-    taken: list[tuple[int, int, object]] = []
+    taken: list[tuple[int, object]] = []
 
     def _take_and_record(duplicate: socket.socket):
         # Recorded before it is closed, as the real one closes it too.
-        taken.append((duplicate.family, duplicate.fileno(), duplicate.getsockname()))
+        taken.append((duplicate.fileno(), duplicate.getsockname()))
         duplicate.close()
         return control
 
@@ -458,12 +381,9 @@ def test_a_grant_tells_the_pools_guard_and_a_clean_release_stands_it_down(
         # Built and started with the pool, before any claim named it.
         assert guard._phase is _Phase.UNCONFIGURED
 
-        hold = harness.client.claim(
-            1, _PAGE_STRIDE, _TEST_DIGEST, _control_address(), g3
-        )
-        assert guard._phase is _Phase.PRIMARY
-        assert guard._control is control
-        assert guard._configured.tier_config == _TierConfig(
+        hold = harness.client.claim(1, _PAGE_STRIDE, _TEST_DIGEST, _control_bind(), g3)
+        assert guard._phase is _Phase.PRIMARY and guard._control is control
+        assert guard._configured == _TierConfig(
             _PAGE_STRIDE,
             _G3Config(
                 paths=(str(g3.paths[0]),),
@@ -472,200 +392,103 @@ def test_a_grant_tells_the_pools_guard_and_a_clean_release_stands_it_down(
                 backend_options=dict(g3.backend_options),
             ),
         )
-        (family, taken_fd, taken_name) = taken[0]
-        assert family == socket.AF_INET
+        taken_fd, taken_name = taken[0]
         # The Guard is handed a duplicate; the pool keeps the original.
-        owned = guard._listener
-        assert taken_fd != owned.fileno()
-        assert taken_name == owned.getsockname()
+        assert taken_fd != guard._listener.fileno()
+        assert taken_name == guard._listener.getsockname()
 
         hold.release()
 
-        assert guard._phase is _Phase.IDLE
-        assert guard._lease is None
+        assert guard._phase is _Phase.IDLE and guard._lease is None
         # The adopted channel went with the lease; the endpoint did not.
         control.close.assert_called_once_with()
         assert guard._listener is not None
 
 
-def test_a_claim_that_cannot_give_its_endpoint_back_is_fatal(
+def test_a_failed_claim_pins_nothing_and_an_unfreeable_endpoint_is_fatal(
     tmp_path: Path,
 ) -> None:
-    """A rollback that cannot prove the address is gone must stop the service."""
-    registry = _new_registry(tmp_path)
+    """A failed claim gives back lease and endpoint; an unfreeable address is fatal."""
+    registry = _new_registry(tmp_path, pool_count=2)
     guard = registry._pools[0]
-    adopt_failure = RuntimeError("adopt failed")
-    unbind_failure = OSError("close failed")
-    uncontained: list[BaseException] = []
-    registry.on_uncontained_failure = uncontained.append
-    guard._adopt = Mock(side_effect=adopt_failure)
-    real_bind = guard._bind_listener
     bound: list[socket.socket] = []
-
-    def bind_a_listener_that_will_not_close(control_bind):
-        listener = real_bind(control_bind)
-        bound.append(listener)
-        guard._listener = Mock(
-            fileno=listener.fileno, close=Mock(side_effect=unbind_failure)
-        )
-        return guard._listener
-
-    guard._bind_listener = bind_a_listener_that_will_not_close
     try:
+        # Everything fallible runs before the lease exists.
+        with patch("kvcr.guard.os.dup", side_effect=OSError("dup failed")):
+            with pytest.raises(OSError, match="dup failed"):
+                registry.claim(0, _TEST_TIER_CONFIG, _FakeLiveness(), _control_bind(0))
+        assert guard._listener is None and guard._lease is None
+        assert guard._reserved is None and guard._phase is not _Phase.PRIMARY
+
+        # The pool survived its failed grant: the retry simply works.
+        replacement = _FakeLiveness()
+        _spec, lease = _claim(registry, 0, replacement)
+        assert guard._lease is lease and guard._bind == _control_bind(0)
+
+        # A rollback that cannot free the pool's address must stop the service.
+        fatal = registry._pools[1]
+        adopt_failure = RuntimeError("adopt failed")
+        unbind_failure = OSError("close failed")
+        uncontained: list[BaseException] = []
+        registry.on_uncontained_failure = uncontained.append
+        fatal._adopt = Mock(side_effect=adopt_failure)
+        real_bind = fatal._bind_listener
+
+        def bind_a_listener_that_will_not_close(control_bind):
+            bound.append(real_bind(control_bind))
+            fatal._listener = Mock(
+                fileno=bound[-1].fileno, close=Mock(side_effect=unbind_failure)
+            )
+            return fatal._listener
+
+        fatal._bind_listener = bind_a_listener_that_will_not_close
         with pytest.raises(RuntimeError) as raised:
-            _claim(registry, 0, _FakeLiveness())
+            _claim(registry, 1, _FakeLiveness())
 
         # The claim's own error, not the one its cleanup hit.
         assert raised.value is adopt_failure
         assert uncontained == [unbind_failure]
         # The transition ended: nothing is left reserved against this pool.
-        assert guard._reserved is None
-        assert guard._lease is None
+        assert fatal._reserved is None and fatal._lease is None
     finally:
-        guard._listener = None
+        registry._pools[1]._listener = None
         for listener in bound:
             listener.close()
         registry.close()
 
 
-@pytest.mark.parametrize(
-    "promotion_error",
-    [None, RuntimeError("promotion failed")],
-    ids=["promoted", "promotion_failed"],
-)
-def test_holder_death_retains_guard_and_pool_stays_busy(
+def test_a_standby_survives_failed_claims_and_hands_over_to_a_replacement(
     tmp_path: Path,
-    promotion_error: RuntimeError | None,
 ) -> None:
+    """Refused or failed claims cost a standby nothing; a good one inherits all."""
+    control_bind = _control_bind(0)
     registry = _new_registry(tmp_path)
     guard = registry._pools[0]
-    uncontained: list[BaseException] = []
-    registry.on_uncontained_failure = uncontained.append
-    promote = Mock(side_effect=promotion_error)
-    guard._promote = promote
-    liveness = _FakeLiveness()
-    try:
-        _claim(registry, 0, liveness)
-
-        _kill_and_wait(registry, 0, liveness)
-
-        promote.assert_called_once_with()
-        assert liveness.closed is True
-        assert _holders_of(registry) == {}
-        if promotion_error is None:
-            assert uncontained == []
-            assert guard._phase is _Phase.STANDBY
-            # Claimable again: the pool waits for a replacement primary.
-            replacement = _FakeLiveness()
-            _spec, lease = _claim(registry, 0, replacement)
-            assert guard._lease is lease
-        else:
-            # Promotion is fatal, on purpose: escalated, and the pool refuses.
-            assert uncontained == [promotion_error]
-            assert guard._phase is _Phase.FAILED
-            with pytest.raises(RuntimeError, match="promotion failed"):
-                _claim(registry, 0, _FakeLiveness())
-    finally:
-        registry.close()
-
-
-def _claim_after_promotion(
-    registry: _PoolRegistry, control_bind: tuple[str, int]
-) -> _FakeLiveness:
-    """Leave pool 0 standing by, with nobody holding it.
-
-    The promotion itself is stubbed: what these tests exercise is the
-    lifecycle around a standby, not the recovery machinery inside one.
-    """
-    guard = registry._pools[0]
+    # The promotion itself is stubbed: what this exercises is the lifecycle
+    # around a standby, not the recovery machinery inside one.
     guard._promote = Mock()
     liveness = _FakeLiveness()
-    _spec, _fd, _lease = registry.claim(0, _TEST_TIER_CONFIG, liveness, control_bind)
-    os.close(_fd)
-    _kill_and_wait(registry, 0, liveness)
-    assert _holders_of(registry) == {}
-    return liveness
-
-
-def test_a_standby_pool_hands_itself_to_a_replacement(tmp_path: Path) -> None:
-    control_bind = _control_bind(0)
-    registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
     try:
-        _claim_after_promotion(registry, control_bind)
-        replacement = _FakeLiveness()
+        _spec, lease = _claim(registry, 0, liveness, control_bind)
 
-        _spec, lease = _claim(registry, 0, replacement, control_bind)
+        # With the actor's observation held back, the dead window answers busy.
+        guard._observe_holder = lambda: None
+        liveness.kill()
+        with pytest.raises(KVCRServiceError, match="busy"):
+            _claim(registry, 0, _FakeLiveness())
+        guard._promote.assert_not_called()
+        assert liveness.closed is False
 
-        assert guard._phase is _Phase.PRIMARY
-        assert guard._lease is lease
-        # The same endpoint, never rebound: the replacement inherits it.
-        assert guard._listener.getsockname() == (control_bind[0], control_bind[1])
-    finally:
-        registry.close()
+        del guard._observe_holder
+        _wait_until(lambda: guard._phase is _Phase.STANDBY, timeout=5)
+        guard._promote.assert_called_once_with()
+        assert liveness.closed is True and _holders_of(registry) == {}
 
-
-def test_a_claim_that_fails_before_the_hand_over_leaves_the_guard_serving(
-    tmp_path: Path,
-) -> None:
-    """Only a hand-over that actually began costs the standby its endpoint."""
-    control_bind = _control_bind(0)
-    registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
-    try:
-        _claim_after_promotion(registry, control_bind)
-        with patch(
-            "kvcr.guard.ZmqPeerControlChannel.from_shared_listener",
-            side_effect=ValueError("cannot share this listener"),
-        ):
-            with pytest.raises(KVCRServiceError, match="cannot share this listener"):
-                _claim(registry, 0, _FakeLiveness(), control_bind)
-
+        # A release racing the death it lost to is a no-op forever after.
+        registry.release(0, lease)
         assert guard._phase is _Phase.STANDBY
-        assert guard._reserved is None
-        assert guard._listener is not None
-    finally:
-        registry.close()
 
-
-def test_a_guard_that_cannot_adopt_a_replacement_fails_the_claim(
-    tmp_path: Path,
-) -> None:
-    """A refused claim costs the pool nothing -- not its standby, not its address."""
-    control_bind = _control_bind(0)
-    registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
-    failure = RuntimeError("adopt failed")
-    try:
-        _claim_after_promotion(registry, control_bind)
-        real_adopt = guard._adopt
-        guard._adopt = Mock(side_effect=failure)
-        with pytest.raises(RuntimeError) as raised:
-            _claim(registry, 0, _FakeLiveness(), control_bind)
-        assert raised.value is failure
-        assert guard._phase is _Phase.STANDBY
-        assert _holders_of(registry) == {}
-        assert guard._listener is not None
-
-        # The failure fenced the claim rather than the pool.
-        guard._adopt = real_adopt
-        replacement = _FakeLiveness()
-        _spec, lease = _claim(registry, 0, replacement, control_bind)
-        assert guard._lease is lease
-    finally:
-        registry.close()
-
-
-def test_a_guard_will_not_hand_a_pool_to_differently_configured_tiers(
-    tmp_path: Path,
-) -> None:
-    control_bind = _control_bind(0)
-    registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
-    try:
-        _claim_after_promotion(registry, control_bind)
-        # Tiers are fixed by the first claim; a mismatched replacement is refused
-        # by the real predicate, and the standby keeps serving.
+        # Tiers are fixed by the first claim; a mismatched replacement is refused.
         with pytest.raises(KVCRServiceError, match="another tier configuration"):
             registry.claim(
                 0,
@@ -673,46 +496,32 @@ def test_a_guard_will_not_hand_a_pool_to_differently_configured_tiers(
                 _FakeLiveness(),
                 control_bind,
             )
+
+        # Only a hand-over that actually began costs the standby its endpoint.
+        with patch(
+            "kvcr.guard.ZmqPeerControlChannel.from_shared_listener",
+            side_effect=ValueError("cannot share this listener"),
+        ):
+            with pytest.raises(KVCRServiceError, match="cannot share this listener"):
+                _claim(registry, 0, _FakeLiveness(), control_bind)
         assert guard._phase is _Phase.STANDBY
+
+        # An adopt failure fences the claim rather than the pool.
+        real_adopt = guard._adopt
+        guard._adopt = Mock(side_effect=RuntimeError("adopt failed"))
+        with pytest.raises(RuntimeError, match="adopt failed"):
+            _claim(registry, 0, _FakeLiveness(), control_bind)
+        assert guard._phase is _Phase.STANDBY
+        assert guard._reserved is None and guard._listener is not None
         assert _holders_of(registry) == {}
+
+        guard._adopt = real_adopt
+        replacement = _FakeLiveness()
+        _spec, lease = _claim(registry, 0, replacement, control_bind)
+        assert guard._phase is _Phase.PRIMARY and guard._lease is lease
+        # The same endpoint, never rebound: the replacement inherited it.
+        assert guard._listener.getsockname() == control_bind
     finally:
-        registry.close()
-
-
-def test_dead_guarded_holder_stays_busy_until_the_actor_promotes(
-    tmp_path: Path,
-) -> None:
-    registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
-    guard._promote = Mock()
-    # Hold the actor's own observation back, so the dead-but-not-yet-promoted
-    # window is stable enough to assert against.
-    guard._observe_holder = lambda: None
-    child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
-    first = PidfdLiveness(os.pidfd_open(child.pid))
-    try:
-        _claim(registry, 0, first)
-        child.terminate()
-        child.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-
-        # Dead, but the actor has not promoted: busy, not "held".
-        with pytest.raises(KVCRServiceError, match="busy"):
-            _claim(registry, 0, _FakeLiveness())
-        assert first.fileno() >= 0
-        guard._promote.assert_not_called()
-
-        del guard._observe_holder
-        _await_phase(registry._pools[0], lambda g: g._phase is _Phase.STANDBY)
-
-        guard._promote.assert_called_once_with()
-        assert _holders_of(registry) == {}
-        with pytest.raises(ValueError, match="pidfd is closed"):
-            first.fileno()
-    finally:
-        if child.poll() is None:
-            child.kill()
-            child.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-        first.close()
         registry.close()
 
 
@@ -743,50 +552,20 @@ def test_slow_promotion_does_not_block_other_pools_or_shutdown(
         with pytest.raises(KVCRServiceError, match="busy"):
             _claim(registry, 0, _FakeLiveness())
 
-        # Small but not zero: the deadline is absolute, so the healthy pool's
-        # actor finishes well inside it while the wedged one burns it.
+        # Small but not zero: the healthy pool finishes well inside the deadline.
         monkeypatch.setattr(
             "kvcr.kvcr_service._REGISTRY_TRANSITION_TIMEOUT_SECONDS", 1.0
         )
         with pytest.raises(TimeoutError, match="pool transitions"):
             registry.close()
         # The wedged pool is kept and named; its neighbour still went.
-        assert registry._pools.keys() == {0}
-        assert second.closed is True
+        assert registry._pools.keys() == {0} and second.closed is True
     finally:
         continue_promotion.set()
         monkeypatch.undo()
         registry.close()
 
     assert first.closed is True
-
-
-def test_shutdown_leaks_only_the_pool_it_cannot_release(tmp_path: Path) -> None:
-    """One pool that will not go keeps its own file, and nobody else's."""
-    failure = RuntimeError("close failed")
-    registry = _new_registry(tmp_path, pool_count=2)
-    stuck = registry._pools[0]
-    stuck._close_resources = Mock(side_effect=failure)
-    first = _FakeLiveness()
-    second = _FakeLiveness()
-    _claim(registry, 0, first)
-    _claim(registry, 1, second)
-    first_path = Path(registry._pools[0]._owner.spec.path)
-    second_path = Path(registry._pools[1]._owner.spec.path)
-
-    with pytest.raises(RuntimeError, match="close failed") as raised:
-        registry.close()
-
-    assert raised.value is failure
-    # The stuck pool keeps its file and lease; the one behind it still goes.
-    assert registry._pools.keys() == {0}
-    assert first.closed is False
-    assert first_path.exists()
-    assert second.closed is True
-    assert not second_path.exists()
-
-    # Clean up the pool this test deliberately leaves behind.
-    type(stuck)._close_resources(stuck)
 
 
 def test_claim_refusals_and_internal_failures_do_not_bind(
@@ -798,11 +577,11 @@ def test_claim_refusals_and_internal_failures_do_not_bind(
         spec = harness.server._registry._pools[0]._owner.spec
         with pytest.raises(KVCRServiceError, match="compatibility digest"):
             harness.client.claim(
-                0, _TEST_ROW_STRIDE, _TEST_DIGEST.swapcase(), _control_address()
+                0, _TEST_ROW_STRIDE, _TEST_DIGEST.swapcase(), _control_bind()
             )
         with pytest.raises(KVCRServiceError, match="one complete KV row"):
             harness.client.claim(
-                0, _TEST_POOL_SIZE_BYTES + 1, _TEST_DIGEST, _control_address()
+                0, _TEST_POOL_SIZE_BYTES + 1, _TEST_DIGEST, _control_bind()
             )
         assert "Unexpected failure while handling KVCR claim" not in caplog.text
 
@@ -814,9 +593,7 @@ def test_claim_refusals_and_internal_failures_do_not_bind(
                 Mock(side_effect=internal_error),
             )
             with pytest.raises(KVCRServiceError, match="internal KVCR service error"):
-                harness.client.claim(
-                    0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
-                )
+                harness.client.claim(0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_bind())
 
         log_record = next(
             record
@@ -828,22 +605,8 @@ def test_claim_refusals_and_internal_failures_do_not_bind(
         assert harness.server._registry._pools[0]._owner.spec is spec
         assert _holders_of(harness.server._registry) == {}
         harness.client.claim(
-            0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
+            0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_bind()
         ).release()
-
-
-def test_live_holder_makes_a_second_claim_busy(tmp_path: Path) -> None:
-    with _running_server(tmp_path) as harness:
-        hold = harness.client.claim(
-            0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
-        )
-        try:
-            with pytest.raises(KVCRServiceError, match="held"):
-                harness.client.claim(
-                    0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
-                )
-        finally:
-            hold.release()
 
 
 def test_held_connection_accepts_only_release(tmp_path: Path) -> None:
@@ -862,40 +625,6 @@ def test_held_connection_accepts_only_release(tmp_path: Path) -> None:
             response = channel.receive(_RELEASE_RESPONSE_DECODER)
             assert response == _Released(1)
             assert _holders_of(harness.server._registry) == {}
-
-
-def test_a_release_racing_a_death_is_stale_after_promotion(tmp_path: Path) -> None:
-    """Whichever ending reserves first wins; the loser is a no-op forever."""
-    registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
-    guard._promote = Mock()
-    liveness = _FakeLiveness()
-    try:
-        _spec, lease = _claim(registry, 0, liveness)
-        _kill_and_wait(registry, 0, liveness)
-
-        # The claimant's release arrives after its death already promoted.
-        registry.release(0, lease)
-
-        assert guard._phase is _Phase.STANDBY
-        guard._promote.assert_called_once_with()
-    finally:
-        registry.close()
-
-
-def test_the_first_fatal_failure_is_the_one_reported() -> None:
-    """Shutdown ends other pools' work, and those endings fail too."""
-    server = object.__new__(_ThreadingUnixServer)
-    server._fatal_error = None
-    server._fatal_lock = threading.Lock()
-    server.registry = Mock()
-    server.shutdown = Mock()
-    first = RuntimeError("Guard failed")
-
-    server.fail(first)
-    server.fail(RuntimeError("and then the shutdown did too"))
-
-    assert server._fatal_error is first
 
 
 def test_unexpected_release_failure_stops_the_service() -> None:
@@ -934,7 +663,7 @@ def test_fork_and_exec_do_not_preserve_claimant_access(
                 "import time",
                 "from kvcr.guard_protocol import KVCRClient",
                 f"hold = KVCRClient({str(harness.server.socket_path)!r}).claim("
-                f"0, {_TEST_ROW_STRIDE}, {_TEST_DIGEST!r}, {_control_address()!r})",
+                f"0, {_TEST_ROW_STRIDE}, {_TEST_DIGEST!r}, {_control_bind()!r})",
                 "forked_pid = os.fork()",
                 "if forked_pid == 0:",
                 "    hold._connection.close()",
@@ -965,9 +694,7 @@ def test_fork_and_exec_do_not_preserve_claimant_access(
             assert spec is not None
             assert spec.path not in Path(f"/proc/{forked_pid}/maps").read_text()
             with pytest.raises(KVCRServiceError, match="held"):
-                harness.client.claim(
-                    0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
-                )
+                harness.client.claim(0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_bind())
 
             child.terminate()
             child.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
@@ -987,14 +714,21 @@ def test_fork_and_exec_do_not_preserve_claimant_access(
                 child.stdout.close()
 
 
-def test_a_guard_that_cannot_prepare_gives_its_pool_back(tmp_path: Path) -> None:
-    """The rank that failed is rolled back too, not just the ones before it."""
-    attached: list[object] = []
+def test_startup_rollback_gives_back_every_pool_but_a_wedged_one(
+    tmp_path: Path,
+) -> None:
+    """A failed startup closes what it built; an unclosable mapping keeps its file."""
+    attached: list[Mock] = []
 
     def attach(spec):
-        if attached:
+        if len(attached) == 0:
+            pool = _stand_in_pool(spec)
+            # Unlinking under a mapping a Guard still holds would fault the process.
+            pool.close.side_effect = RuntimeError("still holding the mapping")
+        elif len(attached) == 1:
+            pool = _stand_in_pool(spec)
+        else:
             raise RuntimeError("attach failed")
-        pool = _stand_in_pool(spec)
         attached.append(pool)
         return pool
 
@@ -1006,16 +740,13 @@ def test_a_guard_that_cannot_prepare_gives_its_pool_back(tmp_path: Path) -> None
         pytest.raises(RuntimeError, match="attach failed"),
     ):
         _PoolRegistry(
-            tmp_path,
-            2,
-            _TEST_POOL_SIZE_BYTES,
-            _TEST_JOURNAL_BYTES,
-            _TEST_DIGEST,
+            tmp_path, 3, _TEST_POOL_SIZE_BYTES, _TEST_JOURNAL_BYTES, _TEST_DIGEST
         )
 
-    # Both pool files are gone: the one that prepared and the one that failed.
-    assert list(tmp_path.iterdir()) == []
-    attached[0].close.assert_called_once_with()
+    # The pool that closed is gone with the one that never attached; the pool
+    # whose mapping would not close keeps its file for the next start's purge.
+    attached[1].close.assert_called_once_with()
+    assert [path.name.split("-")[1] for path in tmp_path.iterdir()] == ["pool_0"]
 
 
 def test_startup_allocation_failure_rolls_back_before_listener(
@@ -1128,8 +859,7 @@ def test_shutdown_continues_after_connection_cleanup_error(
 
 
 def test_a_failed_grant_delivery_retracts_through_the_guard(tmp_path: Path) -> None:
-    """A held undelivered grant is retracted by the claimant's own word: an
-    unactivated release routes through abort_grant, and the pool is free."""
+    """An unactivated release retracts an undelivered grant via abort_grant."""
     registry = _new_registry(tmp_path)
     accepted, peer = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
 
@@ -1147,6 +877,7 @@ def test_a_failed_grant_delivery_retracts_through_the_guard(tmp_path: Path) -> N
         def send_with_fd(self, response: object, listener_fd: int) -> None:
             assert isinstance(response, _Granted)
             assert listener_fd >= 0
+            self.granted_fd = listener_fd
             raise RuntimeError("grant could not be delivered")
 
     class _Server:
@@ -1165,7 +896,11 @@ def test_a_failed_grant_delivery_retracts_through_the_guard(tmp_path: Path) -> N
     guard.abort_grant = Mock(wraps=guard.abort_grant)
     guard.release = Mock(wraps=guard.release)
     try:
-        handler.handle()
+        with patch("kvcr.kvcr_service.os.close", wraps=os.close) as os_close:
+            handler.handle()
+        # The duplicated endpoint went back whatever the send did: one fd per
+        # grant would otherwise leak until claims fail with EMFILE.
+        os_close.assert_any_call(handler.channel.granted_fd)
         assert handler.channel.sent == [_Released(1)]
         # Routed as a retraction, not an ordinary release: the Guard is the
         # one that knows whether this grant stood a serving Guard down.
@@ -1184,30 +919,22 @@ def test_a_failed_grant_delivery_retracts_through_the_guard(tmp_path: Path) -> N
 def test_an_undelivered_grants_lease_survives_its_connection(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """EOF is not a release: a claimant that mapped the pool may have dropped
-    its connection while alive, so only its word or its death frees the lease."""
-    accepted, peer = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    """EOF is not a release: only the claimant's word or its death frees a lease."""
     child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
     registry = _new_registry(tmp_path)
     # Promotion's serving core is not under test; the freed lease is.
     registry._pools[0]._promote = Mock()
-
-    class _Server:
-        def __init__(self) -> None:
-            self.registry = registry
-            self.compatibility_digest = _TEST_DIGEST
-
-        def dispatch(self, request, liveness):
-            return _ThreadingUnixServer.dispatch(self, request, liveness)
-
+    server = object.__new__(_ThreadingUnixServer)
+    server.registry = registry
+    server.compatibility_digest = _TEST_DIGEST
     monkeypatch.setattr(
         PidfdLiveness,
         "from_peer_socket",
         classmethod(lambda _cls, _sock: PidfdLiveness(os.pidfd_open(child.pid))),
     )
     handler = object.__new__(_RequestHandler)
-    handler.request = accepted
-    handler.server = _Server()
+    handler.request = Mock()
+    handler.server = server
     handler.channel = Mock()
     handler.channel.receive.side_effect = [_claim_request(), EOFError()]
     handler.channel.send_with_fd.side_effect = RuntimeError("undelivered")
@@ -1215,59 +942,26 @@ def test_an_undelivered_grants_lease_survives_its_connection(
         # Delivery fails and the connection then EOFs; handle() returns with
         # the lease still held.
         handler.handle()
-        rival = _FakeLiveness()
         with pytest.raises(KVCRServiceError, match="held by another worker"):
-            _claim(registry, 0, rival)
+            _claim(registry, 0, _FakeLiveness())
 
         child.kill()
         child.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
         # Death freed it: the pool's own actor promotes, and the lease is gone.
-        _await_phase(registry._pools[0], lambda g: g._phase is _Phase.STANDBY)
+        guard = registry._pools[0]
+        _wait_until(lambda: guard._phase is _Phase.STANDBY, timeout=5)
         assert _holders_of(registry) == {}
     finally:
         if child.poll() is None:
             child.kill()
             child.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-        peer.close()
-        accepted.close()
         registry.close()
 
 
-def test_a_rollback_that_cannot_stop_a_guard_leaves_its_pool_in_place(
+def test_promotion_failure_fails_the_pool_and_stops_the_whole_service(
     tmp_path: Path,
 ) -> None:
-    """Unlinking under a Guard that would not close would fault the mapping."""
-    wedged, failing = Mock(), Mock()
-    wedged.close.side_effect = RuntimeError("still holding the mapping")
-    failing.start.side_effect = RuntimeError("attach failed")
-
-    def build(spec, _callback, *, pool_index, owner, **_kwargs):
-        guard = wedged if pool_index == 0 else failing
-        guard._spec = spec
-        if guard is failing:
-            # A Guard that closes gives its pool back with everything else.
-            failing.close.side_effect = owner.close
-        return guard
-
-    with (
-        patch("kvcr.kvcr_service._Guard", side_effect=build),
-        pytest.raises(RuntimeError, match="attach failed"),
-    ):
-        _PoolRegistry(
-            tmp_path,
-            2,
-            _TEST_POOL_SIZE_BYTES,
-            _TEST_JOURNAL_BYTES,
-            _TEST_DIGEST,
-        )
-
-    # The wedged pool's file is left for the next start's purge; the pool
-    # whose Guard closed is gone with its owner.
-    assert len(list(tmp_path.iterdir())) == 1
-
-
-def test_promotion_failure_stops_the_whole_service(tmp_path: Path) -> None:
-    """A pool that cannot be promoted is fatal, on purpose."""
+    """A failed promotion is escalated, fences its pool, and keeps the first error."""
     registry = _new_registry(tmp_path)
     guard = registry._pools[0]
     failure = RuntimeError("promotion failed")
@@ -1287,7 +981,53 @@ def test_promotion_failure_stops_the_whole_service(tmp_path: Path) -> None:
 
         assert server._fatal_error is failure
         server.shutdown.assert_called_once_with()
-        assert registry.is_closed() is True
+        assert registry._refusing.is_set() is True
+        assert guard._phase is _Phase.FAILED
+        assert liveness.closed is True and _holders_of(registry) == {}
+        # The fenced pool refuses its next claim with its own failure.
+        with pytest.raises(RuntimeError, match="promotion failed"):
+            guard.claim(_FakeLiveness(), _TEST_TIER_CONFIG, _control_bind(0))
+        # Shutdown ends other pools' work too; those failures never usurp the first.
+        server.fail(RuntimeError("and then the shutdown did too"))
+        assert server._fatal_error is failure
+    finally:
+        registry.close()
+
+
+def test_one_uninspectable_pool_file_does_not_stop_the_service(
+    tmp_path: Path,
+) -> None:
+    """The purge logs and skips a candidate it cannot inspect, then starts."""
+    stale = tmp_path / ("kvcr-stale-" + "a" * 32)
+    stale.write_bytes(b"")
+    with patch(
+        "kvcr.kvcr_service._reclaim_pool_if_orphaned",
+        side_effect=OSError("uninspectable"),
+    ):
+        registry = _new_registry(tmp_path)
+    try:
+        assert stale.exists()
+        liveness = _FakeLiveness()
+        _spec, lease = _claim(registry, 0, liveness)
+        registry.release(0, lease)
+    finally:
+        registry.close()
+
+
+def test_a_pools_endpoint_never_moves_across_claims(tmp_path: Path) -> None:
+    """A claim naming a different control address is refused, not migrated."""
+    registry = _new_registry(tmp_path)
+    liveness = _FakeLiveness()
+    try:
+        _spec, lease = _claim(registry, 0, liveness)
+        registry.release(0, lease)
+
+        moved = ("127.0.0.1", free_port())
+        with pytest.raises(KVCRServiceError, match="cannot be moved"):
+            _claim(registry, 0, _FakeLiveness(), control_bind=moved)
+        # The refusal cost nothing: the original endpoint still grants.
+        _spec, lease = _claim(registry, 0, _FakeLiveness())
+        registry.release(0, lease)
     finally:
         registry.close()
 
@@ -1299,98 +1039,101 @@ def test_a_lease_older_than_the_idle_timeout_still_releases_cleanly(
     """The accept-time idle timeout must not sever a held connection."""
     monkeypatch.setattr("kvcr.kvcr_service._CLIENT_IDLE_TIMEOUT_SECONDS", 0.2)
     with _running_server(tmp_path) as harness:
-        hold = harness.client.claim(
-            0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
-        )
+        hold = harness.client.claim(0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_bind())
         time.sleep(0.5)
 
         hold.release()
 
-        guard = harness.server._registry._pools[0]
-        assert guard._lease is None
+        assert harness.server._registry._pools[0]._lease is None
 
 
-def test_refuse_claims_returns_only_after_inflight_commits_are_decided(
-    tmp_path: Path,
-) -> None:
-    """The barrier: refuse_claims passes every pool's phase lock on its way out."""
+def test_refuse_claims_is_a_barrier_no_grant_can_cross(tmp_path: Path) -> None:
+    """refuse_claims waits out in-flight commits; nothing grants once it returns."""
     registry = _new_registry(tmp_path)
     guard = registry._pools[0]
+    in_adopt = threading.Event()
+    resume = threading.Event()
     returned = threading.Event()
-    with guard._phase_lock:
-        refuser = threading.Thread(
-            target=lambda: (registry.refuse_claims(), returned.set())
-        )
-        refuser.start()
-        # Held by us, exactly as a commit in flight would hold it.
-        assert not returned.wait(timeout=0.3)
-    assert returned.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-    refuser.join(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-    registry.close()
+    real_adopt = guard._adopt
+
+    def gated_adopt(control, tier_config) -> None:
+        real_adopt(control, tier_config)
+        in_adopt.set()
+        assert resume.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+
+    guard._adopt = gated_adopt
+    outcome: dict = {}
+
+    def claim() -> None:
+        try:
+            outcome["grant"] = registry.claim(
+                0, _TEST_TIER_CONFIG, _FakeLiveness(), _control_bind(0)
+            )
+        except BaseException as error:  # noqa: BLE001 - recorded for the assert
+            outcome["error"] = error
+
+    claimant = threading.Thread(target=claim)
+    refuser = threading.Thread(
+        target=lambda: (registry.refuse_claims(), returned.set())
+    )
+    claimant.start()
+    try:
+        assert in_adopt.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+        with guard._phase_lock:
+            # Held by us, exactly as a commit in flight would hold it.
+            refuser.start()
+            assert not returned.wait(timeout=0.3)
+        assert returned.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+        # refuse_claims has RETURNED; the in-flight claim must fail at commit.
+        resume.set()
+        claimant.join(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+        assert not claimant.is_alive()
+        assert "grant" not in outcome
+        assert isinstance(outcome["error"], KVCRServiceError)
+        assert guard._lease is None and guard._reserved is None
+        # The refusal rolled the adoption back: the channel the claim adopted
+        # was closed and released, not left holding the pool's endpoint.
+        assert guard._control is None
+    finally:
+        resume.set()
+        refuser.join(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
+        registry.close()
 
 
-def test_a_release_that_times_out_reports_the_timeout(tmp_path: Path) -> None:
-    """A handler's own TimeoutError is the answer, not a wait to keep waiting."""
+@pytest.mark.parametrize(
+    "failure",
+    [RuntimeError("hand-back failed"), TimeoutError("hand-back timed out")],
+    ids=["plain", "timeout"],
+)
+def test_a_failed_release_reports_promptly_and_fences_the_pool_first(
+    tmp_path: Path, failure: BaseException
+) -> None:
+    """A hand-back failure is the answer now, reported once nothing can claim."""
     registry = _new_registry(tmp_path)
     guard = registry._pools[0]
+    guard._release = Mock(side_effect=failure)
+    claimable_when_reported: list[bool] = []
+    registry.on_uncontained_failure = lambda _error: claimable_when_reported.append(
+        guard._lease is None and guard._failure is None
+    )
     liveness = _FakeLiveness()
     try:
         _spec, lease = _claim(registry, 0, liveness)
-        guard._release = Mock(side_effect=TimeoutError("hand-back timed out"))
 
         started = time.monotonic()
-        with pytest.raises(TimeoutError, match="hand-back timed out"):
+        with pytest.raises(type(failure), match="hand-back") as raised:
             registry.release(0, lease)
 
+        # The handler's own TimeoutError is the answer, not a wait to keep waiting.
+        assert raised.value is failure
         assert time.monotonic() - started < 2
+        # Reported while the pool was already fenced, so nothing could claim it.
+        assert claimable_when_reported == [False]
+        assert guard._phase is _Phase.FAILED
+        with pytest.raises(type(failure), match="hand-back"):
+            _claim(registry, 0, _FakeLiveness())
     finally:
         registry.close()
-
-
-def test_a_dup_failure_on_a_fresh_bind_does_not_pin_the_endpoint(
-    tmp_path: Path,
-) -> None:
-    """A claim that bound the address and then failed must give it back."""
-    registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
-    try:
-        with patch("kvcr.guard.os.dup", side_effect=OSError("dup failed")):
-            with pytest.raises(OSError, match="dup failed"):
-                registry.claim(0, _TEST_TIER_CONFIG, _FakeLiveness(), _control_bind(0))
-        assert guard._listener is None
-
-        # In particular, a retry on a DIFFERENT address must be honoured.
-        replacement = _FakeLiveness()
-        other_bind = _control_bind(0)
-        _spec, lease = _claim(registry, 0, replacement, other_bind)
-        assert guard._bind == other_bind
-        assert guard._lease is lease
-    finally:
-        registry.close()
-
-
-def test_a_listener_that_will_not_close_stays_visible_on_the_kept_pool(
-    tmp_path: Path,
-) -> None:
-    """A kept pool must still name what it leaked, or nobody can ever retry."""
-    registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
-    _claim(registry, 0, _FakeLiveness())
-    real_listener = guard._listener
-    stubborn = Mock(
-        fileno=real_listener.fileno, close=Mock(side_effect=OSError("will not close"))
-    )
-    guard._listener = stubborn
-    try:
-        with pytest.raises(OSError, match="will not close"):
-            registry.close()
-
-        # The pool is kept, and the resource that failed is still reachable.
-        assert registry._pools.keys() == {0}
-        assert registry._pools[0]._listener is stubborn
-    finally:
-        guard._listener = real_listener
-        type(guard)._close_resources(guard)
 
 
 def test_a_pidfd_that_breaks_while_its_process_lives_is_service_fatal(
@@ -1408,18 +1151,19 @@ def test_a_pidfd_that_breaks_while_its_process_lives_is_service_fatal(
         poller = Mock()
         poller.poll.return_value = [(liveness.fileno(), select.POLLNVAL)]
         with patch("kvcr.guard.select.poll", return_value=poller):
-            _await_phase(guard, lambda g: g._phase is _Phase.FAILED)
+            _wait_until(lambda: guard._phase is _Phase.FAILED, timeout=5)
 
         guard._promote.assert_not_called()
-        assert len(uncontained) == 1
-        assert isinstance(uncontained[0], OSError)
-        assert "without POLLIN" in str(uncontained[0])
+        (error,) = uncontained
+        assert isinstance(error, OSError) and "without POLLIN" in str(error)
     finally:
         registry.close()
 
 
-def test_a_release_racing_shutdown_is_absorbed(tmp_path: Path) -> None:
-    """Once close has begun, a release is the close's problem, not a new fatal."""
+def test_a_close_in_progress_absorbs_races_and_answers_stragglers(
+    tmp_path: Path,
+) -> None:
+    """Races against a close are absorbed, and queued work is still answered."""
     registry = _new_registry(tmp_path)
     guard = registry._pools[0]
     liveness = _FakeLiveness()
@@ -1442,14 +1186,20 @@ def test_a_release_racing_shutdown_is_absorbed(tmp_path: Path) -> None:
 
         # Silently absorbed, exactly as the old registry did under its lock.
         registry.release(0, lease)
-
-        # A death in the same window is the close's to clean up, not a
-        # promotion: the pool is being torn down, not failed over.
+        # A death in the same window is the close's to clean up, not a promotion.
         liveness.kill()
-
-        # And a claim in the same window is refused with a typed error.
+        # A claim in the same window is refused with a typed error.
         with pytest.raises(KVCRServiceError, match="closed"):
             registry.claim(0, _TEST_TIER_CONFIG, _FakeLiveness(), _control_bind(0))
+
+        # A command that slipped in behind the close is answered, not abandoned.
+        stray = _Command("release", (object(),))
+        guard._commands.put(stray)
+        gate.set()
+        deadline = time.monotonic() + _SERVER_STOP_TIMEOUT_SECONDS
+        assert guard.finish_close(deadline) is False
+        assert stray.future.done()
+        assert isinstance(stray.future.exception(), KVCRServiceError)
     finally:
         gate.set()
         registry.close()
@@ -1457,108 +1207,9 @@ def test_a_release_racing_shutdown_is_absorbed(tmp_path: Path) -> None:
     assert liveness.closed is True
 
 
-def test_a_command_queued_behind_close_is_answered_not_abandoned(
-    tmp_path: Path,
-) -> None:
-    """Every exit of the actor loop answers what is still queued."""
-    registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
-    gate = threading.Event()
-    entered = threading.Event()
-    real_close_resources = guard._close_resources
-
-    def slow_close() -> None:
-        entered.set()
-        assert gate.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-        real_close_resources()
-
-    guard._close_resources = slow_close
-    guard.begin_close()
-    assert entered.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-    # A raw command that slipped in behind the close, bypassing every gate.
-    stray = _Command("release", (object(),))
-    guard._commands.put(stray)
-    gate.set()
-
-    assert guard.finish_close(time.monotonic() + _SERVER_STOP_TIMEOUT_SECONDS) is False
-    assert stray.future.done()
-    assert isinstance(stray.future.exception(), KVCRServiceError)
-    registry.close()
-
-
-def test_a_grant_that_cannot_dup_its_endpoint_leaves_the_pool_claimable(
-    tmp_path: Path,
-) -> None:
-    """Everything fallible runs before the lease exists."""
-    registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
-    liveness = _FakeLiveness()
-    try:
-        with patch("kvcr.guard.os.dup", side_effect=OSError("dup failed")):
-            with pytest.raises(OSError, match="dup failed"):
-                registry.claim(0, _TEST_TIER_CONFIG, liveness, _control_bind(0))
-
-        assert guard._lease is None
-        assert guard._phase is not _Phase.PRIMARY
-        assert guard._reserved is None
-
-        # The pool survived its failed grant: the next claim simply works.
-        replacement = _FakeLiveness()
-        _spec, lease = _claim(registry, 0, replacement)
-        assert guard._lease is lease
-    finally:
-        registry.close()
-
-
-def test_no_grant_is_produced_after_refuse_claims_returns(tmp_path: Path) -> None:
-    """The grant commits under the same lock the refusal is read under."""
-    registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
-    in_adopt = threading.Event()
-    resume = threading.Event()
-    real_adopt = guard._adopt
-
-    def gated_adopt(control, tier_config) -> None:
-        real_adopt(control, tier_config)
-        in_adopt.set()
-        assert resume.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-
-    guard._adopt = gated_adopt
-    outcome: dict = {}
-
-    def claim() -> None:
-        try:
-            outcome["grant"] = registry.claim(
-                0, _TEST_TIER_CONFIG, _FakeLiveness(), _control_bind(0)
-            )
-        except BaseException as error:  # noqa: BLE001 - recorded for the assert
-            outcome["error"] = error
-
-    claimant = threading.Thread(target=claim)
-    claimant.start()
-    try:
-        assert in_adopt.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-        registry.refuse_claims()
-        # refuse_claims has RETURNED; the claim past every earlier check must
-        # still be refused at its commit.
-        resume.set()
-        claimant.join(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
-        assert not claimant.is_alive()
-
-        assert "grant" not in outcome
-        assert isinstance(outcome["error"], KVCRServiceError)
-        assert guard._lease is None
-        assert guard._reserved is None
-    finally:
-        resume.set()
-        registry.close()
-
-
 def test_shutdown_drains_a_held_connection(tmp_path: Path) -> None:
     with _running_server(tmp_path) as harness:
-        hold = harness.client.claim(
-            0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_address()
-        )
+        hold = harness.client.claim(0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_bind())
         harness.stop()
         _wait_for_connection_state(harness.server, connected=False)
         hold._attachment.close()
@@ -1567,52 +1218,8 @@ def test_shutdown_drains_a_held_connection(tmp_path: Path) -> None:
 
 def test_a_pool_no_bigger_than_its_journal_is_rejected_at_the_flag() -> None:
     """Sized at or below the journal, a pool has nothing left to cache with."""
-
-    def parse(pool_size_gb: str) -> argparse.Namespace:
-        return _parse_args(
-            [
-                "--socket-path",
-                "/run/kvcr/memory.sock",
-                "--pool-dir",
-                "/dev/shm/kvcr",
-                "--pool-count",
-                "1",
-                "--compatibility-digest",
-                "digest",
-                "--pool-size-gb",
-                pool_size_gb,
-            ]
-        )
-
+    flags = "--socket-path s --pool-dir d --pool-count 1 --compatibility-digest g"
     with pytest.raises(SystemExit):
-        parse("0.05")
-    assert parse("0.2").pool_size_bytes > 100 * (1 << 20)
-
-
-def test_a_failed_release_refuses_claims_before_it_frees_the_pool(
-    tmp_path: Path,
-) -> None:
-    """The window between a failed hand-back and the shutdown it causes."""
-    registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
-    failure = RuntimeError("hand-back failed")
-    guard._release = Mock(side_effect=failure)
-    claimable_when_reported: list[bool] = []
-    registry.on_uncontained_failure = lambda _error: claimable_when_reported.append(
-        guard._lease is None and guard._failure is None
-    )
-    liveness = _FakeLiveness()
-    try:
-        _spec, lease = _claim(registry, 0, liveness)
-
-        with pytest.raises(RuntimeError) as raised:
-            registry.release(0, lease)
-
-        assert raised.value is failure
-        # Reported while the pool was already fenced, so nothing could claim it.
-        assert claimable_when_reported == [False]
-        assert guard._phase is _Phase.FAILED
-        with pytest.raises(RuntimeError, match="hand-back failed"):
-            _claim(registry, 0, _FakeLiveness())
-    finally:
-        registry.close()
+        _parse_args([*flags.split(), "--pool-size-gb", "0.05"])
+    parsed = _parse_args([*flags.split(), "--pool-size-gb", "0.2"])
+    assert parsed.pool_size_bytes > 100 * (1 << 20)

--- a/tests/unit/test_kvcr_service.py
+++ b/tests/unit/test_kvcr_service.py
@@ -786,16 +786,6 @@ def test_startup_allocation_failure_rolls_back_before_listener(
     assert list(tmp_path.iterdir()) == []
 
 
-def test_shutdown_unlinks_eager_pools_and_socket(tmp_path: Path) -> None:
-    with _running_server(tmp_path) as harness:
-        pool_paths = list((tmp_path / "pools").glob("kvcr-pool_*-*"))
-        socket_path = harness.server.socket_path
-        assert len(pool_paths) == _TEST_POOL_COUNT
-        harness.stop()
-        assert all(not path.exists() for path in pool_paths)
-        assert not socket_path.exists()
-
-
 def test_claim_after_shutdown_is_rejected(tmp_path: Path) -> None:
     request = _claim_request()
 
@@ -820,7 +810,8 @@ def test_shutdown_does_not_unlink_replaced_socket_path(tmp_path: Path) -> None:
 
 def test_idle_client_does_not_block_shutdown_cleanup(tmp_path: Path) -> None:
     with _running_server(tmp_path) as harness:
-        pool_path = next((tmp_path / "pools").glob("kvcr-pool_0-*"))
+        pool_paths = list((tmp_path / "pools").glob("kvcr-pool_*-*"))
+        assert len(pool_paths) == _TEST_POOL_COUNT
         socket_path = harness.server.socket_path
         _wait_for_connection_state(harness.server, connected=False)
         idle_connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -830,7 +821,7 @@ def test_idle_client_does_not_block_shutdown_cleanup(tmp_path: Path) -> None:
         harness.stop()
         idle_connection.close()
 
-        assert not pool_path.exists()
+        assert all(not path.exists() for path in pool_paths)
         assert not socket_path.exists()
 
 

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -7,7 +7,7 @@ import mmap
 import os
 import stat
 from collections.abc import Iterator
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -45,8 +45,8 @@ def pool_owner(tmp_path: Path) -> Iterator[_KVCRPoolOwner]:
 @pytest.mark.parametrize(
     ("requested_bytes", "row_stride", "expected"),
     [
-        (4096, 1024, (4096, 4)),
-        (4097, 1024, (4096, 4)),
+        (4096, 1024, nullcontext((4096, 4))),
+        (4097, 1024, nullcontext((4096, 4))),
         (1023, 1024, pytest.raises(ValueError, match="one complete KV row")),
         (True, 1, pytest.raises(TypeError)),
         (0, 1, pytest.raises(ValueError)),
@@ -57,14 +57,11 @@ def pool_owner(tmp_path: Path) -> Iterator[_KVCRPoolOwner]:
 def test_pool_geometry_is_row_aligned_and_validated(
     requested_bytes: int,
     row_stride: int,
-    expected: tuple[int, int] | AbstractContextManager[object],
+    expected: AbstractContextManager[tuple[int, int] | None],
 ) -> None:
     """Geometry snaps down to whole KV rows and refuses non-positive or bool input."""
-    if isinstance(expected, tuple):
-        assert _compute_pool_geometry(requested_bytes, row_stride) == expected
-    else:
-        with expected:
-            _compute_pool_geometry(requested_bytes, row_stride)
+    with expected as geometry:
+        assert _compute_pool_geometry(requested_bytes, row_stride) == geometry
 
 
 def test_an_allocated_pool_serves_attachments_and_only_its_owner_unlinks_it(
@@ -100,10 +97,8 @@ def test_an_allocated_pool_serves_attachments_and_only_its_owner_unlinks_it(
             assert populate.call_args.args[1:] == (0, spec.mapping_bytes)
             # A fresh pool's journal header reads empty: exclusive creation,
             # truncation and population all leave only zeros behind.
-            with path.open("rb") as pool_file:
-                assert pool_file.read(_JOURNAL_HEADER_BYTES) == bytes(
-                    _JOURNAL_HEADER_BYTES
-                )
+            header = path.read_bytes()[:_JOURNAL_HEADER_BYTES]
+            assert header == bytes(_JOURNAL_HEADER_BYTES)
 
             journal_marker = b"journal starts at byte zero"
             data_marker = b"data starts after the journal"
@@ -117,16 +112,10 @@ def test_an_allocated_pool_serves_attachments_and_only_its_owner_unlinks_it(
             assert map_file.call_args.args[1:] == (spec.mapping_bytes,)
             assert map_file.call_args.kwargs == {"access": mmap.ACCESS_WRITE}
             try:
-                assert (
-                    ctypes.string_at(attachment.address, len(journal_marker))
-                    == journal_marker
-                )
-                assert (
-                    ctypes.string_at(
-                        attachment.address + spec.journal_bytes, len(data_marker)
-                    )
-                    == data_marker
-                )
+                address = attachment.address
+                assert ctypes.string_at(address, len(journal_marker)) == journal_marker
+                data_address = address + spec.journal_bytes
+                assert ctypes.string_at(data_address, len(data_marker)) == data_marker
             finally:
                 attachment.close()
             # Detaching unmaps but never unlinks the server-owned file.

--- a/tests/unit/test_recovery_journal.py
+++ b/tests/unit/test_recovery_journal.py
@@ -12,12 +12,7 @@ import pytest
 from _kvcr_test_utils import _recovered_record
 
 from kvcr.core import _BlockRecord
-from kvcr.memory import (
-    KVCRPoolAttachment,
-    KVCRPoolSpec,
-    _KVCRPoolOwner,
-    _snapshot_offset,
-)
+from kvcr.memory import KVCRPoolAttachment, KVCRPoolSpec, _KVCRPoolOwner
 from kvcr.recovery_journal import (
     _JOURNAL_HEADER_BYTES,
     _RECORD_BLOCK,
@@ -30,7 +25,6 @@ from kvcr.recovery_journal import (
     _recovery_frames,
     _RecoveryMirror,
     canonical_pool_terms,
-    clear_recovery_snapshot,
     read_handback,
     read_recovery_snapshot,
     write_recovery_snapshot,
@@ -71,13 +65,11 @@ def journal_and_mapping() -> Iterator[tuple[RecoveryJournal, mmap.mmap]]:
         mapping.close()
 
 
-def test_a_journal_round_trips_wraps_and_dies_by_invalidation(
+def test_ring_round_trips_wraps_and_drains_streaming(
     journal_and_mapping: tuple[RecoveryJournal, mmap.mmap],
 ) -> None:
-    """Publish/read, drain, wrap, then invalidation stops current and future roles."""
+    """Frames land at documented offsets, replay in order, wrap, and drain lazily."""
     journal, mapping = journal_and_mapping
-
-    # Variable-width keys and opaque payloads land in the documented layout.
     records = [
         (b"", b"serialized block record"),
         (b"k", b""),
@@ -85,6 +77,7 @@ def test_a_journal_round_trips_wraps_and_dies_by_invalidation(
     ]
     for key, payload in records:
         assert journal.publish(_RECORD_BLOCK, key, payload)
+
     assert struct.unpack_from("<Q", mapping, _INVALID_OFFSET) == (0,)
     assert struct.unpack_from("<Q", mapping, _PUBLISHED_OFFSET) == (
         sum((6 + len(key) + len(payload) + 7) // 8 * 8 for key, payload in records),
@@ -100,23 +93,6 @@ def test_a_journal_round_trips_wraps_and_dies_by_invalidation(
     ]
     assert journal.read_next() is None
 
-    # Drain streams, so a promotion does not hold a second copy of the ring:
-    # _consumed/_published are the ring's byte cursors, and after one item the
-    # read cursor sits strictly between where it started and the write cursor.
-    for index in range(3):
-        assert journal.publish(_RECORD_BLOCK, bytes([index]), bytes([index + 3]))
-    consumed = journal._consumed.load_acquire()
-    published = journal._published.load_acquire()
-    drained = journal.drain()
-    assert next(drained) == (_RECORD_BLOCK, b"\x00", b"\x03")
-    assert consumed < journal._consumed.load_acquire() < published
-    assert list(drained) == [
-        (_RECORD_BLOCK, b"\x01", b"\x04"),
-        (_RECORD_BLOCK, b"\x02", b"\x05"),
-    ]
-    assert journal._consumed.load_acquire() == published
-
-    # The ring wraps without losing records: the write cursor passes capacity.
     for index in range(400):
         key = index.to_bytes(4, "little")
         payload = bytes([index % 256]) * 9
@@ -126,104 +102,18 @@ def test_a_journal_round_trips_wraps_and_dies_by_invalidation(
     assert journal._consumed.load_acquire() == journal._published.load_acquire()
     assert not journal.is_invalid()
 
-    # A caught-up mirror looks finished; only re-reading the shared flag tells
-    # it the journal was invalidated by a role other than itself.
-    consumer = RecoveryJournal(_attachment(mapping, _TEST_JOURNAL_BYTES))
-    assert journal.publish(_RECORD_BLOCK, b"key", b"payload")
-    assert consumer.read_next() is not None
-    assert consumer.read_next() is None
-    assert journal.invalidate() is False
-    with pytest.raises(RecoveryJournalError, match="invalid"):
-        consumer.read_next()
-
-    # Roles that attach after the death never start at all.
-    late_producer = RecoveryJournal(_attachment(mapping, _TEST_JOURNAL_BYTES))
-    late_consumer = RecoveryJournal(_attachment(mapping, _TEST_JOURNAL_BYTES))
-    assert not late_producer.publish(_RECORD_BLOCK, b"key", b"payload")
-    with pytest.raises(RecoveryJournalError, match="invalid"):
-        late_consumer.read_next()
-
-
-def _publish_oversize_frame(
-    journal: RecoveryJournal, mapping: mmap.mmap, caplog: pytest.LogCaptureFixture
-) -> None:
-    """A frame over uint16 is refused whole: _published, the write cursor, holds."""
-    assert journal.publish(_RECORD_BLOCK, b"key0", b"record")
+    # Streaming, so a promotion does not hold a second copy of the ring.
+    for index in range(3):
+        assert journal.publish(_RECORD_BLOCK, bytes([index]), bytes([index + 3]))
     published = journal._published.load_acquire()
-
-    assert not journal.publish(_RECORD_BLOCK, b"key", bytes(1 << 16))
-
-    assert journal._published.load_acquire() == published
-    assert caplog.messages == [
-        "KVCR recovery journal invalidated: frame is 65545 bytes; "
-        "maximum is 65535 bytes"
+    drained = journal.drain()
+    assert next(drained) == (_RECORD_BLOCK, b"\x00", b"\x03")
+    assert journal._consumed.load_acquire() < published
+    assert list(drained) == [
+        (_RECORD_BLOCK, b"\x01", b"\x04"),
+        (_RECORD_BLOCK, b"\x02", b"\x05"),
     ]
-
-
-def _fill_ring(
-    journal: RecoveryJournal, mapping: mmap.mmap, caplog: pytest.LogCaptureFixture
-) -> None:
-    """The frame that finds the ring full is refused whole: the cursor holds."""
-    published = 0
-    while True:
-        before = journal._published.load_acquire()
-        if not journal.publish(_RECORD_BLOCK, b"key", bytes(1000)):
-            break
-        published += 1
-
-    assert published > 0
-    assert journal._published.load_acquire() == before
-
-
-def _tear_frame_key_size(
-    journal: RecoveryJournal, mapping: mmap.mmap, caplog: pytest.LogCaptureFixture
-) -> None:
-    """A published frame whose key size no longer fits its frame size."""
-    assert journal.publish(_RECORD_BLOCK, b"key", b"payload")
-    struct.pack_into("<HH", mapping, _JOURNAL_HEADER_BYTES, 2, 0)
-
-
-def _tear_frame_padding(
-    journal: RecoveryJournal, mapping: mmap.mmap, caplog: pytest.LogCaptureFixture
-) -> None:
-    """A published frame whose padding is no longer zero."""
-    assert journal.publish(_RECORD_BLOCK, b"keys", b"x")
-    mapping[_JOURNAL_HEADER_BYTES + 12] = 1
-
-
-@pytest.mark.parametrize(
-    "provoke,error",
-    [
-        (_publish_oversize_frame, "invalid"),
-        (_fill_ring, "invalid"),
-        (_tear_frame_key_size, "key size"),
-        (_tear_frame_padding, "padding"),
-    ],
-    ids=["oversize-frame", "full-ring", "torn-key-size", "torn-padding"],
-)
-def test_a_frame_the_ring_cannot_carry_invalidates_it_until_reset(
-    journal_and_mapping: tuple[RecoveryJournal, mmap.mmap],
-    caplog: pytest.LogCaptureFixture,
-    provoke: Callable[[RecoveryJournal, mmap.mmap, pytest.LogCaptureFixture], None],
-    error: str,
-) -> None:
-    """Any frame the ring cannot carry invalidates it wholesale, until a reset."""
-    journal, mapping = journal_and_mapping
-    caplog.set_level("WARNING", logger="kvcr.recovery_journal")
-    provoke(journal, mapping, caplog)
-
-    with pytest.raises(RecoveryJournalError, match=error):
-        journal.read_next()
-    assert journal.is_invalid()
-    with pytest.raises(RecoveryJournalError, match="invalid"):
-        list(journal.drain())
-
-    journal.reset()
-
-    assert not journal.is_invalid()
-    assert journal.read_next() is None
-    assert journal.publish(_RECORD_BLOCK, b"key", b"payload")
-    assert journal.read_next() == (_RECORD_BLOCK, b"key", b"payload")
+    assert journal._consumed.load_acquire() == published
 
 
 class _Source:
@@ -251,15 +141,12 @@ def test_publisher_streams_mutations_until_the_journal_refuses_or_fails(
     _attach_journal(local_dram, journal, g3)
     caplog.set_level("WARNING", logger="kvcr.recovery_journal")
 
-    # Stable G2/G3 mutations from either tier publish whole under the block's key.
     local_dram.emit(key, _recovered_record(g2=2))
     g3.emit(key, _recovered_record(g2=2, g3=7))
     local_dram.emit(key, _recovered_record(g3=7))
     g3.emit(key, _BlockRecord())
-
     frames = [journal.read_next() for _ in range(4)]
     assert journal.read_next() is None
-    assert [frame_key for _, frame_key, _ in frames] == [bytes(key)] * 4
     assert [_decode_recovery_record(payload) for _, _, payload in frames] == [
         _recovered_record(g2=2),
         _recovered_record(g2=2, g3=7),
@@ -268,16 +155,15 @@ def test_publisher_streams_mutations_until_the_journal_refuses_or_fails(
     ]
     assert caplog.messages == []
 
-    # One refused attempt, then publication stays off with no second warning.
+    # One refused attempt, then publication stays off with one warning: the
+    # count is the contract, not the wording.
     journal.invalidate()
     caplog.clear()
     with patch.object(journal, "publish", wraps=journal.publish) as publish:
         local_dram.emit(key, _recovered_record(g2=0))
         local_dram.emit(key, _recovered_record(g2=1))
     assert publish.call_count == 1
-    assert caplog.messages == [
-        "KVCR recovery publication disabled after the journal rejected a frame"
-    ]
+    assert len(caplog.messages) == 1
 
     # A publish that raises invalidates recovery; the mutation itself survives.
     with mmap.mmap(-1, _TEST_JOURNAL_BYTES + mmap.PAGESIZE) as fresh_mapping:
@@ -291,19 +177,88 @@ def test_publisher_streams_mutations_until_the_journal_refuses_or_fails(
         assert fresh.is_invalid()
 
 
-def _pool(tmp_path: Path, pool_id: str = "pool_0") -> _KVCRPoolOwner:
-    return _KVCRPoolOwner.allocate(
-        pool_id=pool_id,
+def test_invalidation_stops_every_role_until_an_owner_reset(
+    journal_and_mapping: tuple[RecoveryJournal, mmap.mmap],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Oversize, overflow, or corruption kills the ring for every role until reset."""
+    journal, mapping = journal_and_mapping
+    caplog.set_level("WARNING", logger="kvcr.recovery_journal")
+    consumer = RecoveryJournal(_attachment(mapping, _TEST_JOURNAL_BYTES))
+    assert journal.publish(_RECORD_BLOCK, b"key0", b"record")
+    assert consumer.read_next() is not None
+    assert consumer.read_next() is None
+
+    # A frame past the uint16 size header is refused without publication.
+    before = journal._published.load_acquire()
+    assert not journal.publish(_RECORD_BLOCK, b"key", bytes(1 << 16))
+    assert journal._published.load_acquire() == before
+    assert journal.is_invalid()
+    assert "frame is 65545 bytes; maximum is 65535 bytes" in caplog.text
+
+    # Caught up and finished look identical unless the shared flag is re-read.
+    with pytest.raises(RecoveryJournalError, match="invalid"):
+        consumer.read_next()
+    # A role that attaches to a finished journal never starts.
+    late = RecoveryJournal(_attachment(mapping, _TEST_JOURNAL_BYTES))
+    assert not late.publish(_RECORD_BLOCK, b"key", b"payload")
+    with pytest.raises(RecoveryJournalError, match="invalid"):
+        RecoveryJournal(_attachment(mapping, _TEST_JOURNAL_BYTES)).read_next()
+
+    journal.reset()
+    assert journal._published.load_acquire() == 0
+    assert journal._consumed.load_acquire() == 0
+    assert not journal.is_invalid()
+
+    # A ring without room for the next frame invalidates whole, not partially.
+    published = 0
+    while journal.publish(_RECORD_BLOCK, b"key", bytes(1000)):
+        published = journal._published.load_acquire()
+    assert published > 0
+    assert journal._published.load_acquire() == published
+    assert journal.is_invalid()
+    with pytest.raises(RecoveryJournalError, match="invalid"):
+        journal.read_next()
+    with pytest.raises(RecoveryJournalError, match="invalid"):
+        list(journal.drain())
+
+    # A frame header declaring less than its own key is a corrupt ring.
+    journal.reset()
+    assert journal.publish(_RECORD_BLOCK, b"key", b"payload")
+    struct.pack_into("<HH", mapping, _JOURNAL_HEADER_BYTES, 2, 0)
+    with pytest.raises(RecoveryJournalError, match="key size"):
+        journal.read_next()
+    assert journal.is_invalid()
+
+    # Alignment padding the producer left as zeros must still be zeros.
+    journal.reset()
+    assert journal.publish(_RECORD_BLOCK, b"keys", b"x")
+    mapping[_JOURNAL_HEADER_BYTES + 12] = 1
+    with pytest.raises(RecoveryJournalError, match="padding"):
+        journal.read_next()
+    assert journal.is_invalid()
+
+    # An owner's own declaration kills the ring exactly the same way, and a
+    # consumer that was caught up re-reads the shared flag to notice it.
+    journal.reset()
+    assert journal.publish(_RECORD_BLOCK, b"key1", b"record")
+    fresh = RecoveryJournal(_attachment(mapping, _TEST_JOURNAL_BYTES))
+    assert fresh.read_next() is not None
+    assert fresh.read_next() is None
+    assert journal.invalidate() is False
+    with pytest.raises(RecoveryJournalError, match="invalid"):
+        fresh.read_next()
+
+
+@contextmanager
+def _attached(tmp_path: Path) -> Iterator[KVCRPoolAttachment]:
+    """An owned pool, mapped, the way a Guard or a claimant holds one."""
+    owner = _KVCRPoolOwner.allocate(
+        pool_id="pool_0",
         pool_size_bytes=8192 + 4096,
         journal_bytes=8192,
         pool_dir=tmp_path,
     )
-
-
-@contextmanager
-def _attached(tmp_path: Path, pool_id: str = "pool_0") -> Iterator:
-    """An owned pool, mapped, the way a Guard or a claimant holds one."""
-    owner = _pool(tmp_path, pool_id)
     try:
         attachment = KVCRPoolAttachment.attach(owner.spec)
         try:
@@ -314,76 +269,51 @@ def _attached(tmp_path: Path, pool_id: str = "pool_0") -> Iterator:
         owner.close()
 
 
-def test_a_handback_region_round_trips_and_replays_nothing_once_released(
-    tmp_path: Path,
-) -> None:
-    """A snapshot hides inside the pool file, round trips, and dies with release."""
-    with _attached(tmp_path) as pool:
-        # Inside the pool file, so it has no name of its own to be found under.
-        path = Path(pool._spec.path)
-        assert path.stat().st_size == pool._spec.mapping_bytes
-        assert set(tmp_path.iterdir()) == {path}
+def _write_slot(pool: KVCRPoolAttachment, terms: bytes, key: bytes, slot: int) -> None:
+    """One-slot handback region: the smallest finished snapshot."""
+    frames = _recovery_frames({BlockKey(key * 32): _recovered_record(g2=slot)})
+    write_recovery_snapshot(pool, terms, frames)
 
+
+def test_a_handback_region_lives_and_dies_inside_the_pool_file(tmp_path: Path) -> None:
+    """Replayed whole under its own terms, discardable when torn, gone once released."""
+    with _attached(tmp_path) as pool:
+        path = Path(pool._spec.path)
         terms = canonical_pool_terms(_TEST_DIGEST, 4096, pool._spec)
         assert list(read_recovery_snapshot(pool, terms)) == []
 
         records = {
             BlockKey(b"a" * 32): _recovered_record(g2=3),
+            # One with both halves, one only on disk.
             BlockKey(b"b" * 32): _recovered_record(g2=4, g3=9),
-            BlockKey(b"gone"): _BlockRecord(),
+            BlockKey(b"c" * 32): _recovered_record(g3=2),
         }
         write_recovery_snapshot(pool, terms, _recovery_frames(records))
-
+        # Inside the pool file, so it has no name of its own to be found under.
         assert set(tmp_path.iterdir()) == {path}
         assert path.stat().st_size > pool._spec.mapping_bytes
 
-        # The mirror the ring feeds, unchanged: one record format, two carriers.
-        # Its _records table is the recovered state a claimant would start from.
+        # The mirror the ring feeds is also what replays the region.
         mirror = _RecoveryMirror()
         for frame in read_recovery_snapshot(pool, terms):
             mirror.apply(*frame)
-        recovered = mirror._records
-        assert set(recovered) == {BlockKey(b"a" * 32), BlockKey(b"b" * 32)}
-        assert recovered[BlockKey(b"a" * 32)].local_dram.slot == 3
-        assert recovered[BlockKey(b"b" * 32)].g3.slot == 9
-
-        # A released region is truncated away, so it replays nothing.
-        clear_recovery_snapshot(pool)
-
-        assert list(read_recovery_snapshot(pool, terms)) == []
-
-
-def test_an_interrupted_rewrite_reads_as_unfinished_rather_than_as_other_terms(
-    tmp_path: Path,
-) -> None:
-    """Changed terms are refused forever; an unfinished write is thrown away."""
-    with _attached(tmp_path) as pool:
-        terms = canonical_pool_terms(_TEST_DIGEST, 4096, pool._spec)
-        write_recovery_snapshot(
-            pool,
-            terms,
-            _recovery_frames({BlockKey(b"a" * 32): _recovered_record(g2=1)}),
-        )
-        assert list(read_recovery_snapshot(pool, terms))
+        assert mirror.take_records() == records
 
         # A slot number only means the same bytes under the same geometry.
-        for digest, row_stride in [(_TEST_DIGEST, 8192), ("another-digest", 4096)]:
-            other = canonical_pool_terms(digest, row_stride, pool._spec)
+        for other in (
+            canonical_pool_terms("another-digest", 4096, pool._spec),
+            canonical_pool_terms(_TEST_DIGEST, 8192, pool._spec),
+        ):
             with pytest.raises(RecoveryJournalError, match="other terms"):
                 list(read_recovery_snapshot(pool, other))
 
-        # A rewrite that dies once the replacing body has landed but before its
-        # header has must be discardable, not poison for every later claim.
+        # Stopped once the replacing body has landed but before its header has.
         interrupted = Mock(
             size=_SNAPSHOT_HEADER.size, pack=Mock(side_effect=OSError("interrupted"))
         )
         with patch("kvcr.recovery_journal._SNAPSHOT_HEADER", interrupted):
             with pytest.raises(OSError, match="interrupted"):
-                write_recovery_snapshot(
-                    pool,
-                    terms,
-                    _recovery_frames({BlockKey(b"b" * 32): _recovered_record(g2=2)}),
-                )
+                _write_slot(pool, terms, b"b", 2)
 
         # The failed rewrite took the tail with it -- including the previous
         # snapshot. Old frames must not replay against a Guard whose mirror
@@ -393,11 +323,7 @@ def test_an_interrupted_rewrite_reads_as_unfinished_rather_than_as_other_terms(
         # A crash leaves torn bytes no exception path can truncate: a region
         # whose header never landed reads as unfinished, and read_handback
         # discards it rather than serving it as another handover's terms.
-        write_recovery_snapshot(
-            pool,
-            terms,
-            _recovery_frames({BlockKey(b"c" * 32): _recovered_record(g2=3)}),
-        )
+        _write_slot(pool, terms, b"c", 3)
         with pool.snapshot_region(_SNAPSHOT_HEADER.size + 64) as region:
             region[: _SNAPSHOT_HEADER.size] = bytes(_SNAPSHOT_HEADER.size)
         with pytest.raises(RecoveryJournalTornError, match="unfinished"):
@@ -405,19 +331,8 @@ def test_an_interrupted_rewrite_reads_as_unfinished_rather_than_as_other_terms(
         assert read_handback(pool, _TEST_DIGEST, 4096)._records == {}
         assert list(read_recovery_snapshot(pool, terms)) == []
 
-        # The header lands last, so a region whose last write never finished --
-        # here a flipped digest byte -- never reads as a whole one either.
-        write_recovery_snapshot(
-            pool,
-            terms,
-            _recovery_frames({BlockKey(b"k" * 32): _recovered_record(g2=1)}),
-        )
-        offset = _snapshot_offset(pool._spec.mapping_bytes)
-        with open(pool._spec.path, "r+b") as pool_file:
-            pool_file.seek(offset)
-            byte = pool_file.read(1)[0]
-            pool_file.seek(offset)
-            pool_file.write(bytes([byte ^ 0xFF]))
-
-        with pytest.raises(RecoveryJournalError, match="unfinished"):
-            list(read_recovery_snapshot(pool, terms))
+        # A released region is truncated away, so it replays nothing.
+        _write_slot(pool, terms, b"d", 4)
+        assert list(read_recovery_snapshot(pool, terms))
+        pool.release_snapshot_region()
+        assert list(read_recovery_snapshot(pool, terms)) == []

--- a/tests/unit/test_recovery_mirror.py
+++ b/tests/unit/test_recovery_mirror.py
@@ -75,6 +75,24 @@ def test_recovery_wire_round_trip_keeps_only_settled_slots(
     assert _decode_recovery_record(encoded) == recovered
 
 
+def test_recovery_encoding_accepts_a_field_appended_later() -> None:
+    """Appending is the one change this format allows, and it has to work."""
+
+    class _RecoveryBlockV2(msgspec.Struct, frozen=True, array_like=True):
+        g2: int | None = None
+        g3: int | None = None
+        appended: int = 0
+
+    today = _RECOVERY_ENCODER.encode(
+        _project_recovery_record(_recovered_record(g2=3, g3=5))
+    )
+
+    upgraded = msgspec.msgpack.Decoder(_RecoveryBlockV2).decode(today)
+    assert upgraded.g2 == 3
+    assert upgraded.g3 == 5
+    assert upgraded.appended == 0
+
+
 @pytest.mark.parametrize(
     "payload",
     [


### PR DESCRIPTION
One _Guard actor thread owns the pool file, control listener, lease, holder pidfd, journal consumer, mirror, optional G2-only serving core, and control channel. Phases with caller-reserved transitions (busy answered immediately); lease identity is the staleness authority; the actor polls the pidfd itself between commands. A handler thread still holds each granted connection, but only to hear a release.