### PR TITLE
feat!: prepare Guards for multiple pools

### DIFF
--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -315,8 +315,8 @@ IDs, or raw endpoints.
 
 The KVCR service daemon owns pool lifecycle. It pre-allocates `--guard-count`
 contiguous pool allocations before exposing its socket, one per Guard. Each has
-the same ordered pool sizes. A worker claims an allocation by index; it outlives
-that worker but not the service:
+the same ordered pool sizes. A worker claims a Guard by index; its allocation
+outlives that worker but not the service:
 
 ```bash
 python -m kvcr.kvcr_service \
@@ -341,7 +341,7 @@ GiB plus the journal for every Guard. Until grouped grants are introduced, the
 current claim path exposes those pool regions as one combined data area.
 
 The pre-release wire protocol remains version 1. A worker calls
-`KVCRClient.claim(pool_index, row_stride, compatibility_digest, control_bind)`,
+`KVCRClient.claim(guard_index, row_stride, compatibility_digest, control_bind)`,
 naming the address its Guard will answer on. The digest must match the service
 exactly, and callers must change it whenever the row stride or any other
 KV-cache layout term changes. The returned `KVCRPoolHold` describes the mapped

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -313,16 +313,17 @@ IDs, or raw endpoints.
 
 ### KVCR service daemon
 
-The KVCR service daemon owns pool lifecycle. It pre-allocates `--pool-count`
-fixed-size pools before exposing its socket. A worker claims a pool by index;
-the pool outlives that worker but not the service:
+The KVCR service daemon owns pool lifecycle. It pre-allocates `--guard-count`
+contiguous pool allocations before exposing its socket, one per Guard. Each has
+the same ordered pool sizes. A worker claims an allocation by index; it outlives
+that worker but not the service:
 
 ```bash
 python -m kvcr.kvcr_service \
   --socket-path /run/kvcr/memory.sock \
   --pool-dir /dev/shm/kvcr \
