### PR TITLE
Adjust parser to recognise kv_hint protocol

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -10,6 +10,13 @@ without editing source code in any of those projects.
 > at a specific pinned commit SHA. Treat this as a public preview until the PR is
 > merged and released in vLLM.
 
+> [!WARNING]
+> [KVCR PR #18](https://github.com/ai-dynamo/kvcr/pull/18) adopts the versioned
+> Dynamo-to-KVCR KV hint contract. Once that KVCR change is merged, use Dynamo with
+> [PR #13134](https://github.com/ai-dynamo/dynamo/pull/13134), or a later Dynamo
+> release that includes it. Older Dynamo versions produce an incompatible KV hint
+> contract, so KVCR cannot perform remote reuse.
+
 For source builds, editable installs, API development, or test workflows, use
 the [developer guide](dev-guide.md).
 

--- a/src/kvcr/hint_parser.py
+++ b/src/kvcr/hint_parser.py
@@ -1,23 +1,183 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-"""Hint protocol parsing."""
+"""Parse KV hint envelopes for KVCR fetch metadata.
+
+Hints are advisory request metadata. This module validates versioned KV hint
+envelopes, extracts the first usable ``kv.fetch`` action, and parses the
+fields KVCR consumes. Integration constants are exported by ``kvcr.__init__``.
+"""
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 
-ROUTER_HINT_KEY = "router_hint"
-ROUTER_HINT_CAPABILITIES = frozenset({ROUTER_HINT_KEY})
+# Public integration constants exported by kvcr.__init__.
+ROUTER_HINT_KEY = "kv_hint"
+ROUTER_HINT_CAPABILITIES = frozenset({"router_hint"})
+
+# Envelope/action versions currently understood by the parser.
+_KV_HINT_PROTOCOL_VERSION = "0.1"
+_KV_FETCH_ACTION_TYPE = "kv.fetch"
+_KV_FETCH_ACTION_VERSION = "1.0"
+
+# Hint parsing runs on the request path; suppress repeated warnings for the same
+# malformed integration issue.
+logger = logging.getLogger(__name__)
+_LOGGED_HINT_ISSUES: set[str] = set()
+
+
+def _warn_once(issue: str, message: str, *args: object) -> None:
+    """Log a parser warning at most once per issue kind.
+
+    Args:
+        issue: Stable identifier used to deduplicate warnings.
+        message: Warning message format string.
+        *args: Values interpolated into ``message``.
+    """
+    if issue in _LOGGED_HINT_ISSUES:
+        return
+    _LOGGED_HINT_ISSUES.add(issue)
+    logger.warning(message, *args)
+
+
+def _warn_version_mismatch(
+    *,
+    supported: object,
+    received: object,
+    issue: str,
+    message: str,
+) -> None:
+    """Warn once when a supported schema version does not match received value.
+
+    Args:
+        supported: Version string currently supported by the parser.
+        received: Version value from the hint envelope or action.
+        issue: Stable identifier used to deduplicate warnings.
+        message: Warning message format string for ``supported`` and
+            ``received``.
+    """
+    if received == supported:
+        return
+    _warn_once(issue, message, supported, received)
 
 
 def _parse_kv_hint(
-    payload: Mapping[str, object],
+    hint: Mapping[str, object],
 ) -> tuple[str | None, frozenset[int], str]:
-    """Validate a JSON-shaped router hint and extract KVCR-owned fields."""
-    if not isinstance(payload, Mapping):
+    """Parse a KV hint envelope into KVCR fetch metadata.
+
+    Hints are advisory and parsed on the request path. Version mismatches warn
+    once per issue kind and are interpreted with the schema KVCR currently
+    supports. KVCR consumes the first valid ``kv.fetch`` action in the envelope.
+
+    Args:
+        hint: Versioned KV hint envelope.
+
+    Returns:
+        A tuple (source, block_hashes, mode), where source is the optional
+        source control endpoint, block_hashes holds deduplicated block hashes,
+        and mode is the fetch mode.
+
+    Raises:
+        ValueError: If no usable ``kv.fetch`` action exists or the fetch
+            payload is malformed.
+    """
+    if not isinstance(hint, Mapping):
         raise ValueError("invalid router hint")
 
+    _warn_version_mismatch(
+        supported=_KV_HINT_PROTOCOL_VERSION,
+        received=hint.get("protocol_version"),
+        issue="protocol-version-mismatch",
+        message="KV hint protocol_version mismatch; supported=%r received=%r",
+    )
+
+    fetch_payload = _extract_kv_fetch_payload(hint)
+    return _parse_fetch_payload(fetch_payload)
+
+
+def _parse_fetch_action(action: object) -> Mapping[str, object] | None:
+    """Parse one envelope action as a ``kv.fetch`` payload.
+
+    Args:
+        action: Candidate action from a KV hint envelope.
+
+    Returns:
+        The action payload for a usable ``kv.fetch`` action, or None if the
+        action should be skipped.
+
+    Raises:
+        ValueError: If the action is ``kv.fetch`` but its payload is malformed.
+    """
+    if not isinstance(action, Mapping):
+        return None
+    if action.get("action_type") != _KV_FETCH_ACTION_TYPE:
+        return None
+
+    action_version = action.get("action_version")
+    _warn_version_mismatch(
+        supported=_KV_FETCH_ACTION_VERSION,
+        received=action_version,
+        issue=f"fetch-version-mismatch:{action_version}",
+        message=(
+            "kv.fetch action_version mismatch; supported=%r received=%r; "
+            "processing with supported schema"
+        ),
+    )
+
+    fetch_payload = action.get("payload")
+    if not isinstance(fetch_payload, Mapping):
+        raise ValueError("invalid router hint")
+    return fetch_payload
+
+
+def _extract_kv_fetch_payload(
+    hint: Mapping[str, object],
+) -> Mapping[str, object]:
+    """Extract the first ``kv.fetch`` action payload from a hint envelope.
+
+    Args:
+        hint: Versioned KV hint envelope.
+
+    Returns:
+        The payload mapping from the first usable ``kv.fetch`` action.
+
+    Raises:
+        ValueError: If ``actions`` is missing or malformed, no ``kv.fetch``
+            action exists, or the first matching action has a malformed
+            payload.
+    """
+    actions = hint.get("actions")
+    if not isinstance(actions, list):
+        raise ValueError("invalid router hint")
+
+    for action in actions:
+        payload = _parse_fetch_action(action)
+        if payload is not None:
+            return payload
+
+    raise ValueError("invalid router hint")
+
+
+def _parse_fetch_payload(
+    payload: Mapping[str, object],
+) -> tuple[str | None, frozenset[int], str]:
+    """Parse and validate fields from a ``kv.fetch`` action payload.
+
+    Args:
+        payload: ``kv.fetch`` action payload.
+
+    Returns:
+        A tuple (source, block_hashes, mode), where source is the optional
+        source control endpoint, block_hashes holds deduplicated block hashes,
+        and mode is the fetch mode.
+
+    Raises:
+        ValueError: If the payload does not match the supported router hint
+            shape.
+    """
     source = payload.get("source_control_endpoint")
     block_hashes = payload.get("block_hashes")
     mode = payload.get("mode", "copy")

--- a/src/kvcr/hint_parser.py
+++ b/src/kvcr/hint_parser.py
@@ -76,8 +76,8 @@ def _parse_kv_hint(
         hint: Versioned KV hint envelope.
 
     Returns:
-        A tuple (source, block_hashes, mode), where source is the optional
-        source control endpoint, block_hashes holds deduplicated block hashes,
+        A tuple (source, block_hashes, mode), where source is the source
+        control endpoint, block_hashes holds deduplicated block hashes,
         and mode is the fetch mode.
 
     Raises:
@@ -170,8 +170,8 @@ def _parse_fetch_payload(
         payload: ``kv.fetch`` action payload.
 
     Returns:
-        A tuple (source, block_hashes, mode), where source is the optional
-        source control endpoint, block_hashes holds deduplicated block hashes,
+        A tuple (source, block_hashes, mode), where source is the source
+        control endpoint, block_hashes holds deduplicated block hashes,
         and mode is the fetch mode.
 
     Raises:
@@ -182,7 +182,8 @@ def _parse_fetch_payload(
     block_hashes = payload.get("block_hashes")
     mode = payload.get("mode", "copy")
     if (
-        (source is not None and (not isinstance(source, str) or not source))
+        not isinstance(source, str)
+        or not source
         or not isinstance(block_hashes, list)
         or not isinstance(mode, str)
         or mode not in ("copy", "move")

--- a/src/kvcr/hint_parser.py
+++ b/src/kvcr/hint_parser.py
@@ -29,13 +29,7 @@ _LOGGED_HINT_ISSUES: set[str] = set()
 
 
 def _warn_once(issue: str, message: str, *args: object) -> None:
-    """Log a parser warning at most once per issue kind.
-
-    Args:
-        issue: Stable identifier used to deduplicate warnings.
-        message: Warning message format string.
-        *args: Values interpolated into ``message``.
-    """
+    """Log a parser warning at most once per issue kind."""
     if issue in _LOGGED_HINT_ISSUES:
         return
     _LOGGED_HINT_ISSUES.add(issue)
@@ -49,15 +43,7 @@ def _warn_version_mismatch(
     issue: str,
     message: str,
 ) -> None:
-    """Warn once when a supported schema version does not match received value.
-
-    Args:
-        supported: Version string currently supported by the parser.
-        received: Version value from the hint envelope or action.
-        issue: Stable identifier used to deduplicate warnings.
-        message: Warning message format string for ``supported`` and
-            ``received``.
-    """
+    """Warn once when a supported schema version does not match received value."""
     if received == supported:
         return
     _warn_once(issue, message, supported, received)
@@ -71,18 +57,6 @@ def _parse_kv_hint(
     Hints are advisory and parsed on the request path. Version mismatches warn
     once per issue kind and are interpreted with the schema KVCR currently
     supports. KVCR consumes the first valid ``kv.fetch`` action in the envelope.
-
-    Args:
-        hint: Versioned KV hint envelope.
-
-    Returns:
-        A tuple (source, block_hashes, mode), where source is the source
-        control endpoint, block_hashes holds deduplicated block hashes,
-        and mode is the fetch mode.
-
-    Raises:
-        ValueError: If no usable ``kv.fetch`` action exists or the fetch
-            payload is malformed.
     """
     if not isinstance(hint, Mapping):
         raise ValueError("invalid router hint")
@@ -99,18 +73,7 @@ def _parse_kv_hint(
 
 
 def _parse_fetch_action(action: object) -> Mapping[str, object] | None:
-    """Parse one envelope action as a ``kv.fetch`` payload.
-
-    Args:
-        action: Candidate action from a KV hint envelope.
-
-    Returns:
-        The action payload for a usable ``kv.fetch`` action, or None if the
-        action should be skipped.
-
-    Raises:
-        ValueError: If the action is ``kv.fetch`` but its payload is malformed.
-    """
+    """Parse one envelope action as a ``kv.fetch`` payload."""
     if not isinstance(action, Mapping):
         return None
     if action.get("action_type") != _KV_FETCH_ACTION_TYPE:
@@ -136,19 +99,7 @@ def _parse_fetch_action(action: object) -> Mapping[str, object] | None:
 def _extract_kv_fetch_payload(
     hint: Mapping[str, object],
 ) -> Mapping[str, object]:
-    """Extract the first ``kv.fetch`` action payload from a hint envelope.
-
-    Args:
-        hint: Versioned KV hint envelope.
-
-    Returns:
-        The payload mapping from the first usable ``kv.fetch`` action.
-
-    Raises:
-        ValueError: If ``actions`` is missing or malformed, no ``kv.fetch``
-            action exists, or the first matching action has a malformed
-            payload.
-    """
+    """Extract the first ``kv.fetch`` action payload from a hint envelope."""
     actions = hint.get("actions")
     if not isinstance(actions, list):
         raise ValueError("invalid router hint")
@@ -164,20 +115,8 @@ def _extract_kv_fetch_payload(
 def _parse_fetch_payload(
     payload: Mapping[str, object],
 ) -> tuple[str | None, frozenset[int], str]:
-    """Parse and validate fields from a ``kv.fetch`` action payload.
+    """Parse and validate fields from a ``kv.fetch`` action payload."""
 
-    Args:
-        payload: ``kv.fetch`` action payload.
-
-    Returns:
-        A tuple (source, block_hashes, mode), where source is the source
-        control endpoint, block_hashes holds deduplicated block hashes,
-        and mode is the fetch mode.
-
-    Raises:
-        ValueError: If the payload does not match the supported router hint
-            shape.
-    """
     source = payload.get("source_control_endpoint")
     block_hashes = payload.get("block_hashes")
     mode = payload.get("mode", "copy")

--- a/tests/unit/_kvcr_test_utils.py
+++ b/tests/unit/_kvcr_test_utils.py
@@ -46,11 +46,32 @@ _HANDED_OUT: set[int] = set()
 
 
 def _router_hint(
-    source: str, block_hashes: Collection[int] = (123,)
+    source: str | None,
+    block_hashes: Collection[int] = (123,),
+    *,
+    mode: str = "copy",
+    no_retain: bool | None = None,
 ) -> dict[str, object]:
-    return {
-        "source_control_endpoint": source,
+    payload: dict[str, object] = {
         "block_hashes": list(block_hashes),
+    }
+    if source is not None:
+        payload["source_control_endpoint"] = source
+    if mode != "copy":
+        payload["mode"] = mode
+    if no_retain is not None:
+        payload["no_retain"] = no_retain
+    return {
+        "protocol_version": "0.1",
+        "message_id": "test-message",
+        "actions": [
+            {
+                "action_id": "a1",
+                "action_type": "kv.fetch",
+                "action_version": "1.0",
+                "payload": payload,
+            }
+        ],
     }
 
 

--- a/tests/unit/test_hint_parser.py
+++ b/tests/unit/test_hint_parser.py
@@ -103,6 +103,7 @@ def test_parse_kv_hint_rejects_invalid_protocol(kv_hint: object) -> None:
 @pytest.mark.parametrize(
     "fetch_payload",
     [
+        {"block_hashes": [1]},
         {"source_control_endpoint": "", "block_hashes": [1]},
         {"source_control_endpoint": "tcp://source:1", "block_hashes": []},
         {"source_control_endpoint": "tcp://source:1", "block_hashes": [True]},

--- a/tests/unit/test_hint_parser.py
+++ b/tests/unit/test_hint_parser.py
@@ -1,16 +1,29 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import logging
+from collections.abc import Callable
+
 import pytest
+from _kvcr_test_utils import _router_hint
 
-from kvcr.hint_parser import _parse_kv_hint
+from kvcr.hint_parser import _LOGGED_HINT_ISSUES, _parse_kv_hint
 
 
-def test_parse_kv_hint_extracts_kvcr_fields() -> None:
+def test_parse_kv_hint_extracts_first_fetch_action() -> None:
+    fetch_hint = _router_hint("tcp://source:1234", (123, 456, 123))
     payload = {
-        "source_control_endpoint": "tcp://source:1234",
-        "block_hashes": [123, 456, 123],
-        "framework_hint": {"kept_out_of_kvcr": True},
+        "protocol_version": "0.1",
+        "message_id": "test-message",
+        "actions": [
+            {
+                "action_id": "ignored",
+                "action_type": "kv.future_action",
+                "action_version": "9.0",
+                "payload": {"opaque": True},
+            },
+            fetch_hint["actions"][0],
+        ],
     }
 
     assert _parse_kv_hint(payload) == (
@@ -19,24 +32,82 @@ def test_parse_kv_hint_extracts_kvcr_fields() -> None:
         "copy",
     )
 
-    assert _parse_kv_hint(
-        {"block_hashes": [123], "mode": "move", "no_retain": True}
-    ) == (None, frozenset({123}), "move")
+
+@pytest.mark.parametrize(
+    ("mutate_hint", "warning_text"),
+    [
+        (
+            lambda kv_hint: kv_hint.__setitem__("protocol_version", "9.0"),
+            "KV hint protocol_version mismatch",
+        ),
+        (
+            lambda kv_hint: kv_hint["actions"][0].__setitem__(
+                "action_version", "2.0"
+            ),
+            "kv.fetch action_version mismatch",
+        ),
+    ],
+)
+def test_parse_kv_hint_warns_but_reads_mismatched_versions(
+    caplog: pytest.LogCaptureFixture,
+    mutate_hint: Callable[[dict[str, object]], None],
+    warning_text: str,
+) -> None:
+    """Treat envelope/action version mismatches as advisory, not fatal."""
+    _LOGGED_HINT_ISSUES.clear()
+    kv_hint = _router_hint("tcp://source:1234", (123,))
+    mutate_hint(kv_hint)
+
+    with caplog.at_level(logging.WARNING):
+        parsed = _parse_kv_hint(kv_hint)
+
+    assert parsed == ("tcp://source:1234", frozenset({123}), "copy")
+    assert warning_text in caplog.text
 
 
 @pytest.mark.parametrize(
-    "payload",
+    "kv_hint",
     [
         None,
         {},
+        {"protocol_version": "0.1", "actions": "bad"},
+        {
+            "protocol_version": "0.1",
+            "actions": [
+                {
+                    "action_id": "a1",
+                    "action_type": "kv.future_action",
+                    "action_version": "1.0",
+                    "payload": {},
+                }
+            ],
+        },
+        {
+            "protocol_version": "0.1",
+            "actions": [
+                {
+                    "action_id": "a1",
+                    "action_type": "kv.fetch",
+                    "action_version": "1.0",
+                    "payload": "bad",
+                }
+            ],
+        },
+    ],
+)
+def test_parse_kv_hint_rejects_invalid_protocol(kv_hint: object) -> None:
+    with pytest.raises(ValueError, match="invalid router hint"):
+        _parse_kv_hint(kv_hint)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "fetch_payload",
+    [
         {"source_control_endpoint": "", "block_hashes": [1]},
         {"source_control_endpoint": "tcp://source:1", "block_hashes": []},
         {"source_control_endpoint": "tcp://source:1", "block_hashes": [True]},
         {"source_control_endpoint": "tcp://source:1", "block_hashes": [-1]},
-        {
-            "source_control_endpoint": "tcp://source:1",
-            "block_hashes": [1 << 64],
-        },
+        {"source_control_endpoint": "tcp://source:1", "block_hashes": [1 << 64]},
         {
             "source_control_endpoint": "tcp://source:1",
             "block_hashes": [1],
@@ -45,6 +116,17 @@ def test_parse_kv_hint_extracts_kvcr_fields() -> None:
         {"block_hashes": [1], "no_retain": "yes"},
     ],
 )
-def test_parse_kv_hint_rejects_invalid_protocol(payload: object) -> None:
+def test_parse_kv_hint_rejects_invalid_fetch_payload(fetch_payload: object) -> None:
+    """Reject malformed payloads on a matching ``kv.fetch`` action."""
+    kv_hint = _router_hint("tcp://source:1")
+    kv_hint["actions"] = [
+        {
+            "action_id": "a1",
+            "action_type": "kv.fetch",
+            "action_version": "1.0",
+            "payload": fetch_payload,
+        }
+    ]
+
     with pytest.raises(ValueError, match="invalid router hint"):
-        _parse_kv_hint(payload)  # type: ignore[arg-type]
+        _parse_kv_hint(kv_hint)

--- a/tests/unit/test_kvcr_remote_target.py
+++ b/tests/unit/test_kvcr_remote_target.py
@@ -67,16 +67,14 @@ def test_submit_hint_handles_source_less_protocol_hint():
         key_adapter=_ConstantHashAdapter(),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
     )
-    hint = {"block_hashes": [1], "no_retain": True}
-
-    target.submit_hint(hint, request_id="req")
+    target.submit_hint(_router_hint(None, (1,), no_retain=True), request_id="req")
 
     stored = target._core._remote_fw_dram._request_hints["req"]
     assert stored.source is None
     assert target.query((BlockKey(b"k"),), "req") == [(QueryStatus.MISS, None)]
 
     with pytest.raises(ValueError, match="only copy mode is currently supported"):
-        target.submit_hint({"block_hashes": [1], "mode": "move"})
+        target.submit_hint(_router_hint(None, (1,), mode="move"), request_id="move")
 
 
 def test_kvcr_opportunistic_query_accepts_key_outside_hint():

--- a/tests/unit/test_kvcr_remote_target.py
+++ b/tests/unit/test_kvcr_remote_target.py
@@ -59,7 +59,7 @@ def test_submit_hint_filters_unlisted_hash():
     assert target.query((BlockKey(b"k"),), "req") == [(QueryStatus.MISS, None)]
 
 
-def test_submit_hint_handles_source_less_protocol_hint():
+def test_submit_hint_rejects_source_less_protocol_hint():
     target = _new_kvcr(
         FakeNixlAgent(),
         FakePrimaryPinning(),
@@ -67,14 +67,9 @@ def test_submit_hint_handles_source_less_protocol_hint():
         key_adapter=_ConstantHashAdapter(),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
     )
-    target.submit_hint(_router_hint(None, (1,), no_retain=True), request_id="req")
 
-    stored = target._core._remote_fw_dram._request_hints["req"]
-    assert stored.source is None
-    assert target.query((BlockKey(b"k"),), "req") == [(QueryStatus.MISS, None)]
-
-    with pytest.raises(ValueError, match="only copy mode is currently supported"):
-        target.submit_hint(_router_hint(None, (1,), mode="move"), request_id="move")
+    with pytest.raises(ValueError, match="invalid router hint"):
+        target.submit_hint(_router_hint(None, (1,), no_retain=True), request_id="req")
 
 
 def test_kvcr_opportunistic_query_accepts_key_outside_hint():


### PR DESCRIPTION
## Purpose

Support versioned KV hint envelope in KVCR .

## Details

The parser now expects a versioned KV hint envelope, extracts the first usable `kv.fetch` action, validates the fetch payload, and passes the parsed source endpoint, block hashes, and mode into the existing remote framework-DRAM hint path.

Invalid or malformed hints continue to raise `ValueError`, preserving the existing parser behavior. 

Protocol- and action-version mismatches are advisory: KVCR logs a warning once per issue type, then parses the hint using the currently supported schema.

## Test Plan

- `pytest -q tests/unit/test_hint_parser.py tests/unit/test_kvcr_remote_target.py -k "hint or remote_staging or source_pin_miss" --tb=short`
- vLLM bridge check:
- `pytest -q tests/v1/kv_offload/tiering/test_kvcr_tier.py -k "router_hint or without_router_hint" --tb=short`
- e2e manual test from quick start + dynamo build with https://github.com/ai-dynamo/dynamo/pull/13134 