-  --pool-count 1 \
-  --pool-size-gb 64 \
+  --guard-count 1 \
+  --pool-sizes-gb 48,16 \
   --compatibility-digest example-model-layout
 ```
 
@@ -330,12 +331,14 @@ python -m kvcr.kvcr_service \
 | --- | --- | --- |
 | `--socket-path` | *(required)* | Unix socket the workers connect to |
 | `--pool-dir` | *(required)* | Writable directory holding the pool files |
-| `--pool-count` | *(required)* | Number of pools available by index |
-| `--pool-size-gb` | *(required)* | Total mapped size of each pool |
+| `--guard-count` | *(required)* | Number of Guards available by index |
+| `--pool-sizes-gb` | *(required)* | Comma-separated usable pool sizes in each Guard allocation |
 | `--compatibility-digest` | *(required)* | Exact digest every claimant must provide |
 
-Each pool reserves a fixed 100 MiB journal, taken out of `--pool-size-gb`
-rather than added to it: a 64 GiB pool caches 64 GiB minus 100 MiB.
+The service rounds each pool size down to a memory-page boundary and adds one
+fixed 100 MiB journal to each Guard allocation. For example, `48,16` maps 64
+GiB plus the journal for every Guard. Until grouped grants are introduced, the
+current claim path exposes those pool regions as one combined data area.
 
 The pre-release wire protocol remains version 1. A worker calls
 `KVCRClient.claim(pool_index, row_stride, compatibility_digest, control_bind)`,
@@ -402,7 +405,7 @@ its Guard can mirror fills the ring. Both sides treat that as survivable -- the
 primary stops publishing, the Guard drops what it holds -- and the pool becomes
 claimable but cold if that primary dies. Recovery is lost for that pool only.
 Watch for `KVCR pool recovery disabled` if failovers stop coming back warm. The
-journal is a fixed 100 MiB whatever `--pool-size-gb` is, so the only levers are
+journal is a fixed 100 MiB whatever `--pool-sizes-gb` is, so the only levers are
 larger blocks, which publish fewer residency changes, or accepting a cold
 failover for that pool.
 
@@ -870,14 +873,15 @@ release may need to wait for NIXL quiescence even after caller-visible timeout.
 Verify that:
 
 - the socket parent and pool directory exist and are writable;
-- the pool directory has capacity for every pool at its full
-  `--pool-size-gb`, which already includes that pool's journal. A pool
-  changing hands briefly appends its handback snapshot past that size;
+- the pool directory has capacity for every Guard's full allocation: the sum
+  of `--pool-sizes-gb` plus its 100 MiB journal. A pool changing hands briefly
+  appends its handback snapshot past that size;
   where there is no room for it, that handover comes back cold and the
   service carries on;
 - another process is not listening on the socket;
-- `--pool-count` is at least one; and
-- `--pool-size-gb` is positive, finite, and larger than the 100 MiB journal.
+- `--guard-count` is at least one; and
+- every comma-separated `--pool-sizes-gb` value is positive, finite, and at
+  least one memory page.
 
 The service removes a stale socket only after confirming no live service is
 listening. It refuses to replace a socket owned by another live service.

--- a/src/kvcr/config.py
+++ b/src/kvcr/config.py
@@ -113,6 +113,6 @@ class KVCRConfig:
 @dataclass(frozen=True)
 class KVCRGuardConfig:
     kvcr_service_socket_path: str
-    pool_index: int
+    guard_index: int
     row_stride: int
     compatibility_digest: str

--- a/src/kvcr/guard.py
+++ b/src/kvcr/guard.py
@@ -56,8 +56,8 @@ _Lease = PidfdLiveness
 class _PoolLease:
     """One pool's holder identity and persistent control listener."""
 
-    def __init__(self, pool_index: int) -> None:
-        self._pool_index = pool_index
+    def __init__(self, guard_index: int) -> None:
+        self._guard_index = guard_index
         self.current: _Lease | None = None
         self.listener: socket.socket | None = None
         # As the claimant asked: getsockname() is numeric and rejects aliases.
@@ -79,7 +79,7 @@ class _PoolLease:
         if self.listener is not None:
             if self.bind_address != address:
                 raise KVCRServiceError(
-                    f"KVCR pool {self._pool_index} answers on "
+                    f"KVCR Guard {self._guard_index} answers on "
                     f"{self.bind_address[0]}:{self.bind_address[1]} and cannot be "
                     "moved to "
                     f"{address[0]}:{address[1]}"
@@ -89,7 +89,7 @@ class _PoolLease:
             listener = socket.create_server(address)
         except OSError as error:
             raise KVCRServiceError(
-                f"KVCR pool {self._pool_index} control listener "
+                f"KVCR Guard {self._guard_index} control listener "
                 f"{address[0]}:{address[1]} is unavailable: {error}"
             ) from error
         self.listener = listener
@@ -348,17 +348,17 @@ class _Guard:
         failure_callback: Callable[..., None] | None = None,
         *,
         compatibility_digest: str,
-        pool_index: int = 0,
+        guard_index: int = 0,
         owner: _KVCRPoolOwner | None = None,
         refusing: Callable[[], bool] = lambda: False,
     ) -> None:
         self._spec = spec
-        self._pool_index = pool_index
+        self._guard_index = guard_index
         # Owned here, not by the registry: one thread owns one pool, so a
         # claim needs no lock -- the mailbox is the reservation.
         self._owner = owner
         self._refusing = refusing
-        self._pool_lease = _PoolLease(pool_index)
+        self._pool_lease = _PoolLease(guard_index)
         # Owned by the current primary.
         self._control: ZmqPeerControlChannel | None = None
         self._configured: _TierConfig | None = None
@@ -432,7 +432,7 @@ class _Guard:
                 if self._reserved is _Phase.PROMOTING:
                     # The death of this same lease got here first; it wins.
                     return
-                raise KVCRServiceError(f"KVCR pool {self._pool_index} is busy")
+                raise KVCRServiceError(f"KVCR Guard {self._guard_index} is busy")
             self._reserved = _Phase.RELEASING
         self._submit(_Command(operation, (lease,)))
 
@@ -481,15 +481,15 @@ class _Guard:
             if self._failure is not None:
                 raise self._failure
             if self._reserved is not None:
-                raise KVCRServiceError(f"KVCR pool {self._pool_index} is busy")
+                raise KVCRServiceError(f"KVCR Guard {self._guard_index} is busy")
             if self._phase is _Phase.PRIMARY:
                 lease = self._pool_lease.current
                 if self._pool_lease.poll_pidfd(lease) is None:
                     raise KVCRServiceError(
-                        f"KVCR pool {self._pool_index} is held by another worker"
+                        f"KVCR Guard {self._guard_index} is held by another worker"
                     )
                 # Dead but not yet promoted: the actor is the sole authority.
-                raise KVCRServiceError(f"KVCR pool {self._pool_index} is busy")
+                raise KVCRServiceError(f"KVCR Guard {self._guard_index} is busy")
             if self._phase in (_Phase.FAILED, _Phase.CLOSED):
                 raise KVCRServiceError("KVCR pool registry is closed")
             self._reserved = _Phase.CLAIMING
@@ -695,7 +695,7 @@ class _Guard:
             self._phase = _Phase.STANDBY
 
     def _escalate(self, error: BaseException) -> None:
-        logger.critical("KVCR pool %d Guard failed", self._pool_index)
+        logger.critical("KVCR Guard %d failed", self._guard_index)
         try:
             self._failure_callback(self, error)
         except BaseException:  # noqa: BLE001 - retain the original failure

--- a/src/kvcr/guard_protocol.py
+++ b/src/kvcr/guard_protocol.py
@@ -67,7 +67,7 @@ class _TierConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
 
 
 class _Claim(msgspec.Struct, frozen=True, tag="claim"):
-    pool_index: Annotated[int, msgspec.Meta(ge=0)]
+    guard_index: Annotated[int, msgspec.Meta(ge=0)]
     compatibility_digest: str
     tier_config: _TierConfig
     control_host: str
@@ -95,7 +95,7 @@ class _Release(msgspec.Struct, frozen=True, tag="release"):
 
 
 class _Granted(msgspec.Struct, frozen=True, tag="granted"):
-    pool_index: int
+    guard_index: int
     spec: KVCRPoolSpec
     tier_config: _TierConfig
     version: ProtocolVersion
@@ -211,7 +211,7 @@ class KVCRClient:
 
     def claim(
         self,
-        pool_index: int,
+        guard_index: int,
         row_stride: int,
         compatibility_digest: str,
         control_bind: tuple[str, int],
@@ -228,7 +228,7 @@ class KVCRClient:
         # port or G3 path fails here, not at the service.
         request = msgspec.convert(
             {
-                "pool_index": pool_index,
+                "guard_index": guard_index,
                 "compatibility_digest": compatibility_digest,
                 "tier_config": {"row_stride": row_stride, "g3": g3_config},
                 "control_host": control_bind[0],
@@ -247,7 +247,7 @@ class KVCRClient:
             if isinstance(response, _Error):
                 raise KVCRServiceError(response.message)
             grant_received = True
-            spec = _grant_spec(response, pool_index, request.tier_config)
+            spec = _grant_spec(response, guard_index, request.tier_config)
             if listener_fd is None:
                 # Every pool has a Guard, and a Guard answers on the endpoint
                 # this claimant named. A grant without it means the two sides
@@ -299,14 +299,14 @@ class KVCRClient:
 
 def _grant_spec(
     response: _Granted,
-    requested_pool_index: int,
+    requested_guard_index: int,
     requested_tier_config: _TierConfig,
 ) -> KVCRPoolSpec:
     """Take the grant apart, refusing one that answers a different request."""
-    if response.pool_index != requested_pool_index:
+    if response.guard_index != requested_guard_index:
         raise KVCRGuardProtocolError(
-            "claim pool mismatch: "
-            f"requested {requested_pool_index}, got {response.pool_index}"
+            "claim Guard mismatch: "
+            f"requested {requested_guard_index}, got {response.guard_index}"
         )
     if response.tier_config != requested_tier_config:
         raise KVCRGuardProtocolError("claim tier configuration mismatch")

--- a/src/kvcr/kvcr_service.py
+++ b/src/kvcr/kvcr_service.py
@@ -9,15 +9,17 @@ import argparse
 import contextlib
 import functools
 import logging
-import math
+import mmap
 import os
 import re
 import signal
 import socket
 import socketserver
 import stat
+import sys
 import threading
 import time
+from decimal import Decimal, InvalidOperation, localcontext
 from pathlib import Path
 from types import FrameType
 from typing import Any
@@ -58,6 +60,7 @@ _STALE_SOCKET_PROBE_SECONDS = 1.0
 _DEFAULT_JOURNAL_BYTES = 100 * (1 << 20)
 # Matches names produced by memory._pool_filename: "kvcr-<pool_id>-<32 hex>".
 _ORPHANED_POOL_NAME = re.compile(rf"{re.escape(_POOL_PREFIX)}-.+-[0-9a-f]{{32}}")
+_GB = 1 << 30
 
 
 class _PoolRegistry:
@@ -70,15 +73,15 @@ class _PoolRegistry:
     def __init__(
         self,
         pool_dir: str | os.PathLike[str],
-        pool_count: int,
-        pool_size_bytes: int,
+        guard_count: int,
+        pool_sizes_bytes: tuple[int, ...],
         journal_bytes: int,
         compatibility_digest: str,
     ) -> None:
         self._pool_dir = Path(pool_dir).resolve()
         if not self._pool_dir.is_dir():
             raise ValueError(f"KVCR pool directory does not exist: {self._pool_dir}")
-        self._pool_count = pool_count
+        self._guard_count = guard_count
         self._pools: dict[int, _Guard] = {}
         self._refusing = threading.Event()
         # Stand-in until the owning server takes over; only it can stop the service.
@@ -86,11 +89,12 @@ class _PoolRegistry:
             logger.critical, "Uncontained KVCR pool failure: %s"
         )
         self._purge_orphaned_pools()
-        for rank in range(pool_count):
+        mapping_bytes = journal_bytes + sum(pool_sizes_bytes)
+        for rank in range(guard_count):
             try:
                 owner = _KVCRPoolOwner.allocate(
                     pool_id=f"pool_{rank}",
-                    pool_size_bytes=pool_size_bytes,
+                    pool_size_bytes=mapping_bytes,
                     journal_bytes=journal_bytes,
                     pool_dir=self._pool_dir,
                 )
@@ -167,9 +171,9 @@ class _PoolRegistry:
                     logger.info("Leaving KVCR pool still in use: %s", path)
 
     def _pool(self, pool_index: int) -> _Guard:
-        if not (0 <= pool_index < self._pool_count):
+        if not (0 <= pool_index < self._guard_count):
             raise KVCRServiceError(
-                f"pool_index {pool_index} is out of range [0, {self._pool_count})"
+                f"pool_index {pool_index} is out of range [0, {self._guard_count})"
             )
         guard = self._pools.get(pool_index)
         if guard is None:
@@ -451,8 +455,8 @@ class _KVCRService:
         self,
         socket_path: str | os.PathLike[str],
         pool_dir: str | os.PathLike[str],
-        pool_count: int,
-        pool_size_bytes: int,
+        guard_count: int,
+        pool_sizes_bytes: tuple[int, ...],
         compatibility_digest: str,
         journal_bytes: int = _DEFAULT_JOURNAL_BYTES,
     ) -> None:
@@ -465,7 +469,7 @@ class _KVCRService:
         # per pod and clears the path before starting it.
         _unlink_stale_socket(self.socket_path)
         self._registry = _PoolRegistry(
-            pool_dir, pool_count, pool_size_bytes, journal_bytes, compatibility_digest
+            pool_dir, guard_count, pool_sizes_bytes, journal_bytes, compatibility_digest
         )
         try:
             self._server = _ThreadingUnixServer(
@@ -563,38 +567,56 @@ def _handle_shutdown_signal(signum: int, frame: FrameType | None) -> None:
     raise _ShutdownRequested
 
 
+def _parse_pool_sizes_gb(value: str) -> tuple[int, ...]:
+    try:
+        sizes_gb = tuple(Decimal(item) for item in value.split(","))
+        if not all(size.is_finite() and size > 0 for size in sizes_gb):
+            raise InvalidOperation
+    except InvalidOperation as error:
+        raise argparse.ArgumentTypeError(
+            "--pool-sizes-gb must contain positive, finite numbers"
+        ) from error
+    if any(size > sys.maxsize for size in sizes_gb):
+        raise argparse.ArgumentTypeError(
+            "--pool-sizes-gb describes an allocation that is too large"
+        )
+    page = mmap.PAGESIZE
+    with localcontext() as context:
+        context.prec = max(len(size.as_tuple().digits) for size in sizes_gb) + 10
+        sizes_bytes = tuple(int(size * _GB) // page * page for size in sizes_gb)
+    if not all(size >= page for size in sizes_bytes):
+        raise argparse.ArgumentTypeError(
+            "--pool-sizes-gb values must be at least one memory page"
+        )
+    if _DEFAULT_JOURNAL_BYTES + sum(sizes_bytes) > sys.maxsize:
+        raise argparse.ArgumentTypeError(
+            "--pool-sizes-gb describes an allocation that is too large"
+        )
+    return sizes_bytes
+
+
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse and validate the service's command line."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--socket-path", required=True)
     parser.add_argument("--pool-dir", required=True)
-    parser.add_argument("--pool-count", type=int, required=True)
-    parser.add_argument("--pool-size-gb", type=float, required=True)
+    parser.add_argument("--guard-count", type=int, required=True)
+    parser.add_argument(
+        "--pool-sizes-gb",
+        type=_parse_pool_sizes_gb,
+        dest="pool_sizes_bytes",
+        required=True,
+    )
     parser.add_argument("--compatibility-digest", required=True)
     args = parser.parse_args(argv)
-
-    # Reject nan/inf before converting to int, which would otherwise raise a
-    # raw ValueError/OverflowError instead of an argparse usage error.
-    if not math.isfinite(args.pool_size_gb) or args.pool_size_gb <= 0:
-        parser.error("--pool-size-gb must be a positive, finite number")
-    if args.pool_count < 1:
-        parser.error("--pool-count must be at least 1")
-
-    args.pool_size_bytes = int(args.pool_size_gb * (1 << 30))
-    if args.pool_size_bytes <= _DEFAULT_JOURNAL_BYTES:
-        # The journal is carved out of this size, not added to it, so a pool this small
-        # has no room to cache anything.
-        parser.error(
-            "--pool-size-gb must exceed the "
-            f"{_DEFAULT_JOURNAL_BYTES >> 20} MiB journal each pool reserves"
-        )
+    if args.guard_count < 1:
+        parser.error("--guard-count must be at least 1")
     return args
 
 
 def main() -> None:
     """Run the standalone KVCR service daemon."""
     args = _parse_args()
-    pool_size_bytes = args.pool_size_bytes
 
     shutdown_signals = {signal.SIGINT, signal.SIGTERM}
     previous_mask = signal.pthread_sigmask(signal.SIG_BLOCK, shutdown_signals)
@@ -605,18 +627,18 @@ def main() -> None:
         server = _KVCRService(
             args.socket_path,
             args.pool_dir,
-            pool_count=args.pool_count,
-            pool_size_bytes=pool_size_bytes,
+            guard_count=args.guard_count,
+            pool_sizes_bytes=args.pool_sizes_bytes,
             compatibility_digest=args.compatibility_digest,
         )
         signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
         logging.basicConfig(level=logging.INFO)
         logger.info(
-            "KVCR service ready: socket=%s pools=%d pool_size_bytes=%d "
+            "KVCR service ready: socket=%s guards=%d pool_sizes_bytes=%s "
             "journal_bytes=%d",
             args.socket_path,
-            args.pool_count,
-            pool_size_bytes,
+            args.guard_count,
+            args.pool_sizes_bytes,
             _DEFAULT_JOURNAL_BYTES,
         )
         server.serve_forever()

--- a/src/kvcr/kvcr_service.py
+++ b/src/kvcr/kvcr_service.py
@@ -82,7 +82,7 @@ class _PoolRegistry:
         if not self._pool_dir.is_dir():
             raise ValueError(f"KVCR pool directory does not exist: {self._pool_dir}")
         self._guard_count = guard_count
-        self._pools: dict[int, _Guard] = {}
+        self._guards: dict[int, _Guard] = {}
         self._refusing = threading.Event()
         # Stand-in until the owning server takes over; only it can stop the service.
         self.on_uncontained_failure = functools.partial(
@@ -105,7 +105,7 @@ class _PoolRegistry:
                         owner.spec,
                         functools.partial(self._guard_failed, rank),
                         compatibility_digest=compatibility_digest,
-                        pool_index=rank,
+                        guard_index=rank,
                         owner=owner,
                         refusing=self._refusing.is_set,
                     )
@@ -116,7 +116,7 @@ class _PoolRegistry:
                     raise
                 # Recorded before it starts, so a failed preparation is rolled back by
                 # the sweep below.
-                self._pools[rank] = guard
+                self._guards[rank] = guard
                 guard.start()
             except BaseException:
                 self._release_pools()
@@ -124,7 +124,7 @@ class _PoolRegistry:
 
     def _release_pools(self) -> None:
         """Give back every pool built so far, for a startup that cannot finish."""
-        for pool_index, guard in list(self._pools.items()):
+        for guard_index, guard in list(self._guards.items()):
             # Even an interrupt must not stop the sweep: the startup failure is
             # already propagating, and every pool left behind is committed RAM.
             try:
@@ -139,7 +139,7 @@ class _PoolRegistry:
                     exc_info=True,
                 )
                 continue
-            del self._pools[pool_index]
+            del self._guards[guard_index]
 
     def _purge_orphaned_pools(self) -> None:
         """Remove pool files no live daemon owns.
@@ -170,19 +170,19 @@ class _PoolRegistry:
                 else:
                     logger.info("Leaving KVCR pool still in use: %s", path)
 
-    def _pool(self, pool_index: int) -> _Guard:
-        if not (0 <= pool_index < self._guard_count):
+    def _guard(self, guard_index: int) -> _Guard:
+        if not (0 <= guard_index < self._guard_count):
             raise KVCRServiceError(
-                f"pool_index {pool_index} is out of range [0, {self._guard_count})"
+                f"guard_index {guard_index} is out of range [0, {self._guard_count})"
             )
-        guard = self._pools.get(pool_index)
+        guard = self._guards.get(guard_index)
         if guard is None:
-            raise KVCRServiceError(f"no claimable KVCR pool {pool_index}")
+            raise KVCRServiceError(f"no claimable KVCR Guard {guard_index}")
         return guard
 
     def claim(
         self,
-        pool_index: int,
+        guard_index: int,
         tier_config: _TierConfig,
         liveness: PidfdLiveness,
         control_bind: tuple[str, int],
@@ -194,14 +194,14 @@ class _PoolRegistry:
         """
         if self._refusing.is_set():
             raise KVCRServiceError("KVCR pool registry is closed")
-        return self._pool(pool_index).claim(liveness, tier_config, control_bind)
+        return self._guard(guard_index).claim(liveness, tier_config, control_bind)
 
-    def release(self, pool_index: int, lease: "_Lease") -> None:
-        self._pool(pool_index).release(lease)
+    def release(self, guard_index: int, lease: "_Lease") -> None:
+        self._guard(guard_index).release(lease)
 
-    def abort_grant(self, pool_index: int, lease: "_Lease") -> None:
+    def abort_grant(self, guard_index: int, lease: "_Lease") -> None:
         """Take back a grant its claimant declared it never served."""
-        self._pool(pool_index).abort_grant(lease)
+        self._guard(guard_index).abort_grant(lease)
 
     def refuse_claims(self) -> None:
         """Stop granting pools without waiting for the close path to run.
@@ -211,7 +211,7 @@ class _PoolRegistry:
         """
         self._refusing.set()
         # Snapshot: close() deletes pools from the dict on other threads.
-        for guard in list(self._pools.values()):
+        for guard in list(self._guards.values()):
             with guard._phase_lock:
                 pass
 
@@ -225,7 +225,7 @@ class _PoolRegistry:
         self._refusing.set()
         failure: BaseException | None = None
         # Tell all pools before waiting on any: a wedged one must not block the rest.
-        for guard in self._pools.values():
+        for guard in self._guards.values():
             try:
                 guard.begin_close()
             except BaseException as error:  # noqa: BLE001 - raised below
@@ -233,27 +233,27 @@ class _PoolRegistry:
         deadline = time.monotonic() + _REGISTRY_TRANSITION_TIMEOUT_SECONDS
         wedged: list[int] = []
         kept: set[int] = set()
-        for pool_index in sorted(self._pools):
+        for guard_index in sorted(self._guards):
             try:
-                if self._pools[pool_index].finish_close(deadline):
-                    wedged.append(pool_index)
-                    kept.add(pool_index)
+                if self._guards[guard_index].finish_close(deadline):
+                    wedged.append(guard_index)
+                    kept.add(guard_index)
             except BaseException as error:  # noqa: BLE001 - raised below
                 failure = failure or error
-                kept.add(pool_index)
+                kept.add(guard_index)
         # Wedged pools stay visible; drained ones stay listed until the whole
         # drain finished, so a release racing shutdown is absorbed.
-        for pool_index in [index for index in self._pools if index not in kept]:
-            del self._pools[pool_index]
+        for guard_index in [index for index in self._guards if index not in kept]:
+            del self._guards[guard_index]
         if failure is not None:
             raise failure
         if wedged:
             raise TimeoutError(
-                f"timed out waiting for KVCR pool transitions: pools {wedged} leaked"
+                f"timed out waiting for KVCR Guard transitions: guards {wedged} leaked"
             )
 
     def _guard_failed(
-        self, pool_index: int, _guard: "_Guard", error: BaseException
+        self, guard_index: int, _guard: "_Guard", error: BaseException
     ) -> None:
         """A Guard has stopped being one, which the service cannot survive.
 
@@ -261,7 +261,7 @@ class _PoolRegistry:
         still hold an endpoint the service cannot reach. One pool takes the others'
         workers with it; add isolation back if that stops being acceptable.
         """
-        logger.critical("KVCR pool %d Guard failed", pool_index)
+        logger.critical("KVCR Guard %d failed", guard_index)
         self.on_uncontained_failure(error)
 
 
@@ -299,7 +299,7 @@ class _RequestHandler(socketserver.BaseRequestHandler):
                 self.channel.send(response)
             return
 
-        pool_index, listener_fd, lease = grant
+        guard_index, listener_fd, lease = grant
         try:
             # No timeout: a held connection must wait as long as the lease lives.
             # Inside the try: shutdown may have landed; listener_fd closes either way.
@@ -316,9 +316,9 @@ class _RequestHandler(socketserver.BaseRequestHandler):
         finally:
             with contextlib.suppress(OSError):
                 os.close(listener_fd)
-        self._await_release(pool_index, lease)
+        self._await_release(guard_index, lease)
 
-    def _await_release(self, pool_index: int, lease: "_Lease") -> None:
+    def _await_release(self, guard_index: int, lease: "_Lease") -> None:
         """Wait for the one message a held connection may send: its release.
 
         The pool's actor watches the pidfd, not this thread. EOF only ends the
@@ -332,21 +332,21 @@ class _RequestHandler(socketserver.BaseRequestHandler):
             except (KVCRGuardProtocolError, KVCRMsgFramingError) as error:
                 self._send_error(error)
                 continue
-            if self._release_or_fail(pool_index, lease, release.activated):
+            if self._release_or_fail(guard_index, lease, release.activated):
                 with contextlib.suppress(OSError):
                     self.channel.send(_Released(_PROTOCOL_VERSION))
             return
 
     def _release_or_fail(
-        self, pool_index: int, lease: "_Lease", activated: bool = True
+        self, guard_index: int, lease: "_Lease", activated: bool = True
     ) -> bool:
         try:
             if activated:
-                self.server.registry.release(pool_index, lease)
+                self.server.registry.release(guard_index, lease)
             else:
                 # The claimant declared it never served this lease; the Guard
                 # it stood down may resume serving.
-                self.server.registry.abort_grant(pool_index, lease)
+                self.server.registry.abort_grant(guard_index, lease)
         except KVCRServiceError as error:
             # Registry closing: claimant learns the release did not commit; not fatal.
             self._send_error(error)
@@ -407,14 +407,14 @@ class _ThreadingUnixServer(
                 "KVCR compatibility digest does not match the service"
             )
         spec, listener_fd, lease = self.registry.claim(
-            request.pool_index,
+            request.guard_index,
             request.tier_config,
             liveness,
             (request.control_host, request.control_port),
         )
         return (
-            _Granted(request.pool_index, spec, request.tier_config, _PROTOCOL_VERSION),
-            (request.pool_index, listener_fd, lease),
+            _Granted(request.guard_index, spec, request.tier_config, _PROTOCOL_VERSION),
+            (request.guard_index, listener_fd, lease),
         )
 
     def fail(self, error: BaseException) -> None:

--- a/src/kvcr/recovery_journal.py
+++ b/src/kvcr/recovery_journal.py
@@ -441,7 +441,7 @@ def claim_guarded_pool(
             "endpoint, so that a Guard can answer on it after this worker dies"
         )
     hold = KVCRClient(guard_config.kvcr_service_socket_path).claim(
-        guard_config.pool_index,
+        guard_config.guard_index,
         guard_config.row_stride,
         guard_config.compatibility_digest,
         bind_address(),

--- a/tests/unit/test_control_channels.py
+++ b/tests/unit/test_control_channels.py
@@ -112,7 +112,7 @@ def channel() -> Iterator[ZmqPeerControlChannel]:
 
 def test_messages_keep_their_boundaries(pair: Pair) -> None:
     sender, receiver = pair
-    claim = _Message("claim", {"pool_index": 3})
+    claim = _Message("claim", {"guard_index": 3})
     FramedConnection(sender).send(claim)
     FramedConnection(sender).send(_Message("ping"))
     incoming = FramedConnection(receiver)
@@ -134,7 +134,7 @@ def test_a_frame_carries_at_most_one_descriptor(
     received_fd: int | None = None
     with _pipe() as (read_fd, _write_fd):
         try:
-            message = _Message("claim", {"pool_index": 3})
+            message = _Message("claim", {"guard_index": 3})
             FramedConnection(sender).send_with_fd(message, read_fd)
 
             received, received_fd = incoming.receive_with_fd(_MESSAGE_DECODER)

--- a/tests/unit/test_guard_integration.py
+++ b/tests/unit/test_guard_integration.py
@@ -147,7 +147,7 @@ def _make_kvcr(
             ),
             KVCRGuardConfig(
                 kvcr_service_socket_path=socket_path,
-                pool_index=0,
+                guard_index=0,
                 row_stride=page_size,
                 compatibility_digest=_DIGEST,
             ),
@@ -318,7 +318,7 @@ def test_a_promoted_guard_serves_real_nixl_transfers(
         "_real_nixl_primary_child", service.socket_path, g3_path, control_port
     )
     _await_marker(primary, "ready", _REAL_NIXL_TIMEOUT_SECONDS)
-    guard = service._registry._pools[0]
+    guard = service._registry._guards[0]
 
     primary.kill()
     primary.wait(timeout=_TIMEOUT_SECONDS)
@@ -484,7 +484,7 @@ def test_request_timeout_during_promotion_then_retry_uses_guard(
         child.kill()
         child.wait(timeout=_TIMEOUT_SECONDS)
         assert promotion_started.wait(timeout=_TIMEOUT_SECONDS)
-        guard = service._registry._pools[0]
+        guard = service._registry._guards[0]
 
         now[0] = 6.0
         _wait_until(
@@ -556,7 +556,7 @@ def test_replacement_primary_takes_the_cache_back_from_a_guard(
     # operation deadline instead of failing them now.
     idle = spawn("_primary_child", service.socket_path, g3_path, control_port, "idle")
     _await_marker(idle, "ready")
-    first_guard = service._registry._pools[0]
+    first_guard = service._registry._guards[0]
     idle.kill()
     idle.wait(timeout=_TIMEOUT_SECONDS)
     _wait_until(lambda: first_guard._serving, timeout=_TIMEOUT_SECONDS)

--- a/tests/unit/test_guard_integration.py
+++ b/tests/unit/test_guard_integration.py
@@ -234,8 +234,8 @@ def live_service(
     service = _KVCRService(
         tmp_path / "service.sock",
         pool_dir,
-        pool_count=1,
-        pool_size_bytes=8192 + os.sysconf("SC_PAGE_SIZE"),
+        guard_count=1,
+        pool_sizes_bytes=(os.sysconf("SC_PAGE_SIZE"),),
         journal_bytes=8192,
         compatibility_digest=_DIGEST,
     )

--- a/tests/unit/test_guard_protocol.py
+++ b/tests/unit/test_guard_protocol.py
@@ -31,7 +31,7 @@ from kvcr.guard_protocol import (
 )
 from kvcr.memory import _JOURNAL_HEADER_BYTES, KVCRPoolSpec
 
-_POOL_INDEX = 3
+_GUARD_INDEX = 3
 _ROW_STRIDE = 1024
 _GENERATION = "a" * 32
 _DEVICE = 2049
@@ -162,15 +162,15 @@ class _Attachment:
 
 def _grant(
     *,
-    pool_index: int = _POOL_INDEX,
+    guard_index: int = _GUARD_INDEX,
     mapping_bytes: int = _MAPPING_BYTES,
     tier_config: _TierConfig = _TIER_CONFIG,
 ) -> _Granted:
     return _Granted(
-        pool_index,
+        guard_index,
         KVCRPoolSpec(
-            pool_id=f"pool_{_POOL_INDEX}",
-            path=f"/tmp/kvcr-pool_{_POOL_INDEX}-{_GENERATION}",
+            pool_id=f"pool_{_GUARD_INDEX}",
+            path=f"/tmp/kvcr-pool_{_GUARD_INDEX}-{_GENERATION}",
             generation=_GENERATION,
             device=_DEVICE,
             inode=_INODE,
@@ -224,12 +224,12 @@ def test_claim_and_release_round_trip_typed_messages_and_geometry(
     monkeypatch.setattr(protocol_module.KVCRPoolAttachment, "attach", attach)
 
     hold = KVCRClient("/unused").claim(
-        _POOL_INDEX, _ROW_STRIDE, _DIGEST, ("127.0.0.1", 5555)
+        _GUARD_INDEX, _ROW_STRIDE, _DIGEST, ("127.0.0.1", 5555)
     )
 
     assert msgspec.to_builtins(connection.sent[0]) == {
         "type": "claim",
-        "pool_index": _POOL_INDEX,
+        "guard_index": _GUARD_INDEX,
         "compatibility_digest": _DIGEST,
         "tier_config": {"row_stride": _ROW_STRIDE, "g3": None},
         "control_host": "127.0.0.1",
@@ -238,10 +238,10 @@ def test_claim_and_release_round_trip_typed_messages_and_geometry(
     }
     assert msgspec.to_builtins(_grant()) == {
         "type": "granted",
-        "pool_index": _POOL_INDEX,
+        "guard_index": _GUARD_INDEX,
         "spec": {
-            "pool_id": f"pool_{_POOL_INDEX}",
-            "path": f"/tmp/kvcr-pool_{_POOL_INDEX}-{_GENERATION}",
+            "pool_id": f"pool_{_GUARD_INDEX}",
+            "path": f"/tmp/kvcr-pool_{_GUARD_INDEX}-{_GENERATION}",
             "generation": _GENERATION,
             "device": _DEVICE,
             "inode": _INODE,
@@ -284,7 +284,7 @@ def test_claim_and_release_round_trip_typed_messages_and_geometry(
 @pytest.mark.parametrize(
     ("reply", "mapping_error"),
     [
-        pytest.param(_grant(pool_index=_POOL_INDEX + 1), None, id="wrong-pool"),
+        pytest.param(_grant(guard_index=_GUARD_INDEX + 1), None, id="wrong-guard"),
         pytest.param(
             _grant(tier_config=_TierConfig(_ROW_STRIDE * 2, None)),
             None,
@@ -323,7 +323,7 @@ def test_a_failed_claim_is_released_without_masking_the_original(
         type(original) if original is not None else KVCRGuardProtocolError
     ) as raised:
         KVCRClient("/unused").claim(
-            _POOL_INDEX, _ROW_STRIDE, _DIGEST, ("127.0.0.1", 5555)
+            _GUARD_INDEX, _ROW_STRIDE, _DIGEST, ("127.0.0.1", 5555)
         )
 
     if original is not None:
@@ -331,7 +331,7 @@ def test_a_failed_claim_is_released_without_masking_the_original(
     # A mismatched or undecodable grant is refused before the pool is mapped.
     assert attach.call_count == (1 if mapping_error else 0)
     assert connection.sent == [
-        _Claim(_POOL_INDEX, _DIGEST, _TIER_CONFIG, "127.0.0.1", 5555, 1),
+        _Claim(_GUARD_INDEX, _DIGEST, _TIER_CONFIG, "127.0.0.1", 5555, 1),
         # Unactivated: this claim never served, so the Guard may resume.
         _Release(1, activated=False),
     ]

--- a/tests/unit/test_kvcr.py
+++ b/tests/unit/test_kvcr.py
@@ -108,7 +108,7 @@ def test_local_dram_observer_reports_only_stable_slot_changes() -> None:
 
 _GUARD_CONFIG = KVCRGuardConfig(
     kvcr_service_socket_path="/tmp/kvcr.sock",
-    pool_index=3,
+    guard_index=3,
     row_stride=1024,
     compatibility_digest="Opaque-Digest",
 )
@@ -359,7 +359,7 @@ def test_service_journal_is_attached_before_primary_start(
         KVCRBackendConfigs(g3=g3_config),
         KVCRGuardConfig(
             kvcr_service_socket_path="/tmp/kvcr.sock",
-            pool_index=3,
+            guard_index=3,
             row_stride=1024,
             compatibility_digest="Opaque-Digest",
         ),

--- a/tests/unit/test_kvcr_service.py
+++ b/tests/unit/test_kvcr_service.py
@@ -59,9 +59,10 @@ def _holders_of(registry) -> dict[int, object]:
 _SERVER_STOP_TIMEOUT_SECONDS = 5
 _CONNECTION_POLL_INTERVAL_SECONDS = 0.001
 
-_TEST_POOL_COUNT = 2
+_TEST_GUARD_COUNT = 2
 _TEST_JOURNAL_BYTES = 8192
-_TEST_POOL_SIZE_BYTES = _TEST_JOURNAL_BYTES + 8192
+_TEST_POOL_SIZE_BYTES = 8192
+_TEST_POOL_SIZES_BYTES = (_TEST_POOL_SIZE_BYTES,)
 _TEST_ROW_STRIDE = 1024
 _TEST_DIGEST = "opaque digest: Preserve-Me EXACTLY"
 _TEST_TIER_CONFIG = _TierConfig(_TEST_ROW_STRIDE, None)
@@ -139,8 +140,8 @@ def _test_socket_path() -> Path:
 @contextmanager
 def _running_server(
     tmp_path: Path,
-    pool_count: int = _TEST_POOL_COUNT,
-    pool_size_bytes: int = _TEST_POOL_SIZE_BYTES,
+    guard_count: int = _TEST_GUARD_COUNT,
+    pool_sizes_bytes: tuple[int, ...] = _TEST_POOL_SIZES_BYTES,
     journal_bytes: int = _TEST_JOURNAL_BYTES,
 ) -> Iterator[_ServerHarness]:
     socket_path = _test_socket_path()
@@ -149,8 +150,8 @@ def _running_server(
     server = _KVCRService(
         socket_path,
         pool_dir,
-        pool_count=pool_count,
-        pool_size_bytes=pool_size_bytes,
+        guard_count=guard_count,
+        pool_sizes_bytes=pool_sizes_bytes,
         compatibility_digest=_TEST_DIGEST,
         journal_bytes=journal_bytes,
     )
@@ -220,7 +221,7 @@ def _stand_in_pool(spec) -> Mock:
     return attachment
 
 
-def _new_registry(tmp_path: Path, pool_count: int = 1) -> _PoolRegistry:
+def _new_registry(tmp_path: Path, guard_count: int = 1) -> _PoolRegistry:
     """A registry of real Guards over stand-in pool mappings."""
     journal = Mock()
     journal.read_next.return_value = None
@@ -230,8 +231,8 @@ def _new_registry(tmp_path: Path, pool_count: int = 1) -> _PoolRegistry:
     ):
         return _PoolRegistry(
             tmp_path,
-            pool_count,
-            _TEST_POOL_SIZE_BYTES,
+            guard_count,
+            _TEST_POOL_SIZES_BYTES,
             _TEST_JOURNAL_BYTES,
             _TEST_DIGEST,
         )
@@ -255,11 +256,21 @@ def test_socket_is_private(tmp_path: Path) -> None:
         assert stat.S_IMODE(harness.server.socket_path.stat().st_mode) == 0o600
 
 
+def test_each_guard_allocation_contains_all_pool_sizes(tmp_path: Path) -> None:
+    pool_sizes = (2 * _PAGE_STRIDE, 3 * _PAGE_STRIDE)
+    with _running_server(tmp_path, pool_sizes_bytes=pool_sizes) as harness:
+        expected = _TEST_JOURNAL_BYTES + sum(pool_sizes)
+        assert all(
+            guard._owner.spec.mapping_bytes == expected
+            for guard in harness.server._registry._pools.values()
+        )
+
+
 def test_registry_lifecycle_from_independent_leases_to_a_wedged_close(
     tmp_path: Path,
 ) -> None:
     """Pools lease independently; close keeps, names, and can retry a wedged one."""
-    registry = _new_registry(tmp_path, pool_count=2)
+    registry = _new_registry(tmp_path, guard_count=2)
     guard = registry._pools[0]
     first, second, third = _FakeLiveness(), _FakeLiveness(), _FakeLiveness()
     first_spec, stale = _claim(registry, 0, first)
@@ -413,7 +424,7 @@ def test_a_failed_claim_pins_nothing_and_an_unfreeable_endpoint_is_fatal(
     tmp_path: Path,
 ) -> None:
     """A failed claim gives back lease and endpoint; an unfreeable address is fatal."""
-    registry = _new_registry(tmp_path, pool_count=2)
+    registry = _new_registry(tmp_path, guard_count=2)
     guard = registry._pools[0]
     bound: list[socket.socket] = []
     try:
@@ -536,7 +547,7 @@ def test_slow_promotion_does_not_block_other_pools_or_shutdown(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    registry = _new_registry(tmp_path, pool_count=2)
+    registry = _new_registry(tmp_path, guard_count=2)
     guard = registry._pools[0]
     promotion_started = threading.Event()
     continue_promotion = threading.Event()
@@ -617,7 +628,7 @@ def test_claim_refusals_and_internal_failures_do_not_bind(
 
 
 def test_held_connection_accepts_only_release(tmp_path: Path) -> None:
-    with _running_server(tmp_path, pool_count=1) as harness:
+    with _running_server(tmp_path, guard_count=1) as harness:
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as connection:
             connection.connect(str(harness.server.socket_path))
             channel = FramedConnection(connection)
@@ -747,7 +758,7 @@ def test_startup_rollback_gives_back_every_pool_but_a_wedged_one(
         pytest.raises(RuntimeError, match="attach failed"),
     ):
         _PoolRegistry(
-            tmp_path, 3, _TEST_POOL_SIZE_BYTES, _TEST_JOURNAL_BYTES, _TEST_DIGEST
+            tmp_path, 3, _TEST_POOL_SIZES_BYTES, _TEST_JOURNAL_BYTES, _TEST_DIGEST
         )
 
     # The pool that closed is gone with the one that never attached; the pool
@@ -781,8 +792,8 @@ def test_startup_allocation_failure_rolls_back_before_listener(
         _KVCRService(
             _test_socket_path(),
             tmp_path,
-            pool_count=3,
-            pool_size_bytes=_TEST_POOL_SIZE_BYTES,
+            guard_count=3,
+            pool_sizes_bytes=_TEST_POOL_SIZES_BYTES,
             compatibility_digest=_TEST_DIGEST,
             journal_bytes=_TEST_JOURNAL_BYTES,
         )
@@ -818,7 +829,7 @@ def test_shutdown_does_not_unlink_replaced_socket_path(tmp_path: Path) -> None:
 def test_idle_client_does_not_block_shutdown_cleanup(tmp_path: Path) -> None:
     with _running_server(tmp_path) as harness:
         pool_paths = list((tmp_path / "pools").glob("kvcr-pool_*-*"))
-        assert len(pool_paths) == _TEST_POOL_COUNT
+        assert len(pool_paths) == _TEST_GUARD_COUNT
         socket_path = harness.server.socket_path
         _wait_for_connection_state(harness.server, connected=False)
         idle_connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -1214,10 +1225,36 @@ def test_shutdown_drains_a_held_connection(tmp_path: Path) -> None:
         hold._connection.close()
 
 
-def test_a_pool_no_bigger_than_its_journal_is_rejected_at_the_flag() -> None:
-    """Sized at or below the journal, a pool has nothing left to cache with."""
-    flags = "--socket-path s --pool-dir d --pool-count 1 --compatibility-digest g"
+def _service_args(pool_sizes_gb: str) -> list[str]:
+    return (
+        "--socket-path s --pool-dir d --guard-count 2 --pool-sizes-gb".split()
+        + [pool_sizes_gb]
+        + "--compatibility-digest g".split()
+    )
+
+
+def test_pool_size_list_preserves_order_and_floors_each_item_to_pages() -> None:
+    raw_sizes = (2 * _PAGE_STRIDE + 123, 3 * _PAGE_STRIDE + 456)
+    parsed = _parse_args(
+        _service_args(",".join(str(size / (1 << 30)) for size in raw_sizes))
+    )
+
+    expected = (2 * _PAGE_STRIDE, 3 * _PAGE_STRIDE)
+    assert parsed.pool_sizes_bytes == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "1,,2",
+        "nan",
+        "0",
+        str((_PAGE_STRIDE - 1) / (1 << 30)),
+        "1e1000000",
+        ",".join([str(sys.maxsize // (1 << 30))] * 2),
+    ],
+)
+def test_invalid_pool_size_items_are_rejected(value: str) -> None:
     with pytest.raises(SystemExit):
-        _parse_args([*flags.split(), "--pool-size-gb", "0.05"])
-    parsed = _parse_args([*flags.split(), "--pool-size-gb", "0.2"])
-    assert parsed.pool_size_bytes > 100 * (1 << 20)
+        _parse_args(_service_args(value))

--- a/tests/unit/test_kvcr_service.py
+++ b/tests/unit/test_kvcr_service.py
@@ -51,7 +51,7 @@ def _holders_of(registry) -> dict[int, object]:
     """The pools a worker holds, in the shape the old binding map had."""
     return {
         i: p._pool_lease.current
-        for i, p in registry._pools.items()
+        for i, p in registry._guards.items()
         if p._pool_lease.current is not None
     }
 
@@ -93,22 +93,22 @@ class _FakeLiveness:
             os.close(self._write)
 
 
-def _claim(registry, pool_index, liveness, control_bind=None):
+def _claim(registry, guard_index, liveness, control_bind=None):
     """Claim through the registry, closing the granted fd the tests never send."""
     spec, listener_fd, lease = registry.claim(
-        pool_index,
+        guard_index,
         _TEST_TIER_CONFIG,
         liveness,
-        control_bind or _control_bind(pool_index),
+        control_bind or _control_bind(guard_index),
     )
     os.close(listener_fd)
     return spec, lease
 
 
-def _kill_and_wait(registry, pool_index, liveness) -> None:
+def _kill_and_wait(registry, guard_index, liveness) -> None:
     """Die the way a real claimant does: the pool's own actor notices."""
     liveness.kill()
-    guard = registry._pools[pool_index]
+    guard = registry._guards[guard_index]
     _wait_until(
         lambda: guard._phase in (_Phase.STANDBY, _Phase.FAILED) or guard._failure,
         timeout=5,
@@ -175,14 +175,14 @@ def _send_raw_request(
         return channel.receive(_CLAIM_RESPONSE_DECODER)
 
 
-_POOL_BINDS: dict[int, tuple[str, int]] = {}
+_GUARD_BINDS: dict[int, tuple[str, int]] = {}
 
 
-def _control_bind(pool_index: int = 0) -> tuple[str, int]:
-    """The address a pool answers on, stable for as long as it exists."""
-    if pool_index not in _POOL_BINDS:
-        _POOL_BINDS[pool_index] = ("127.0.0.1", free_port())
-    return _POOL_BINDS[pool_index]
+def _control_bind(guard_index: int = 0) -> tuple[str, int]:
+    """The address a Guard answers on, stable for as long as it exists."""
+    if guard_index not in _GUARD_BINDS:
+        _GUARD_BINDS[guard_index] = ("127.0.0.1", free_port())
+    return _GUARD_BINDS[guard_index]
 
 
 # A free address a client can ask the service to bind.
@@ -197,8 +197,8 @@ def _claim_request(
 @pytest.fixture(autouse=True)
 def _channels_are_taken():
     """Close the duplicate a claim hands its Guard, as a real Guard would."""
-    # Within a test a pool's endpoint never moves; across tests it is gone.
-    _POOL_BINDS.clear()
+    # Within a test a Guard's endpoint never moves; across tests it is gone.
+    _GUARD_BINDS.clear()
     # A promoted Guard's poll loop drains this, so recv() must be iterable.
     channel = Mock(recv=Mock(return_value=[]))
 
@@ -211,7 +211,7 @@ def _channels_are_taken():
         side_effect=_take,
     ):
         yield
-    _POOL_BINDS.clear()
+    _GUARD_BINDS.clear()
 
 
 def _stand_in_pool(spec) -> Mock:
@@ -262,7 +262,7 @@ def test_each_guard_allocation_contains_all_pool_sizes(tmp_path: Path) -> None:
         expected = _TEST_JOURNAL_BYTES + sum(pool_sizes)
         assert all(
             guard._owner.spec.mapping_bytes == expected
-            for guard in harness.server._registry._pools.values()
+            for guard in harness.server._registry._guards.values()
         )
 
 
@@ -271,7 +271,7 @@ def test_registry_lifecycle_from_independent_leases_to_a_wedged_close(
 ) -> None:
     """Pools lease independently; close keeps, names, and can retry a wedged one."""
     registry = _new_registry(tmp_path, guard_count=2)
-    guard = registry._pools[0]
+    guard = registry._guards[0]
     first, second, third = _FakeLiveness(), _FakeLiveness(), _FakeLiveness()
     first_spec, stale = _claim(registry, 0, first)
     _spec, _fd, _lease = registry.claim(
@@ -288,17 +288,17 @@ def test_registry_lifecycle_from_independent_leases_to_a_wedged_close(
 
     # The retried release of the old lease must not end the new one.
     registry.release(0, stale)
-    assert registry._pools[0]._pool_lease.current is current
+    assert registry._guards[0]._pool_lease.current is current
     assert third.closed is False
 
     first_path = Path(guard._owner.spec.path)
-    second_path = Path(registry._pools[1]._owner.spec.path)
+    second_path = Path(registry._guards[1]._owner.spec.path)
     # An unclosable mapping keeps its file: unlinking would hide committed RAM.
     guard._recovery.attachment.close.side_effect = RuntimeError("mapping held")
     with pytest.raises(RuntimeError, match="mapping held"):
         registry.close()
-    assert registry._pools.keys() == {0}
-    assert registry._pools[0]._recovery.attachment is not None
+    assert registry._guards.keys() == {0}
+    assert registry._guards[0]._recovery.attachment is not None
     assert first_path.exists()
     # The pool behind it still went, files and all.
     assert second.closed is True and not second_path.exists()
@@ -309,13 +309,13 @@ def test_registry_lifecycle_from_independent_leases_to_a_wedged_close(
     guard._pool_lease.listener = stubborn
     with pytest.raises(OSError, match="will not close"):
         registry.close()
-    assert registry._pools.keys() == {0}
-    assert registry._pools[0]._pool_lease.listener is stubborn
+    assert registry._guards.keys() == {0}
+    assert registry._guards[0]._pool_lease.listener is stubborn
 
     # With nothing left refusing, the retried close finally takes the pool.
     guard._pool_lease.listener = None
     registry.close()
-    assert registry._pools == {} and third.closed is True
+    assert registry._guards == {} and third.closed is True
 
 
 def test_refused_claims_do_not_bind_the_pool(tmp_path: Path) -> None:
@@ -392,7 +392,7 @@ def test_a_grant_tells_the_pools_guard_and_a_clean_release_stands_it_down(
         ),
         _running_server(tmp_path) as harness,
     ):
-        guard = harness.server._registry._pools[1]
+        guard = harness.server._registry._guards[1]
         # Built and started with the pool, before any claim named it.
         assert guard._phase is _Phase.UNCONFIGURED
 
@@ -425,7 +425,7 @@ def test_a_failed_claim_pins_nothing_and_an_unfreeable_endpoint_is_fatal(
 ) -> None:
     """A failed claim gives back lease and endpoint; an unfreeable address is fatal."""
     registry = _new_registry(tmp_path, guard_count=2)
-    guard = registry._pools[0]
+    guard = registry._guards[0]
     bound: list[socket.socket] = []
     try:
         # Everything fallible runs before the lease exists.
@@ -442,7 +442,7 @@ def test_a_failed_claim_pins_nothing_and_an_unfreeable_endpoint_is_fatal(
         assert guard._pool_lease.bind_address == _control_bind(0)
 
         # A rollback that cannot free the pool's address must stop the service.
-        fatal = registry._pools[1]
+        fatal = registry._guards[1]
         adopt_failure = RuntimeError("adopt failed")
         unbind_failure = OSError("close failed")
         uncontained: list[BaseException] = []
@@ -468,7 +468,7 @@ def test_a_failed_claim_pins_nothing_and_an_unfreeable_endpoint_is_fatal(
         # The transition ended: nothing is left reserved against this pool.
         assert fatal._reserved is None and fatal._pool_lease.current is None
     finally:
-        registry._pools[1]._pool_lease.listener = None
+        registry._guards[1]._pool_lease.listener = None
         for listener in bound:
             listener.close()
         registry.close()
@@ -480,7 +480,7 @@ def test_a_standby_survives_failed_claims_and_hands_over_to_a_replacement(
     """Refused or failed claims cost a standby nothing; a good one inherits all."""
     control_bind = _control_bind(0)
     registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
+    guard = registry._guards[0]
     # The promotion itself is stubbed: what this exercises is the lifecycle
     # around a standby, not the recovery machinery inside one.
     guard._promote = Mock()
@@ -548,7 +548,7 @@ def test_slow_promotion_does_not_block_other_pools_or_shutdown(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     registry = _new_registry(tmp_path, guard_count=2)
-    guard = registry._pools[0]
+    guard = registry._guards[0]
     promotion_started = threading.Event()
     continue_promotion = threading.Event()
     first = _FakeLiveness()
@@ -574,10 +574,10 @@ def test_slow_promotion_does_not_block_other_pools_or_shutdown(
         monkeypatch.setattr(
             "kvcr.kvcr_service._REGISTRY_TRANSITION_TIMEOUT_SECONDS", 1.0
         )
-        with pytest.raises(TimeoutError, match="pool transitions"):
+        with pytest.raises(TimeoutError, match="Guard transitions"):
             registry.close()
         # The wedged pool is kept and named; its neighbour still went.
-        assert registry._pools.keys() == {0} and second.closed is True
+        assert registry._guards.keys() == {0} and second.closed is True
     finally:
         continue_promotion.set()
         monkeypatch.undo()
@@ -592,7 +592,7 @@ def test_claim_refusals_and_internal_failures_do_not_bind(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with _running_server(tmp_path) as harness:
-        spec = harness.server._registry._pools[0]._owner.spec
+        spec = harness.server._registry._guards[0]._owner.spec
         with pytest.raises(KVCRServiceError, match="compatibility digest"):
             harness.client.claim(
                 0, _TEST_ROW_STRIDE, _TEST_DIGEST.swapcase(), _control_bind()
@@ -620,7 +620,7 @@ def test_claim_refusals_and_internal_failures_do_not_bind(
         )
         assert log_record.exc_info is not None
         assert log_record.exc_info[1] is internal_error
-        assert harness.server._registry._pools[0]._owner.spec is spec
+        assert harness.server._registry._guards[0]._owner.spec is spec
         assert _holders_of(harness.server._registry) == {}
         harness.client.claim(
             0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_bind()
@@ -708,7 +708,7 @@ def test_fork_and_exec_do_not_preserve_claimant_access(
             forked_pidfd = os.pidfd_open(forked_pid)
             forked_poller = select.poll()
             forked_poller.register(forked_pidfd, select.POLLIN)
-            spec = harness.server._registry._pools[0]._owner.spec
+            spec = harness.server._registry._guards[0]._owner.spec
             assert spec is not None
             assert spec.path not in Path(f"/proc/{forked_pid}/maps").read_text()
             with pytest.raises(KVCRServiceError, match="held"):
@@ -901,7 +901,7 @@ def test_a_failed_grant_delivery_retracts_through_the_guard(tmp_path: Path) -> N
     handler.request = accepted
     handler.channel = _Channel()
     handler.server = _Server()
-    guard = registry._pools[0]
+    guard = registry._guards[0]
     guard.abort_grant = Mock(wraps=guard.abort_grant)
     guard.release = Mock(wraps=guard.release)
     try:
@@ -932,7 +932,7 @@ def test_an_undelivered_grants_lease_survives_its_connection(
     child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
     registry = _new_registry(tmp_path)
     # Promotion's serving core is not under test; the freed lease is.
-    registry._pools[0]._promote = Mock()
+    registry._guards[0]._promote = Mock()
     server = object.__new__(_ThreadingUnixServer)
     server.registry = registry
     server.compatibility_digest = _TEST_DIGEST
@@ -957,7 +957,7 @@ def test_an_undelivered_grants_lease_survives_its_connection(
         child.kill()
         child.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
         # Death freed it: the pool's own actor promotes, and the lease is gone.
-        guard = registry._pools[0]
+        guard = registry._guards[0]
         _wait_until(lambda: guard._phase is _Phase.STANDBY, timeout=5)
         assert _holders_of(registry) == {}
     finally:
@@ -972,7 +972,7 @@ def test_promotion_failure_fails_the_pool_and_stops_the_whole_service(
 ) -> None:
     """A failed promotion is escalated, fences its pool, and keeps the first error."""
     registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
+    guard = registry._guards[0]
     failure = RuntimeError("promotion failed")
     guard._promote = Mock(side_effect=failure)
 
@@ -1053,13 +1053,13 @@ def test_a_lease_older_than_the_idle_timeout_still_releases_cleanly(
 
         hold.release()
 
-        assert harness.server._registry._pools[0]._pool_lease.current is None
+        assert harness.server._registry._guards[0]._pool_lease.current is None
 
 
 def test_refuse_claims_is_a_barrier_no_grant_can_cross(tmp_path: Path) -> None:
     """refuse_claims waits out in-flight commits; nothing grants once it returns."""
     registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
+    guard = registry._guards[0]
     in_adopt = threading.Event()
     resume = threading.Event()
     returned = threading.Event()
@@ -1119,7 +1119,7 @@ def test_a_failed_release_reports_promptly_and_fences_the_pool_first(
 ) -> None:
     """A hand-back failure is the answer now, reported once nothing can claim."""
     registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
+    guard = registry._guards[0]
     guard._release = Mock(side_effect=failure)
     claimable_when_reported: list[bool] = []
     registry.on_uncontained_failure = lambda _error: claimable_when_reported.append(
@@ -1150,7 +1150,7 @@ def test_a_pidfd_that_breaks_while_its_process_lives_is_service_fatal(
 ) -> None:
     """Promotion on a broken descriptor could seat a second server on the pool."""
     registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
+    guard = registry._guards[0]
     guard._promote = Mock()
     uncontained: list[BaseException] = []
     registry.on_uncontained_failure = uncontained.append
@@ -1174,7 +1174,7 @@ def test_a_close_in_progress_absorbs_races_and_answers_stragglers(
 ) -> None:
     """Races against a close are absorbed, and queued work is still answered."""
     registry = _new_registry(tmp_path)
-    guard = registry._pools[0]
+    guard = registry._guards[0]
     liveness = _FakeLiveness()
     _spec, lease = _claim(registry, 0, liveness)
     gate = threading.Event()

--- a/tests/unit/test_kvcr_service_workflow.py
+++ b/tests/unit/test_kvcr_service_workflow.py
@@ -43,23 +43,23 @@ _STOP_TIMEOUT_SECONDS = 5.0
 _START_TIMEOUT_SECONDS = 60.0
 
 
-_POOL_BINDS: dict[int, tuple[str, int]] = {}
+_GUARD_BINDS: dict[int, tuple[str, int]] = {}
 
 
-def _control_bind(pool_index: int) -> tuple[str, int]:
-    """One address per pool, stable across the claims that reuse it."""
-    bind = _POOL_BINDS.get(pool_index)
+def _control_bind(guard_index: int) -> tuple[str, int]:
+    """One address per Guard, stable across the claims that reuse it."""
+    bind = _GUARD_BINDS.get(guard_index)
     if bind is None:
-        bind = _POOL_BINDS[pool_index] = ("127.0.0.1", free_port())
+        bind = _GUARD_BINDS[guard_index] = ("127.0.0.1", free_port())
     return bind
 
 
 @pytest.fixture(autouse=True)
-def _fresh_pool_binds() -> Iterator[None]:
-    """One address per pool per test; the service holding it is gone by the next."""
-    _POOL_BINDS.clear()
+def _fresh_guard_binds() -> Iterator[None]:
+    """One address per Guard per test; the service holding it is gone by the next."""
+    _GUARD_BINDS.clear()
     yield
-    _POOL_BINDS.clear()
+    _GUARD_BINDS.clear()
 
 
 def _socket_path() -> Path:
@@ -68,14 +68,14 @@ def _socket_path() -> Path:
 
 
 def _claim_when_ready(
-    process: subprocess.Popen[bytes], socket_path: Path, pool_index: int
+    process: subprocess.Popen[bytes], socket_path: Path, guard_index: int
 ) -> KVCRPoolHold:
     client = KVCRClient(socket_path)
     deadline = time.monotonic() + _START_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
         try:
             return client.claim(
-                pool_index, _ROW_STRIDE, _DIGEST, _control_bind(pool_index)
+                guard_index, _ROW_STRIDE, _DIGEST, _control_bind(guard_index)
             )
         except KVCRSocketError:
             if process.poll() is not None:
@@ -186,7 +186,7 @@ def test_pools_persist_bytes_and_a_held_pool_refuses_claims(tmp_path: Path) -> N
                     KVCRBackendConfigs(),
                     KVCRGuardConfig(
                         kvcr_service_socket_path=str(socket_path),
-                        pool_index=0,
+                        guard_index=0,
                         row_stride=_ROW_STRIDE,
                         compatibility_digest=_DIGEST,
                     ),

--- a/tests/unit/test_kvcr_service_workflow.py
+++ b/tests/unit/test_kvcr_service_workflow.py
@@ -36,8 +36,8 @@ from kvcr.kvcr_service import _DEFAULT_JOURNAL_BYTES, _KVCRService
 _ROW_STRIDE = 1024
 _DIGEST = "opaque workflow digest: Preserve-Me EXACTLY"
 _JOURNAL_BYTES = 8192
-_POOL_SIZE_BYTES = _JOURNAL_BYTES + 8192
-_CLI_POOL_SIZE_BYTES = _DEFAULT_JOURNAL_BYTES + 8192
+_POOL_SIZE_BYTES = 8192
+_CLI_POOL_SIZE_BYTES = 8192
 _CLI_POOL_SIZE_GB = str(_CLI_POOL_SIZE_BYTES / (1 << 30))
 _STOP_TIMEOUT_SECONDS = 5.0
 _START_TIMEOUT_SECONDS = 60.0
@@ -97,9 +97,9 @@ def _running_daemon(pool_dir: Path) -> Iterator[tuple[subprocess.Popen[bytes], P
             str(socket_path),
             "--pool-dir",
             str(pool_dir),
-            "--pool-count",
+            "--guard-count",
             "2",
-            "--pool-size-gb",
+            "--pool-sizes-gb",
             _CLI_POOL_SIZE_GB,
             "--compatibility-digest",
             _DIGEST,
@@ -121,7 +121,7 @@ def _running_daemon(pool_dir: Path) -> Iterator[tuple[subprocess.Popen[bytes], P
 @contextmanager
 def _running_service(
     pool_dir: Path,
-    pool_count: int = 2,
+    guard_count: int = 2,
     socket_path: Path | None = None,
 ) -> Iterator[Path]:
     if socket_path is None:
@@ -129,8 +129,8 @@ def _running_service(
     server = _KVCRService(
         socket_path,
         pool_dir,
-        pool_count=pool_count,
-        pool_size_bytes=_POOL_SIZE_BYTES,
+        guard_count=guard_count,
+        pool_sizes_bytes=(_POOL_SIZE_BYTES,),
         compatibility_digest=_DIGEST,
         journal_bytes=_JOURNAL_BYTES,
     )
@@ -218,10 +218,13 @@ def test_cli_daemon_sets_geometry_and_restart_reclaims_only_unattached(
 
             # The deployed flags produce the requested pool and data geometry.
             pools = list(pool_dir.iterdir())
-            assert len(pools) == 2, "--pool-count pools at startup"
-            requested = int(float(_CLI_POOL_SIZE_GB) * (1 << 30))
-            client_rows = (requested - _DEFAULT_JOURNAL_BYTES) // _ROW_STRIDE
-            assert all(path.stat().st_size == requested for path in pools)
+            assert len(pools) == 2, "--guard-count pools at startup"
+            pool_bytes = int(float(_CLI_POOL_SIZE_GB) * (1 << 30))
+            client_rows = pool_bytes // _ROW_STRIDE
+            assert all(
+                path.stat().st_size == _DEFAULT_JOURNAL_BYTES + pool_bytes
+                for path in pools
+            )
             assert hold.local_dram.length == client_rows * _ROW_STRIDE
             assert hold.local_dram.slot_count == client_rows
 
@@ -234,7 +237,7 @@ def test_cli_daemon_sets_geometry_and_restart_reclaims_only_unattached(
             assert unclaimed_pool.exists()
 
             # The successor reclaims the unclaimed pool but leaves the attached one.
-            with _running_service(pool_dir, pool_count=1, socket_path=socket_path):
+            with _running_service(pool_dir, guard_count=1, socket_path=socket_path):
                 assert attached_pool.exists()
                 assert not unclaimed_pool.exists()
                 assert len(list(pool_dir.iterdir())) == 2
@@ -246,7 +249,7 @@ def test_cli_daemon_sets_geometry_and_restart_reclaims_only_unattached(
             hold = None
 
             # Once the worker unmaps it, the next successor reclaims the orphan.
-            with _running_service(pool_dir, pool_count=1, socket_path=socket_path):
+            with _running_service(pool_dir, guard_count=1, socket_path=socket_path):
                 assert not attached_pool.exists()
                 assert len(list(pool_dir.iterdir())) == 1
         finally:


### PR DESCRIPTION
## Summary

- Rename `--pool-count` to `--guard-count` and accept an ordered, comma-separated list through `--pool-sizes-gb`.
- Allocate one journal-prefixed contiguous mapping per Guard, sized as the journal plus the sum of its pool sizes.
- Rename `pool_index` to `guard_index` across `KVCRGuardConfig`, `KVCRClient.claim`, claim/grant messages, service internals, documentation, and tests.
- Keep the existing Guard/client data plane unchanged for now; it sees the pool regions as one combined data area.

