### PR TITLE
API update for multi-pool

### DIFF
--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -145,7 +145,7 @@ kvcr = KVCR(
 
 kvcr.deposit(blocks, no_evict=False, hints=None, callback=None)  # blocks: dict[BlockKey, list[MemDescriptor]]; completion includes per-key status and, with no_evict, a release handle
 kvcr.query(block_key_list, request_id=None) -> list[tuple[Status, CacheTier | None]] # HIT/MISS/FETCHING/FETCHABLE with known location
-kvcr.fetch(block_key_list, request_id=None, hints=None, expected_layouts=None, callback=None) -> OperationHandle # completion value is (list[MemDescriptor], release_handle)
+kvcr.fetch(block_key_list, request_id=None, expected_layout=None, hints=None, callback=None) -> OperationHandle # completion value is (list[MemDescriptor], release_handle)
 kvcr.deliver(destinations, request_id=None, callback=None) -> OperationHandle # destinations: dict[BlockKey, list[MemDescriptor]]
 kvcr.release(release_handle_list) -> list[Result[None, Error]]      # release fetch/no-evict claims
 
@@ -164,9 +164,10 @@ framework.release_pin(pin_handle)                                               
 
 The list-shaped API allows a key to span multiple pools. A descriptor's `info`
 can identify its pool and may be extended for other descriptor metadata.
-`fetch` may receive the expected layout for each key as a list of
-`(block_size_bytes, pool_name)` entries so KVCR can allocate the destinations
-immediately.
+`fetch` may receive the expected layout shared by its keys as an ordered list
+of pool names so KVCR can allocate the destinations. Repeated
+names represent multiple descriptors from the same pool. A single-pool caller
+using the empty pool name may omit it.
 
 ### Operating flow
 

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -102,7 +102,7 @@ Figure 1 summarizes the component boundaries.
 
 A KVCR-owned DRAM pool may be allocated by the framework and passed to KVCR, or owned by KVCR-Guard. This choice changes the pool lifetime and recovery guarantee, but not the cache API or policy semantics. The pool should remain near the GPUs it serves when the NUMA topology permits. When KVCR-Guard owns the pool, the active in-process KVCR attaches through a socket endpoint and then accesses the pool directly through shared memory, so normal cache operations require no IPC round trip.
 
-`KVLayoutManifest` identifies the framework, model, KV layout, and host representation needed to interpret cached data. A pool may contain multiple internal pools for different attention-head requirements. When `kvcr_guard_endpoint` is provided, KVCR attaches to the relevant preserved pool and verifies that the supplied manifest is compatible; initialization fails if the pool is unavailable or incompatible. Matching TP layouts are sufficient for most prefill-to-prefill, decode-to-decode, and aggregated deployments. A TP-independent host representation further removes that constraint as well.
+`compatibility_manifest` identifies the framework, model, KV layout, and host representation needed to interpret cached data. A pool may contain multiple internal pools for different attention-head requirements. When `kvcr_guard_endpoint` is provided, KVCR attaches to the relevant preserved pool and verifies that the supplied manifest is compatible; initialization fails if the pool is unavailable or incompatible.
 
 If the engine or GPU fails, KVCR-Guard fences the failed owner before activating its backup KVCR. A replacement in-process KVCR can attach to the preserved pool, recover the committed state, resynchronize inventory if needed, and assume ownership through a fenced handoff. Partial writes, in-flight operations, and framework-owned GPU or host memory are not recovered. Recovery and handoff must preserve committed-data integrity and prevent concurrent ownership.
 
@@ -136,17 +136,17 @@ The framework and KVCR interact through the following API.
 # Python-style pseudocode
 # Framework → KVCR
 kvcr = KVCR(
-    pools=[PoolSpec(...)],
-    layout_manifest=layout_manifest,
+    pool_layout=[(block_size_bytes, pool_name), ...],
+    compatibility_manifest=compatibility_manifest,
     kvcr_guard_endpoint=None,
     peer_control_endpoint=peer_control_endpoint,
     config=config,
 )
 
-kvcr.deposit(blocks, no_evict=False, hints=None, callback=None)  # blocks: dict[BlockKey, MemDescriptor]; completion value is None or (ptr, release_handle)
+kvcr.deposit(blocks, no_evict=False, hints=None, callback=None)  # blocks: dict[BlockKey, list[MemDescriptor]]; completion includes per-key status and, with no_evict, a release handle
 kvcr.query(block_key_list, request_id=None) -> list[tuple[Status, CacheTier | None]] # HIT/MISS/FETCHING/FETCHABLE with known location
-kvcr.fetch(block_key_list, request_id=None, hints=None, callback=None) -> OperationHandle # completion value is (ptr, release_handle)
-kvcr.deliver(destinations, request_id=None, callback=None) -> OperationHandle # destinations: dict[BlockKey, MemDescriptor]
+kvcr.fetch(block_key_list, request_id=None, hints=None, expected_layouts=None, callback=None) -> OperationHandle # completion value is (list[MemDescriptor], release_handle)
+kvcr.deliver(destinations, request_id=None, callback=None) -> OperationHandle # destinations: dict[BlockKey, list[MemDescriptor]]
 kvcr.release(release_handle_list) -> list[Result[None, Error]]      # release fetch/no-evict claims
 
 kvcr.poll_completed() -> list[Completion]                          # drain individual completions
@@ -162,6 +162,12 @@ framework.cancel_pin_request(pin_request_id)                                    
 framework.release_pin(pin_handle)                                                 # release an acquired framework-owned source pin
 ```
 
+The list-shaped API allows a key to span multiple pools. A descriptor's `info`
+can identify its pool and may be extended for other descriptor metadata.
+`fetch` may receive the expected layout for each key as a list of
+`(block_size_bytes, pool_name)` entries so KVCR can allocate the destinations
+immediately.
+
 ### Operating flow
 
 **Using KVCR-owned DRAM**
@@ -170,7 +176,7 @@ framework.release_pin(pin_handle)                                               
 
 `fetch`/`release` — framework asks the KVCR to make a block resident in its KVCR-owned DRAM pool and pin it there. On success, `fetch` returns the resident pointer and a release handle; the framework calls `deliver` to place the block into a framework-provided destination and calls `release` when the pool claim is no longer needed.
 
-`deposit` also accepts a `no_evict` flag (batch-level, applies to all entries): when set, the KVCR keeps every completed slot non-evictable and returns the pointer plus release handle per entry. A framework that wants guaranteed local DRAM residency behavior for selected KV blocks can get that behavior through `no_evict`, while the KVCR still handles sharing, routing visibility, transfer setup, and tiering policy. The framework calls `release` with the corresponding handle to clear the no-evict claim.
+`deposit` also accepts a `no_evict` flag (batch-level, applies to all entries): when set, the KVCR keeps every completed slot non-evictable and returns a release handle per entry. A framework that wants guaranteed local DRAM residency behavior for selected KV blocks can get that behavior through `no_evict`, while the KVCR still handles sharing, routing visibility, transfer setup, and tiering policy. The framework calls `release` with the corresponding handle to clear the no-evict claim.
 
 The tradeoff is backpressure: when policy cannot free enough capacity—for example, because `no_evict` claims occupy the pool or an attempted eviction does not free its source—KVCR may invoke `capacity_needed` as a last-resort pressure signal. The framework should release enough claims to free the requested slots. If sufficient capacity remains unavailable, affected committed entries complete with errors. Pool size and the free-slot threshold that triggers `capacity_needed` are deployment knobs.
 
@@ -237,7 +243,7 @@ KVCR-to-KVCR movement is destination-initiated. A router hint gives the destinat
 
 `submit_hint` may establish the peer connection, but does not start data movement or remote pinning; proactive fetching, staging, or pinning may be added later if useful. `discard_hint` normally reports that the relevant request is over, and also permits an integration to discard the request-scoped hint early. A route-time `submit_hint` may carry a whole `BlockKeyList` from one source. In the future, if necessary, multi-source assembly can be added by splitting the list into multiple hinted operations.
 
-The router may choose not to send a hint based on its internal cost model. Router hints may later be extended to request proactive copy or move for cache rebalancing, which may require periodic utilization reports from KVCR.
+The router may choose not to send a hint based on its internal cost model. Router hints may later be extended to request proactive copy or move for cache rebalancing, which may require periodic utilization reports from KVCR. The router also considers sending hints for matching TP layouts, meaning prefill-to-prefill, decode-to-decode, and aggregated deployments, which cover many use cases. A TP-independent host representation further removes that constraint.
 
 ### Peer control and liveness
 

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -136,7 +136,7 @@ The framework and KVCR interact through the following API.
 # Python-style pseudocode
 # Framework → KVCR
 kvcr = KVCR(
-    pool_layout=[(block_size_bytes, pool_name), ...],
+    pool_layouts=[(pool_name, block_size_bytes), ...],
     compatibility_manifest=compatibility_manifest,
     kvcr_guard_endpoint=None,
     peer_control_endpoint=peer_control_endpoint,
@@ -165,9 +165,9 @@ framework.release_pin(pin_handle)                                               
 The list-shaped API allows a key to span multiple pools. A descriptor's `info`
 can identify its pool and may be extended for other descriptor metadata.
 `fetch` may receive the expected layout shared by its keys as an ordered list
-of pool names so KVCR can allocate the destinations. Repeated
-names represent multiple descriptors from the same pool. A single-pool caller
-using the empty pool name may omit it.
+of pool names so KVCR can allocate the destinations. Repeated names represent
+multiple descriptors from the same pool. A single-pool caller using the empty
+pool name may omit it.
 
 ### Operating flow
 

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -213,7 +213,10 @@ from kvcr import KVCR, KVCRBindings
 from kvcr.config import KVCRBackendConfigs, KVCRConfig
 
 runner = KVCR(
-    config=KVCRConfig(nixl_agent_name="worker-0"),
+    config=KVCRConfig(
+        nixl_agent_name="worker-0",
+        pool_layout=[(block_size_bytes, "")],
+    ),
     bindings=KVCRBindings(
         request_pin=request_pin,
         poll_pin_results=poll_pin_results,
@@ -337,19 +340,19 @@ python -m kvcr.kvcr_service \
 
 The service rounds each pool size down to a memory-page boundary and adds one
 fixed 100 MiB journal to each Guard allocation. For example, `48,16` maps 64
-GiB plus the journal for every Guard. Until grouped grants are introduced, the
-current claim path exposes those pool regions as one combined data area.
+GiB plus the journal for every Guard. The current claim path exposes those
+regions as one combined data area.
 
 The pre-release wire protocol remains version 1. A worker calls
-`KVCRClient.claim(guard_index, row_stride, compatibility_digest, control_bind)`,
+`KVCRClient.claim(guard_index, pool_layout, compatibility_digest, control_bind)`,
 naming the address its Guard will answer on. The digest must match the service
-exactly, and callers must change it whenever the row stride or any other
-KV-cache layout term changes. The returned `KVCRPoolHold` describes the mapped
-local DRAM and owns an exclusive lease on the pool. Each claim is measured
-against its own pool only; pools do not have to agree on a stride.
+exactly, and callers must change it whenever the pool layout or any other KV-cache
+term changes. The returned `KVCRPoolHold` describes the mapped local DRAM and
+owns an exclusive lease on the pool. Only one pool-layout entry is currently
+supported; an empty string is a valid pool name.
 
 **A pool's configuration is fixed by its first claim.** Every later claim on
-that pool must name the same row stride and, when G3 is configured, the same
+that pool must name the same pool layout and, when G3 is configured, the same
 G3 paths in the same order, the same per-file capacity, and the same backend
 and backend options. It must also name the same remote framework DRAM backend.
 A mismatch is refused for the life of the service. Change the configuration by

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -215,7 +215,7 @@ from kvcr.config import KVCRBackendConfigs, KVCRConfig
 runner = KVCR(
     config=KVCRConfig(
         nixl_agent_name="worker-0",
-        pool_layout=[(block_size_bytes, "")],
+        pool_layouts=[("", block_size_bytes)],
     ),
     bindings=KVCRBindings(
         request_pin=request_pin,
@@ -344,12 +344,13 @@ GiB plus the journal for every Guard. The current claim path exposes those
 regions as one combined data area.
 
 The pre-release wire protocol remains version 1. A worker calls
-`KVCRClient.claim(guard_index, pool_layout, compatibility_digest, control_bind)`,
+`KVCRClient.claim(guard_index, pool_layouts, compatibility_digest, control_bind)`,
 naming the address its Guard will answer on. The digest must match the service
-exactly, and callers must change it whenever the pool layout or any other KV-cache
-term changes. The returned `KVCRPoolHold` describes the mapped local DRAM and
-owns an exclusive lease on the pool. Only one pool-layout entry is currently
-supported; an empty string is a valid pool name.
+exactly, and each pool-layout entry is `(pool_name, block_size_bytes)`. Callers must
+change the digest whenever the pool layout or any other KV-cache term changes.
+The returned `KVCRPoolHold` describes the mapped local DRAM and owns an exclusive
+lease on the pool. Only one pool-layout entry is currently supported; an empty
+string is a valid pool name.
 
 **A pool's configuration is fixed by its first claim.** Every later claim on
 that pool must name the same pool layout and, when G3 is configured, the same

--- a/src/kvcr/api.py
+++ b/src/kvcr/api.py
@@ -92,7 +92,7 @@ class KVCR:
                 core = _KVCRCore(config, bindings, backend_configs)
             else:
                 claimed = _recovery.claim_guarded_pool(
-                    guard_config, bindings, backend_configs
+                    config, guard_config, bindings, backend_configs
                 )
                 pool_hold = claimed.hold
                 core = _recovery.claimed_core(
@@ -147,7 +147,7 @@ class KVCR:
 
     def deliver(
         self,
-        blocks: Mapping[BlockKey, MemDescriptor],
+        blocks: Mapping[BlockKey, list[MemDescriptor]],
         request_id: str | None = None,
     ) -> OpHandle:
         """Asynchronously deliver blocks to caller-provided destinations."""
@@ -155,7 +155,7 @@ class KVCR:
 
     def deposit(
         self,
-        blocks: Mapping[BlockKey, MemDescriptor],
+        blocks: Mapping[BlockKey, list[MemDescriptor]],
         no_evict: bool = False,
         hints: object | None = None,
     ) -> OpHandle:
@@ -167,9 +167,10 @@ class KVCR:
         keys: Collection[BlockKey],
         request_id: str | None = None,
         hints: object | None = None,
+        expected_layouts: Mapping[BlockKey, list[tuple[int, str]]] | None = None,
     ) -> OpHandle:
         """Asynchronously fetch blocks into KVCR-managed storage."""
-        return self._core.fetch(keys, request_id, hints)
+        return self._core.fetch(keys, request_id, hints, expected_layouts)
 
     def release(
         self,

--- a/src/kvcr/api.py
+++ b/src/kvcr/api.py
@@ -166,11 +166,11 @@ class KVCR:
         self,
         keys: Collection[BlockKey],
         request_id: str | None = None,
+        expected_layout: list[str] | None = None,
         hints: object | None = None,
-        expected_layouts: Mapping[BlockKey, list[tuple[int, str]]] | None = None,
     ) -> OpHandle:
         """Asynchronously fetch blocks into KVCR-managed storage."""
-        return self._core.fetch(keys, request_id, hints, expected_layouts)
+        return self._core.fetch(keys, request_id, expected_layout, hints)
 
     def release(
         self,

--- a/src/kvcr/config.py
+++ b/src/kvcr/config.py
@@ -18,8 +18,7 @@ InventorySink = Callable[[InventoryEvent], None]
 @dataclass(frozen=True)
 class LocalDramOptions:
     address: int
-    length: int
-    slot_count: int
+    pool_sizes_bytes: list[tuple[int, str]]
     backend: str = "UCX"
 
 
@@ -105,6 +104,7 @@ class KeyAdapter(Protocol):
 @dataclass(frozen=True)
 class KVCRConfig:
     nixl_agent_name: str
+    pool_layout: list[tuple[int, str]]
     enable_telemetry: bool = False
     operation_timeout_ms: int = 1000
     inventory_report_interval_ms: int = 10
@@ -116,5 +116,4 @@ class KVCRConfig:
 class KVCRGuardConfig:
     kvcr_service_socket_path: str
     guard_index: int
-    row_stride: int
     compatibility_digest: str

--- a/src/kvcr/config.py
+++ b/src/kvcr/config.py
@@ -15,6 +15,22 @@ from .types import (
 InventorySink = Callable[[InventoryEvent], None]
 
 
+def _validate_pool_layout(pool_layout: list[tuple[int, str]]) -> None:
+    if not pool_layout:
+        raise ValueError("pool_layout must contain at least one pool")
+    names = []
+    for block_size_bytes, pool_name in pool_layout:
+        if type(block_size_bytes) is not int or block_size_bytes <= 0:
+            raise ValueError("pool_layout block size must be a positive integer")
+        if not isinstance(pool_name, str):
+            raise ValueError("pool_layout pool name must be a string")
+        names.append(pool_name)
+    if len(names) != len(set(names)):
+        raise ValueError("pool_layout pool names must be unique")
+    if len(names) > 1 and "" in names:
+        raise ValueError("pool_layout cannot use an empty name with multiple pools")
+
+
 @dataclass(frozen=True)
 class LocalDramOptions:
     address: int

--- a/src/kvcr/config.py
+++ b/src/kvcr/config.py
@@ -10,31 +10,32 @@ from typing import Protocol
 from .types import (
     BlockKey,
     InventoryEvent,
+    LocalDramRegions,
+    PoolBlockLayouts,
 )
 
 InventorySink = Callable[[InventoryEvent], None]
 
 
-def _validate_pool_layout(pool_layout: list[tuple[int, str]]) -> None:
-    if not pool_layout:
-        raise ValueError("pool_layout must contain at least one pool")
+def _validate_pool_layouts(pool_layouts: PoolBlockLayouts) -> None:
+    if not pool_layouts:
+        raise ValueError("pool_layouts must contain at least one pool")
     names = []
-    for block_size_bytes, pool_name in pool_layout:
-        if type(block_size_bytes) is not int or block_size_bytes <= 0:
-            raise ValueError("pool_layout block size must be a positive integer")
+    for pool_name, block_size_bytes in pool_layouts:
         if not isinstance(pool_name, str):
-            raise ValueError("pool_layout pool name must be a string")
+            raise ValueError("pool_layouts pool name must be a string")
+        if type(block_size_bytes) is not int or block_size_bytes <= 0:
+            raise ValueError("pool_layouts block size must be a positive integer")
         names.append(pool_name)
     if len(names) != len(set(names)):
-        raise ValueError("pool_layout pool names must be unique")
+        raise ValueError("pool_layouts pool names must be unique")
     if len(names) > 1 and "" in names:
-        raise ValueError("pool_layout cannot use an empty name with multiple pools")
+        raise ValueError("pool_layouts cannot use an empty name with multiple pools")
 
 
 @dataclass(frozen=True)
 class LocalDramOptions:
-    address: int
-    pool_sizes_bytes: list[tuple[int, str]]
+    pools: LocalDramRegions
     backend: str = "UCX"
 
 
@@ -120,7 +121,7 @@ class KeyAdapter(Protocol):
 @dataclass(frozen=True)
 class KVCRConfig:
     nixl_agent_name: str
-    pool_layout: list[tuple[int, str]]
+    pool_layouts: PoolBlockLayouts
     enable_telemetry: bool = False
     operation_timeout_ms: int = 1000
     inventory_report_interval_ms: int = 10

--- a/src/kvcr/core.py
+++ b/src/kvcr/core.py
@@ -115,6 +115,15 @@ class _KVCRCore:
         backend_configs: KVCRBackendConfigs,
     ) -> None:
         self.config = config
+        self.pool_layout = list(config.pool_layout)
+        # TODO: Support multiple pools after remote fetch and G3 discover layouts.
+        if len(self.pool_layout) != 1:
+            raise ValueError("only a single pool is currently supported")
+        self.block_size_bytes, pool_name = self.pool_layout[0]
+        if type(self.block_size_bytes) is not int or self.block_size_bytes <= 0:
+            raise ValueError("pool_layout block size must be a positive integer")
+        if not isinstance(pool_name, str):
+            raise ValueError("pool_layout pool name must be a string")
         if self.config.operation_timeout_ms <= 0:
             raise ValueError("operation_timeout_ms must be positive")
         if self.config.inventory_report_interval_ms < 0:
@@ -156,11 +165,6 @@ class _KVCRCore:
         self._block_record_map: dict[BlockKey, _BlockRecord] = {}
         self._pending_inventory_events: list[InventoryEvent] = []
         self._inventory_flush_deadline: float | None = None
-        self._capacity_low_watermark_slots = ceil(
-            (local_dram_config.slot_count if local_dram_config else 0)
-            * self.config.capacity_low_watermark_percent
-            / 100
-        )
         self._capacity_pressure_active = False
         self._closed = False
         self._outstanding_operations = 0
@@ -205,6 +209,11 @@ class _KVCRCore:
             if local_dram_config is not None
             else None
         )
+        self._capacity_low_watermark_slots = ceil(
+            (self._local_dram._total_slots if self._local_dram is not None else 0)
+            * self.config.capacity_low_watermark_percent
+            / 100
+        )
         self._remote_fw_dram = _RemoteFWDram(
             self,
             backend_configs.remote_fw_dram,
@@ -214,7 +223,7 @@ class _KVCRCore:
             _G3(
                 self,
                 g3_config,
-                local_dram_config.length // local_dram_config.slot_count,
+                self.block_size_bytes,
             )
             if g3_config is not None and local_dram_config is not None
             else None
@@ -348,17 +357,21 @@ class _KVCRCore:
     # TODO: Add optional completion callbacks to movement APIs.
     def deliver(
         self,
-        blocks: Mapping[BlockKey, MemDescriptor],
+        blocks: Mapping[BlockKey, list[MemDescriptor]],
         request_id: str | None = None,
     ) -> OpHandle:
         op_handle = self._next_op_handle
         self._next_op_handle += 1
         deadline = self._operation_deadline()
         local_dram = self._local_dram
+        normalized = {
+            key: self._normalize_descriptors(descriptors)
+            for key, descriptors in blocks.items()
+        }
         local_blocks: dict[BlockKey, MemDescriptor] = {}
         g3_blocks: dict[BlockKey, MemDescriptor] = {}
         remote_blocks: dict[BlockKey, MemDescriptor] = {}
-        for key, destination in blocks.items():
+        for key, destination in normalized.items():
             if self._is_local_resident(key):
                 local_blocks[key] = destination
             elif self._g3 is not None and self._g3.is_ready(key):
@@ -388,7 +401,7 @@ class _KVCRCore:
 
     def deposit(
         self,
-        blocks: Mapping[BlockKey, MemDescriptor],
+        blocks: Mapping[BlockKey, list[MemDescriptor]],
         no_evict: bool = False,
         hints: object | None = None,
     ) -> OpHandle:
@@ -400,7 +413,15 @@ class _KVCRCore:
                 {key: OpEntryResult(OpEntryStatus.FAILED) for key in blocks},
             )
         else:
-            self._local_dram.deposit(op_handle, blocks, no_evict=no_evict, hints=hints)
+            self._local_dram.deposit(
+                op_handle,
+                {
+                    key: self._normalize_descriptors(descriptors)
+                    for key, descriptors in blocks.items()
+                },
+                no_evict=no_evict,
+                hints=hints,
+            )
         return op_handle
 
     def fetch(
@@ -408,11 +429,16 @@ class _KVCRCore:
         keys: Collection[BlockKey],
         request_id: str | None = None,
         hints: object | None = None,
+        expected_layouts: Mapping[BlockKey, list[tuple[int, str]]] | None = None,
     ) -> OpHandle:
         op_handle = self._next_op_handle
         self._next_op_handle += 1
         local_dram = self._local_dram
         ordered_keys = tuple(dict.fromkeys(keys))
+        if expected_layouts is not None and any(
+            expected_layouts.get(key) != self.pool_layout for key in ordered_keys
+        ):
+            raise ValueError("expected layouts must match the configured pool_layout")
         if local_dram is None:
             self._complete(
                 op_handle,
@@ -671,6 +697,18 @@ class _KVCRCore:
                 sources.update(claimed)
                 self._local_dram_sources_by_op[op_id] = sources
         return sources
+
+    def _normalize_descriptors(self, descriptors: list[MemDescriptor]) -> MemDescriptor:
+        if not isinstance(descriptors, list):
+            raise TypeError("block descriptors must be a list")
+        if len(descriptors) != 1 or not isinstance(descriptors[0], MemDescriptor):
+            raise ValueError("each block requires exactly one descriptor")
+        descriptor = descriptors[0]
+        if descriptor.info != self.pool_layout[0][1]:
+            raise ValueError(f"unknown descriptor pool {descriptor.info!r}")
+        if descriptor.size != self.block_size_bytes:
+            raise ValueError("block descriptor has the wrong byte count")
+        return descriptor
 
     def _release_local_dram_sources(
         self,

--- a/src/kvcr/core.py
+++ b/src/kvcr/core.py
@@ -14,6 +14,7 @@ from .config import (
     KVCRBackendConfigs,
     KVCRConfig,
     TelemetryStats,
+    _validate_pool_layout,
 )
 from .hint_parser import _parse_kv_hint
 from .local_disk import _G3, _G3Residency
@@ -116,14 +117,11 @@ class _KVCRCore:
     ) -> None:
         self.config = config
         self.pool_layout = list(config.pool_layout)
+        _validate_pool_layout(self.pool_layout)
         # TODO: Support multiple pools after remote fetch and G3 discover layouts.
         if len(self.pool_layout) != 1:
             raise ValueError("only a single pool is currently supported")
-        self.block_size_bytes, pool_name = self.pool_layout[0]
-        if type(self.block_size_bytes) is not int or self.block_size_bytes <= 0:
-            raise ValueError("pool_layout block size must be a positive integer")
-        if not isinstance(pool_name, str):
-            raise ValueError("pool_layout pool name must be a string")
+        self.block_size_bytes = self.pool_layout[0][0]
         if self.config.operation_timeout_ms <= 0:
             raise ValueError("operation_timeout_ms must be positive")
         if self.config.inventory_report_interval_ms < 0:
@@ -428,17 +426,16 @@ class _KVCRCore:
         self,
         keys: Collection[BlockKey],
         request_id: str | None = None,
+        expected_layout: list[str] | None = None,
         hints: object | None = None,
-        expected_layouts: Mapping[BlockKey, list[tuple[int, str]]] | None = None,
     ) -> OpHandle:
+        expected_layout = [""] if expected_layout is None else expected_layout
+        if expected_layout != [self.pool_layout[0][1]]:
+            raise ValueError("expected layout must match the configured pool_layout")
         op_handle = self._next_op_handle
         self._next_op_handle += 1
         local_dram = self._local_dram
         ordered_keys = tuple(dict.fromkeys(keys))
-        if expected_layouts is not None and any(
-            expected_layouts.get(key) != self.pool_layout for key in ordered_keys
-        ):
-            raise ValueError("expected layouts must match the configured pool_layout")
         if local_dram is None:
             self._complete(
                 op_handle,

--- a/src/kvcr/core.py
+++ b/src/kvcr/core.py
@@ -14,7 +14,7 @@ from .config import (
     KVCRBackendConfigs,
     KVCRConfig,
     TelemetryStats,
-    _validate_pool_layout,
+    _validate_pool_layouts,
 )
 from .hint_parser import _parse_kv_hint
 from .local_disk import _G3, _G3Residency
@@ -116,12 +116,12 @@ class _KVCRCore:
         backend_configs: KVCRBackendConfigs,
     ) -> None:
         self.config = config
-        self.pool_layout = list(config.pool_layout)
-        _validate_pool_layout(self.pool_layout)
+        self.pool_layouts = list(config.pool_layouts)
+        _validate_pool_layouts(self.pool_layouts)
         # TODO: Support multiple pools after remote fetch and G3 discover layouts.
-        if len(self.pool_layout) != 1:
+        if len(self.pool_layouts) != 1:
             raise ValueError("only a single pool is currently supported")
-        self.block_size_bytes = self.pool_layout[0][0]
+        self.block_size_bytes = self.pool_layouts[0][1]
         if self.config.operation_timeout_ms <= 0:
             raise ValueError("operation_timeout_ms must be positive")
         if self.config.inventory_report_interval_ms < 0:
@@ -430,8 +430,8 @@ class _KVCRCore:
         hints: object | None = None,
     ) -> OpHandle:
         expected_layout = [""] if expected_layout is None else expected_layout
-        if expected_layout != [self.pool_layout[0][1]]:
-            raise ValueError("expected layout must match the configured pool_layout")
+        if expected_layout != [self.pool_layouts[0][0]]:
+            raise ValueError("expected layout must match the configured pool_layouts")
         op_handle = self._next_op_handle
         self._next_op_handle += 1
         local_dram = self._local_dram
@@ -701,7 +701,7 @@ class _KVCRCore:
         if len(descriptors) != 1 or not isinstance(descriptors[0], MemDescriptor):
             raise ValueError("each block requires exactly one descriptor")
         descriptor = descriptors[0]
-        if descriptor.info != self.pool_layout[0][1]:
+        if descriptor.info != self.pool_layouts[0][0]:
             raise ValueError(f"unknown descriptor pool {descriptor.info!r}")
         if descriptor.size != self.block_size_bytes:
             raise ValueError("block descriptor has the wrong byte count")

--- a/src/kvcr/guard.py
+++ b/src/kvcr/guard.py
@@ -187,11 +187,11 @@ class _RecoveryState:
         self.attachment = KVCRPoolAttachment.attach(self._spec)
         self._journal = RecoveryJournal(self.attachment)
 
-    def recover(self, row_stride: int) -> _RecoveryMirror:
-        """Return held recovery or read the prior handback under this stride."""
+    def recover(self, pool_layout: list[tuple[int, str]]) -> _RecoveryMirror:
+        """Return held recovery or read the prior handback under this pool layout."""
         if self.mirror is not None:
             return self.mirror
-        return read_handback(self.attachment, self._compatibility_digest, row_stride)
+        return read_handback(self.attachment, self._compatibility_digest, pool_layout)
 
     def start_primary(self) -> None:
         """Arm recovery for the accepted primary and reset its journal."""
@@ -248,10 +248,15 @@ class _RecoveryState:
         return _without_g3(records)
 
     def local_dram_info(
-        self, effective_bytes: int, rows: int, backend: str
+        self,
+        effective_bytes: int,
+        pool_name: str,
+        backend: str,
     ) -> LocalDramOptions:
         return LocalDramOptions(
-            self.attachment.data_address, effective_bytes, rows, backend
+            self.attachment.data_address,
+            [(effective_bytes, pool_name)],
+            backend,
         )
 
     def release_snapshot_region(self) -> None:
@@ -263,12 +268,16 @@ class _RecoveryState:
     # replacement serves whatever is in the slots. Refusing two pools that name
     # the same paths is the cheap first step; it does not cover a second
     # service, or a KVCR using G3 with no pool at all.
-    def hand_back(self, records: dict[BlockKey, _BlockRecord], row_stride: int) -> None:
-        """Write and mirror a closed core's map under the stride it served."""
+    def hand_back(
+        self,
+        records: dict[BlockKey, _BlockRecord],
+        pool_layout: list[tuple[int, str]],
+    ) -> None:
+        """Write and mirror a closed core's map under its pool layout."""
         mirror = self.mirror
         records = _with_g3(records, self._g3_records)
         try:
-            self._write_handback(records, row_stride)
+            self._write_handback(records, pool_layout)
         except OSError as error:
             if error.errno not in _RECOVERY_CAPACITY_ERRORS:
                 raise
@@ -278,13 +287,13 @@ class _RecoveryState:
             mirror.adopt(records)
         self._g3_records = {}
 
-    def release(self, row_stride: int) -> None:
+    def release(self, pool_layout: list[tuple[int, str]]) -> None:
         """Write the current primary's journal tail, then drop its mirror."""
         mirror = self.mirror
         try:
             while (frame := self._journal.read_next()) is not None:
                 mirror.apply(*frame)
-            self._write_handback(mirror.take_records(), row_stride)
+            self._write_handback(mirror.take_records(), pool_layout)
         except RecoveryJournalError as error:
             self._drop_recovery(error)
         except OSError as error:
@@ -303,11 +312,11 @@ class _RecoveryState:
     def _write_handback(
         self,
         records: Mapping[BlockKey, _BlockRecord],
-        row_stride: int,
+        pool_layout: list[tuple[int, str]],
     ) -> None:
         write_recovery_snapshot(
             self.attachment,
-            canonical_pool_terms(self._compatibility_digest, row_stride, self._spec),
+            canonical_pool_terms(self._compatibility_digest, pool_layout, self._spec),
             _recovery_frames(records),
         )
 
@@ -727,11 +736,11 @@ class _Guard:
             if self._failure is not None:
                 raise self._failure
             self._refuse_incompatible(tier_config)
-            served_under = self._configured.row_stride if self._configured else 0
+            served_under = self._configured.pool_layout if self._configured else ()
             # The prior handback is this lease's baseline. Read now, under
-            # the claim's stride: refusing at promotion stops the service,
+            # the claim's pool layout: refusing at promotion stops the service,
             # and a claimant dying in between takes everything with it.
-            recovered = self._recovery.recover(tier_config.row_stride)
+            recovered = self._recovery.recover(tier_config.pool_layout)
             # Last, once nothing left can refuse this claim: a pool whose handback
             # would not replay has not chosen anything, and a corrected claim can
             # still have it.
@@ -766,11 +775,11 @@ class _Guard:
         if self._failure is not None:
             raise self._failure
         if self._serving:
-            self._hand_back(self._configured.row_stride)
+            self._hand_back(self._configured.pool_layout)
             # Re-adopt lets start_primary() retain or replace the mirror.
             self._recovery.mirror = None
         elif self._recovery.mirror is not None:
-            self._recovery.release(self._configured.row_stride)
+            self._recovery.release(self._configured.pool_layout)
         if self._control is not None:
             self._control.close()
             self._control = None
@@ -778,7 +787,7 @@ class _Guard:
     def _refuse_incompatible(self, tier_config: _TierConfig) -> None:
         """Refuse tiers other than the ones this pool was claimed with.
         The first claim fixes configuration for the service's lifetime: the
-        bytes stay, and a changed stride or G3 path order misnames every slot.
+        bytes stay, and a changed pool layout or G3 path order misnames every slot.
         """
         if self._configured is not None and self._configured != tier_config:
             raise RecoveryMirrorError(
@@ -789,7 +798,7 @@ class _Guard:
         """Take up this primary's tiers: the geometry check runs before the
         assignment, so a bad configuration leaves the old one intact.
         """
-        _compute_pool_geometry(self._spec.data_bytes, tier_config.row_stride)
+        _compute_pool_geometry(self._spec.data_bytes, tier_config.pool_layout[0][0])
         self._configured = tier_config
 
     def _poll(self) -> bool:
@@ -848,15 +857,17 @@ class _Guard:
         def reject_pin(keys: object) -> int:
             raise RuntimeError("Guard has no framework-owned memory")
 
-        effective_bytes, rows = _compute_pool_geometry(
-            self._spec.data_bytes, self._configured.row_stride
-        )
+        block_size, pool_name = self._configured.pool_layout[0]
+        effective_bytes, _ = _compute_pool_geometry(self._spec.data_bytes, block_size)
         dram = self._recovery.local_dram_info(
-            effective_bytes, rows, self._configured.remote_fw_dram_backend
+            effective_bytes,
+            pool_name,
+            self._configured.remote_fw_dram_backend,
         )
         core = _KVCRCore(
             KVCRConfig(
                 nixl_agent_name=f"KVCR-Guard-{uuid.uuid4()}",
+                pool_layout=list(self._configured.pool_layout),
                 inventory_report_interval_ms=0,
                 nixl_listen_port=0,
             ),
@@ -882,7 +893,7 @@ class _Guard:
         core.start()
         self._serving = True
 
-    def _hand_back(self, row_stride: int) -> None:
+    def _hand_back(self, pool_layout: list[tuple[int, str]]) -> None:
         """Stop serving, leaving this pool's state where the next primary looks.
         The core closes first: the Guard stops answering, and region and
         records both come from the map close leaves behind.
@@ -891,7 +902,7 @@ class _Guard:
         if core is None or self._recovery.mirror is None:
             raise RecoveryMirrorError("a serving Guard has no state to hand back")
         core.close()
-        self._recovery.hand_back(core._block_record_map, row_stride)
+        self._recovery.hand_back(core._block_record_map, pool_layout)
         self._core = None
         self._serving = False
 

--- a/src/kvcr/guard.py
+++ b/src/kvcr/guard.py
@@ -44,7 +44,7 @@ from .recovery_journal import (
     read_handback,
     write_recovery_snapshot,
 )
-from .types import BlockKey
+from .types import BlockKey, PoolBlockLayouts
 
 logger = logging.getLogger(__name__)
 
@@ -187,11 +187,11 @@ class _RecoveryState:
         self.attachment = KVCRPoolAttachment.attach(self._spec)
         self._journal = RecoveryJournal(self.attachment)
 
-    def recover(self, pool_layout: list[tuple[int, str]]) -> _RecoveryMirror:
+    def recover(self, pool_layouts: PoolBlockLayouts) -> _RecoveryMirror:
         """Return held recovery or read the prior handback under this pool layout."""
         if self.mirror is not None:
             return self.mirror
-        return read_handback(self.attachment, self._compatibility_digest, pool_layout)
+        return read_handback(self.attachment, self._compatibility_digest, pool_layouts)
 
     def start_primary(self) -> None:
         """Arm recovery for the accepted primary and reset its journal."""
@@ -254,8 +254,7 @@ class _RecoveryState:
         backend: str,
     ) -> LocalDramOptions:
         return LocalDramOptions(
-            self.attachment.data_address,
-            [(effective_bytes, pool_name)],
+            [(pool_name, self.attachment.data_address, effective_bytes)],
             backend,
         )
 
@@ -271,13 +270,13 @@ class _RecoveryState:
     def hand_back(
         self,
         records: dict[BlockKey, _BlockRecord],
-        pool_layout: list[tuple[int, str]],
+        pool_layouts: PoolBlockLayouts,
     ) -> None:
         """Write and mirror a closed core's map under its pool layout."""
         mirror = self.mirror
         records = _with_g3(records, self._g3_records)
         try:
-            self._write_handback(records, pool_layout)
+            self._write_handback(records, pool_layouts)
         except OSError as error:
             if error.errno not in _RECOVERY_CAPACITY_ERRORS:
                 raise
@@ -287,13 +286,13 @@ class _RecoveryState:
             mirror.adopt(records)
         self._g3_records = {}
 
-    def release(self, pool_layout: list[tuple[int, str]]) -> None:
+    def release(self, pool_layouts: PoolBlockLayouts) -> None:
         """Write the current primary's journal tail, then drop its mirror."""
         mirror = self.mirror
         try:
             while (frame := self._journal.read_next()) is not None:
                 mirror.apply(*frame)
-            self._write_handback(mirror.take_records(), pool_layout)
+            self._write_handback(mirror.take_records(), pool_layouts)
         except RecoveryJournalError as error:
             self._drop_recovery(error)
         except OSError as error:
@@ -312,11 +311,11 @@ class _RecoveryState:
     def _write_handback(
         self,
         records: Mapping[BlockKey, _BlockRecord],
-        pool_layout: list[tuple[int, str]],
+        pool_layouts: PoolBlockLayouts,
     ) -> None:
         write_recovery_snapshot(
             self.attachment,
-            canonical_pool_terms(self._compatibility_digest, pool_layout, self._spec),
+            canonical_pool_terms(self._compatibility_digest, pool_layouts, self._spec),
             _recovery_frames(records),
         )
 
@@ -736,11 +735,11 @@ class _Guard:
             if self._failure is not None:
                 raise self._failure
             self._refuse_incompatible(tier_config)
-            served_under = self._configured.pool_layout if self._configured else ()
+            served_under = self._configured.pool_layouts if self._configured else ()
             # The prior handback is this lease's baseline. Read now, under
             # the claim's pool layout: refusing at promotion stops the service,
             # and a claimant dying in between takes everything with it.
-            recovered = self._recovery.recover(tier_config.pool_layout)
+            recovered = self._recovery.recover(tier_config.pool_layouts)
             # Last, once nothing left can refuse this claim: a pool whose handback
             # would not replay has not chosen anything, and a corrected claim can
             # still have it.
@@ -775,11 +774,11 @@ class _Guard:
         if self._failure is not None:
             raise self._failure
         if self._serving:
-            self._hand_back(self._configured.pool_layout)
+            self._hand_back(self._configured.pool_layouts)
             # Re-adopt lets start_primary() retain or replace the mirror.
             self._recovery.mirror = None
         elif self._recovery.mirror is not None:
-            self._recovery.release(self._configured.pool_layout)
+            self._recovery.release(self._configured.pool_layouts)
         if self._control is not None:
             self._control.close()
             self._control = None
@@ -798,7 +797,7 @@ class _Guard:
         """Take up this primary's tiers: the geometry check runs before the
         assignment, so a bad configuration leaves the old one intact.
         """
-        _compute_pool_geometry(self._spec.data_bytes, tier_config.pool_layout[0][0])
+        _compute_pool_geometry(self._spec.data_bytes, tier_config.pool_layouts[0][1])
         self._configured = tier_config
 
     def _poll(self) -> bool:
@@ -857,7 +856,7 @@ class _Guard:
         def reject_pin(keys: object) -> int:
             raise RuntimeError("Guard has no framework-owned memory")
 
-        block_size, pool_name = self._configured.pool_layout[0]
+        pool_name, block_size = self._configured.pool_layouts[0]
         effective_bytes, _ = _compute_pool_geometry(self._spec.data_bytes, block_size)
         dram = self._recovery.local_dram_info(
             effective_bytes,
@@ -867,7 +866,7 @@ class _Guard:
         core = _KVCRCore(
             KVCRConfig(
                 nixl_agent_name=f"KVCR-Guard-{uuid.uuid4()}",
-                pool_layout=list(self._configured.pool_layout),
+                pool_layouts=list(self._configured.pool_layouts),
                 inventory_report_interval_ms=0,
                 nixl_listen_port=0,
             ),
@@ -893,7 +892,7 @@ class _Guard:
         core.start()
         self._serving = True
 
-    def _hand_back(self, pool_layout: list[tuple[int, str]]) -> None:
+    def _hand_back(self, pool_layouts: PoolBlockLayouts) -> None:
         """Stop serving, leaving this pool's state where the next primary looks.
         The core closes first: the Guard stops answering, and region and
         records both come from the map close leaves behind.
@@ -902,7 +901,7 @@ class _Guard:
         if core is None or self._recovery.mirror is None:
             raise RecoveryMirrorError("a serving Guard has no state to hand back")
         core.close()
-        self._recovery.hand_back(core._block_record_map, pool_layout)
+        self._recovery.hand_back(core._block_record_map, pool_layouts)
         self._core = None
         self._serving = False
 

--- a/src/kvcr/guard_protocol.py
+++ b/src/kvcr/guard_protocol.py
@@ -15,7 +15,7 @@ from typing import Annotated, Literal
 
 import msgspec
 
-from .config import G3Options, LocalDramOptions
+from .config import G3Options, LocalDramOptions, _validate_pool_layout
 from .control_channels import (
     FramedConnection,
     KVCRGuardProtocolError,
@@ -53,14 +53,11 @@ class _TierConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
     remote_fw_dram_backend: Annotated[str, msgspec.Meta(min_length=1)] = "UCX"
 
     def __post_init__(self) -> None:
+        _validate_pool_layout(self.pool_layout)
         # TODO: Support multiple pools after fetch and storage can discover layouts.
         if len(self.pool_layout) != 1:
             raise ValueError("only a single pool is currently supported")
-        block_size_bytes, pool_name = self.pool_layout[0]
-        if isinstance(block_size_bytes, bool) or block_size_bytes <= 0:
-            raise ValueError("pool layout block size must be a positive integer")
-        if not isinstance(pool_name, str):
-            raise ValueError("pool layout pool name must be a string")
+        block_size_bytes = self.pool_layout[0][0]
         # Mirrors what the claimant's _G3 will enforce. The first claim fixes
         # the pool's tiers forever, so a config no claimant could ever open
         # must be refused here, before it binds.

--- a/src/kvcr/guard_protocol.py
+++ b/src/kvcr/guard_protocol.py
@@ -48,19 +48,27 @@ class _G3Config(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
 
 
 class _TierConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
-    row_stride: Annotated[int, msgspec.Meta(gt=0)]
+    pool_layout: list[tuple[int, str]]
     g3: _G3Config | None
     remote_fw_dram_backend: Annotated[str, msgspec.Meta(min_length=1)] = "UCX"
 
     def __post_init__(self) -> None:
+        # TODO: Support multiple pools after fetch and storage can discover layouts.
+        if len(self.pool_layout) != 1:
+            raise ValueError("only a single pool is currently supported")
+        block_size_bytes, pool_name = self.pool_layout[0]
+        if isinstance(block_size_bytes, bool) or block_size_bytes <= 0:
+            raise ValueError("pool layout block size must be a positive integer")
+        if not isinstance(pool_name, str):
+            raise ValueError("pool layout pool name must be a string")
         # Mirrors what the claimant's _G3 will enforce. The first claim fixes
         # the pool's tiers forever, so a config no claimant could ever open
         # must be refused here, before it binds.
         if self.g3 is None:
             return
-        if self.row_stride % mmap.PAGESIZE:
+        if block_size_bytes % mmap.PAGESIZE:
             raise ValueError("G3 slot size must be page aligned")
-        if self.g3.capacity_bytes_per_file % self.row_stride:
+        if self.g3.capacity_bytes_per_file % block_size_bytes:
             raise ValueError("G3 file capacity must contain complete slots")
         resolved = {os.path.realpath(path) for path in self.g3.paths}
         if len(resolved) != len(self.g3.paths):
@@ -213,7 +221,7 @@ class KVCRClient:
     def claim(
         self,
         guard_index: int,
-        row_stride: int,
+        pool_layout: list[tuple[int, str]],
         compatibility_digest: str,
         control_bind: tuple[str, int],
         g3: G3Options | None = None,
@@ -226,14 +234,14 @@ class KVCRClient:
             "backend": g3.backend,
             "backend_options": dict(g3.backend_options),
         }
-        # msgspec.convert validates where __init__ would not: bad stride,
+        # msgspec.convert validates where __init__ would not: bad pool layout,
         # port or G3 path fails here, not at the service.
         request = msgspec.convert(
             {
                 "guard_index": guard_index,
                 "compatibility_digest": compatibility_digest,
                 "tier_config": {
-                    "row_stride": row_stride,
+                    "pool_layout": pool_layout,
                     "g3": g3_config,
                     "remote_fw_dram_backend": remote_fw_dram_backend,
                 },
@@ -262,19 +270,17 @@ class KVCRClient:
                     "claim was granted without the endpoint it answers on"
                 )
             try:
-                effective_bytes, rows = _compute_pool_geometry(
-                    spec.data_bytes, request.tier_config.row_stride
-                )
+                block_size, pool_name = request.tier_config.pool_layout[0]
+                effective_bytes, _ = _compute_pool_geometry(spec.data_bytes, block_size)
             except ValueError as geometry_error:
                 raise KVCRGuardProtocolError(
-                    "invalid pool grant: no room for the journal and one KV row"
+                    "invalid pool grant: no room for one KV block"
                 ) from geometry_error
             attachment = KVCRPoolAttachment.attach(spec)
             return KVCRPoolHold(
                 local_dram=LocalDramOptions(
                     attachment.data_address,
-                    effective_bytes,
-                    rows,
+                    [(effective_bytes, pool_name)],
                     request.tier_config.remote_fw_dram_backend,
                 ),
                 _attachment=attachment,

--- a/src/kvcr/guard_protocol.py
+++ b/src/kvcr/guard_protocol.py
@@ -15,7 +15,7 @@ from typing import Annotated, Literal
 
 import msgspec
 
-from .config import G3Options, LocalDramOptions, _validate_pool_layout
+from .config import G3Options, LocalDramOptions, _validate_pool_layouts
 from .control_channels import (
     FramedConnection,
     KVCRGuardProtocolError,
@@ -23,6 +23,7 @@ from .control_channels import (
     KVCRSocketError,
 )
 from .memory import KVCRPoolAttachment, KVCRPoolSpec, _compute_pool_geometry
+from .types import PoolBlockLayouts
 
 logger = logging.getLogger(__name__)
 
@@ -48,16 +49,16 @@ class _G3Config(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
 
 
 class _TierConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
-    pool_layout: list[tuple[int, str]]
+    pool_layouts: PoolBlockLayouts
     g3: _G3Config | None
     remote_fw_dram_backend: Annotated[str, msgspec.Meta(min_length=1)] = "UCX"
 
     def __post_init__(self) -> None:
-        _validate_pool_layout(self.pool_layout)
+        _validate_pool_layouts(self.pool_layouts)
         # TODO: Support multiple pools after fetch and storage can discover layouts.
-        if len(self.pool_layout) != 1:
+        if len(self.pool_layouts) != 1:
             raise ValueError("only a single pool is currently supported")
-        block_size_bytes = self.pool_layout[0][0]
+        block_size_bytes = self.pool_layouts[0][1]
         # Mirrors what the claimant's _G3 will enforce. The first claim fixes
         # the pool's tiers forever, so a config no claimant could ever open
         # must be refused here, before it binds.
@@ -218,7 +219,7 @@ class KVCRClient:
     def claim(
         self,
         guard_index: int,
-        pool_layout: list[tuple[int, str]],
+        pool_layouts: PoolBlockLayouts,
         compatibility_digest: str,
         control_bind: tuple[str, int],
         g3: G3Options | None = None,
@@ -238,7 +239,7 @@ class KVCRClient:
                 "guard_index": guard_index,
                 "compatibility_digest": compatibility_digest,
                 "tier_config": {
-                    "pool_layout": pool_layout,
+                    "pool_layouts": pool_layouts,
                     "g3": g3_config,
                     "remote_fw_dram_backend": remote_fw_dram_backend,
                 },
@@ -267,7 +268,7 @@ class KVCRClient:
                     "claim was granted without the endpoint it answers on"
                 )
             try:
-                block_size, pool_name = request.tier_config.pool_layout[0]
+                pool_name, block_size = request.tier_config.pool_layouts[0]
                 effective_bytes, _ = _compute_pool_geometry(spec.data_bytes, block_size)
             except ValueError as geometry_error:
                 raise KVCRGuardProtocolError(
@@ -276,8 +277,7 @@ class KVCRClient:
             attachment = KVCRPoolAttachment.attach(spec)
             return KVCRPoolHold(
                 local_dram=LocalDramOptions(
-                    attachment.data_address,
-                    [(effective_bytes, pool_name)],
+                    [(pool_name, attachment.data_address, effective_bytes)],
                     request.tier_config.remote_fw_dram_backend,
                 ),
                 _attachment=attachment,

--- a/src/kvcr/local_dram.py
+++ b/src/kvcr/local_dram.py
@@ -144,21 +144,25 @@ class _LocalDram:
     ) -> None:
         if region.address <= 0:
             raise ValueError("local DRAM address must be positive")
-        if region.length <= 0:
-            raise ValueError("local DRAM length must be positive")
-        if region.slot_count <= 0:
-            raise ValueError("local DRAM slot_count must be positive")
-        if region.length % region.slot_count:
-            raise ValueError("local DRAM length must divide evenly into slots")
+        if len(region.pool_sizes_bytes) != 1:
+            raise ValueError("local DRAM supports only a single pool")
+        length, pool_name = region.pool_sizes_bytes[0]
+        if type(length) is not int or length <= 0:
+            raise ValueError("local DRAM pool size must be a positive integer")
+        if pool_name != kvcr.pool_layout[0][1]:
+            raise ValueError("local DRAM pool name must match pool_layout")
         if not region.backend:
             raise ValueError("local DRAM NIXL backend must be non-empty")
 
         self._kvcr = kvcr
         self._backend = region.backend
         self._address = region.address
-        self._length = region.length
-        self._slot_size = region.length // region.slot_count
-        self._free_slots = deque(range(region.slot_count))
+        self._length = length
+        self._slot_size = kvcr.block_size_bytes
+        slot_count = length // self._slot_size
+        if not slot_count:
+            raise ValueError("local DRAM pool must hold at least one block")
+        self._free_slots = deque(range(slot_count))
         self._evictable = _EvictionQueue()
         self._unscored: set[BlockKey] = set()
         self._pending_residency_ops: dict[_OpId, _PendingResidencyOp] = {}
@@ -271,7 +275,9 @@ class _LocalDram:
             if residency is not None:
                 if residency.state is _LocalDramState.READY:
                     op.results[key] = (
-                        self._new_public_claim(key, residency)
+                        self._new_public_claim(
+                            key, residency, include_descriptors=False
+                        )
                         if no_evict
                         else OpEntryResult(OpEntryStatus.SUCCESS)
                     )
@@ -364,7 +370,9 @@ class _LocalDram:
                     op.results[key] = OpEntryResult(OpEntryStatus.FAILED)
             elif residency.state is _LocalDramState.READY:
                 self._kvcr._record_access((key,))
-                op.results[key] = self._new_public_claim(key, residency)
+                op.results[key] = self._new_public_claim(
+                    key, residency, include_descriptors=True
+                )
             elif residency.state is _LocalDramState.DISCARDING:
                 # A discarded fill still owns its slot, so this block cannot be
                 # reserved yet. Wait for the slot instead of failing a key a
@@ -608,7 +616,11 @@ class _LocalDram:
                         if residency_op.op_id[0] == "fetch":
                             self._kvcr._record_access((key,))
                         residency_op.results[key] = (
-                            self._new_public_claim(key, residency)
+                            self._new_public_claim(
+                                key,
+                                residency,
+                                include_descriptors=residency_op.op_id[0] == "fetch",
+                            )
                             if residency_op.claim_on_ready
                             else OpEntryResult(OpEntryStatus.SUCCESS)
                         )
@@ -845,7 +857,11 @@ class _LocalDram:
                     op.capacity_waiters.remove(waiter.key)
                     if residency.state is _LocalDramState.READY:
                         op.results[waiter.key] = (
-                            self._new_public_claim(waiter.key, residency)
+                            self._new_public_claim(
+                                waiter.key,
+                                residency,
+                                include_descriptors=op.op_id[0] == "fetch",
+                            )
                             if op.claim_on_ready
                             else OpEntryResult(OpEntryStatus.SUCCESS)
                         )
@@ -909,7 +925,11 @@ class _LocalDram:
             self._update_capacity_pressure()
 
     def _new_public_claim(
-        self, key: BlockKey, residency: _LocalDramResidency
+        self,
+        key: BlockKey,
+        residency: _LocalDramResidency,
+        *,
+        include_descriptors: bool,
     ) -> OpEntryResult:
         self._acquire_claim(key, residency)
         handle = ReleaseHandle(self._next_release_handle)
@@ -917,7 +937,7 @@ class _LocalDram:
         self._public_claims[handle] = (key, residency)
         return OpEntryResult(
             OpEntryStatus.SUCCESS,
-            self._descriptor(residency.slot),
+            [self._descriptor(residency.slot)] if include_descriptors else None,
             handle,
         )
 
@@ -1020,7 +1040,7 @@ class _LocalDram:
             addr=self._address + slot * self._slot_size,
             size=self._slot_size,
             device_Id=0,
-            info="",
+            info=self._kvcr.pool_layout[0][1],
         )
 
     def _update_capacity_pressure(self) -> None:

--- a/src/kvcr/local_dram.py
+++ b/src/kvcr/local_dram.py
@@ -142,21 +142,21 @@ class _LocalDram:
         kvcr: "_KVCRCore",
         region: LocalDramOptions,
     ) -> None:
-        if region.address <= 0:
-            raise ValueError("local DRAM address must be positive")
-        if len(region.pool_sizes_bytes) != 1:
+        if len(region.pools) != 1:
             raise ValueError("local DRAM supports only a single pool")
-        length, pool_name = region.pool_sizes_bytes[0]
+        pool_name, address, length = region.pools[0]
+        if address <= 0:
+            raise ValueError("local DRAM address must be positive")
         if type(length) is not int or length <= 0:
             raise ValueError("local DRAM pool size must be a positive integer")
-        if pool_name != kvcr.pool_layout[0][1]:
-            raise ValueError("local DRAM pool name must match pool_layout")
+        if pool_name != kvcr.pool_layouts[0][0]:
+            raise ValueError("local DRAM pool name must match pool_layouts")
         if not region.backend:
             raise ValueError("local DRAM NIXL backend must be non-empty")
 
         self._kvcr = kvcr
         self._backend = region.backend
-        self._address = region.address
+        self._address = address
         self._length = length
         self._slot_size = kvcr.block_size_bytes
         slot_count = length // self._slot_size
@@ -1040,7 +1040,7 @@ class _LocalDram:
             addr=self._address + slot * self._slot_size,
             size=self._slot_size,
             device_Id=0,
-            info=self._kvcr.pool_layout[0][1],
+            info=self._kvcr.pool_layouts[0][0],
         )
 
     def _update_capacity_pressure(self) -> None:

--- a/src/kvcr/memory.py
+++ b/src/kvcr/memory.py
@@ -275,17 +275,17 @@ class _KVCRPoolOwner:
 
 def _compute_pool_geometry(
     requested_bytes: int,
-    row_stride: int,
+    block_size_bytes: int,
 ) -> tuple[int, int]:
     _validate_positive_int("requested_bytes", requested_bytes)
-    _validate_positive_int("row_stride", row_stride)
-    rows = requested_bytes // row_stride
-    if rows == 0:
+    _validate_positive_int("block_size_bytes", block_size_bytes)
+    block_count = requested_bytes // block_size_bytes
+    if block_count == 0:
         raise ValueError(
-            "requested_bytes must hold at least one complete KV row "
-            f"of {row_stride} bytes"
+            "requested_bytes must hold at least one complete KV block "
+            f"of {block_size_bytes} bytes"
         )
-    return rows * row_stride, rows
+    return block_count * block_size_bytes, block_count
 
 
 def _validate_pool_layout(mapping_bytes: int, journal_bytes: int) -> None:

--- a/src/kvcr/recovery_journal.py
+++ b/src/kvcr/recovery_journal.py
@@ -418,6 +418,7 @@ class ClaimedPool:
 
 
 def claim_guarded_pool(
+    config: KVCRConfig,
     guard_config: KVCRGuardConfig,
     bindings: "KVCRBindings",
     backend_configs: KVCRBackendConfigs,
@@ -442,7 +443,7 @@ def claim_guarded_pool(
         )
     hold = KVCRClient(guard_config.kvcr_service_socket_path).claim(
         guard_config.guard_index,
-        guard_config.row_stride,
+        config.pool_layout,
         guard_config.compatibility_digest,
         bind_address(),
         backend_configs.g3,
@@ -455,7 +456,7 @@ def claim_guarded_pool(
         recovered = read_handback(
             hold._attachment,
             guard_config.compatibility_digest,
-            guard_config.row_stride,
+            config.pool_layout,
         )
     except BaseException:
         # A failing release must not mask the error that made the claim unusable.
@@ -538,15 +539,17 @@ def _recovery_frames(
 
 
 # Bound to the pool and to the geometry: a slot index only means the same
-# bytes under the same file and layout. The generation stops a replay into a
+# bytes under the same file and pool layout. The generation stops a replay into a
 # different pool of the same shape; the digest separates finished from filling.
 _SNAPSHOT_HEADER = struct.Struct("<32sQ")
 _SNAPSHOT_DOMAIN = b"KVCR-HANDBACK\0"
-_SNAPSHOT_TERMS = struct.Struct("<QQQQQ")
+_SNAPSHOT_TERMS = struct.Struct("<QQQQ")
 
 
 def canonical_pool_terms(
-    compatibility_digest: str, row_stride: int, spec: "KVCRPoolSpec"
+    compatibility_digest: str,
+    pool_layout: list[tuple[int, str]],
+    spec: "KVCRPoolSpec",
 ) -> bytes:
     """Encode what a handback region must not be replayed across."""
     return (
@@ -554,8 +557,12 @@ def canonical_pool_terms(
         + compatibility_digest.encode()
         + b"\0"
         + bytes.fromhex(spec.generation)
+        + msgspec.msgpack.encode(pool_layout)
         + _SNAPSHOT_TERMS.pack(
-            row_stride, spec.journal_bytes, spec.mapping_bytes, spec.device, spec.inode
+            spec.journal_bytes,
+            spec.mapping_bytes,
+            spec.device,
+            spec.inode,
         )
     )
 
@@ -653,7 +660,9 @@ def read_recovery_snapshot(
 
 
 def read_handback(
-    pool: KVCRPoolAttachment, compatibility_digest: str, row_stride: int
+    pool: KVCRPoolAttachment,
+    compatibility_digest: str,
+    pool_layout: list[tuple[int, str]],
 ) -> _RecoveryMirror:
     """Replay whatever the last Guard left for this pool, if anything.
 
@@ -664,7 +673,7 @@ def read_handback(
     else ever would, and it would refuse every later claim on this pool too.
     """
     mirror = _RecoveryMirror()
-    terms = canonical_pool_terms(compatibility_digest, row_stride, pool._spec)
+    terms = canonical_pool_terms(compatibility_digest, pool_layout, pool._spec)
     try:
         for frame in read_recovery_snapshot(pool, terms):
             mirror.apply(*frame)

--- a/src/kvcr/recovery_journal.py
+++ b/src/kvcr/recovery_journal.py
@@ -23,7 +23,7 @@ from .guard_protocol import KVCRClient, KVCRPoolHold
 from .local_disk import _G3, _G3Residency
 from .local_dram import _LocalDram, _LocalDramResidency, _LocalDramState
 from .memory import _JOURNAL_HEADER_BYTES, KVCRPoolAttachment, KVCRPoolSpec
-from .types import BlockKey, RecoveryMirrorError
+from .types import BlockKey, PoolBlockLayouts, RecoveryMirrorError
 
 if TYPE_CHECKING:
     from .api import KVCRBindings
@@ -443,7 +443,7 @@ def claim_guarded_pool(
         )
     hold = KVCRClient(guard_config.kvcr_service_socket_path).claim(
         guard_config.guard_index,
-        config.pool_layout,
+        config.pool_layouts,
         guard_config.compatibility_digest,
         bind_address(),
         backend_configs.g3,
@@ -456,7 +456,7 @@ def claim_guarded_pool(
         recovered = read_handback(
             hold._attachment,
             guard_config.compatibility_digest,
-            config.pool_layout,
+            config.pool_layouts,
         )
     except BaseException:
         # A failing release must not mask the error that made the claim unusable.
@@ -548,7 +548,7 @@ _SNAPSHOT_TERMS = struct.Struct("<QQQQ")
 
 def canonical_pool_terms(
     compatibility_digest: str,
-    pool_layout: list[tuple[int, str]],
+    pool_layouts: PoolBlockLayouts,
     spec: "KVCRPoolSpec",
 ) -> bytes:
     """Encode what a handback region must not be replayed across."""
@@ -557,7 +557,7 @@ def canonical_pool_terms(
         + compatibility_digest.encode()
         + b"\0"
         + bytes.fromhex(spec.generation)
-        + msgspec.msgpack.encode(pool_layout)
+        + msgspec.msgpack.encode(pool_layouts)
         + _SNAPSHOT_TERMS.pack(
             spec.journal_bytes,
             spec.mapping_bytes,
@@ -662,7 +662,7 @@ def read_recovery_snapshot(
 def read_handback(
     pool: KVCRPoolAttachment,
     compatibility_digest: str,
-    pool_layout: list[tuple[int, str]],
+    pool_layouts: PoolBlockLayouts,
 ) -> _RecoveryMirror:
     """Replay whatever the last Guard left for this pool, if anything.
 
@@ -673,7 +673,7 @@ def read_handback(
     else ever would, and it would refuse every later claim on this pool too.
     """
     mirror = _RecoveryMirror()
-    terms = canonical_pool_terms(compatibility_digest, pool_layout, pool._spec)
+    terms = canonical_pool_terms(compatibility_digest, pool_layouts, pool._spec)
     try:
         for frame in read_recovery_snapshot(pool, terms):
             mirror.apply(*frame)

--- a/src/kvcr/remote_fw_dram.py
+++ b/src/kvcr/remote_fw_dram.py
@@ -892,8 +892,11 @@ class _RemoteFWDram:
             ):
                 raise TypeError("invalid remaining_timeout_ms")
             keys = _message_keys(payload)
-            dst_descriptors = msgspec.convert(
-                payload["dst_descriptors"], type=_MEM_DESCRIPTORS_TYPE
+            dst_descriptors = tuple(
+                self._kvcr._normalize_descriptors([descriptor])
+                for descriptor in msgspec.convert(
+                    payload["dst_descriptors"], type=_MEM_DESCRIPTORS_TYPE
+                )
             )
         except (KeyError, TypeError, ValueError, msgspec.ValidationError):
             logger.warning("KVCR malformed start_write op=%d", op_handle)
@@ -1289,7 +1292,7 @@ class _RemoteFWDram:
     def _install_framework_pin(
         self,
         keys: Collection[BlockKey],
-        pin_result: tuple[PinHandle, Mapping[BlockKey, MemDescriptor | None]],
+        pin_result: tuple[PinHandle, Mapping[BlockKey, list[MemDescriptor] | None]],
     ) -> PinHandle | None:
         pin_handle: PinHandle | None = None
         try:
@@ -1299,16 +1302,19 @@ class _RemoteFWDram:
             requested_keys = set(keys)
             if set(descriptors) != requested_keys:
                 raise KeyError("request_pin returned incomplete descriptors")
-            if any(
-                descriptor is not None and not isinstance(descriptor, MemDescriptor)
-                for descriptor in descriptors.values()
-            ):
-                raise TypeError("request_pin returned invalid descriptors")
-            if not any(descriptor is not None for descriptor in descriptors.values()):
+            normalized = {
+                key: (
+                    None
+                    if descriptor_list is None
+                    else self._kvcr._normalize_descriptors(descriptor_list)
+                )
+                for key, descriptor_list in descriptors.items()
+            }
+            if not any(descriptor is not None for descriptor in normalized.values()):
                 raise ValueError("request_pin returned no descriptors")
             pin_keys = self._kvcr._framework_pin_keys.setdefault(pin_handle, set())
             for key in keys:
-                descriptor = descriptors[key]
+                descriptor = normalized[key]
                 if descriptor is None:
                     continue
                 record = self._kvcr._block_record(key)

--- a/src/kvcr/types.py
+++ b/src/kvcr/types.py
@@ -28,6 +28,10 @@ class MemDescriptor:
     In a scenario where one key spans multiple workers and NIXL agents, grouping
     its spans by endpoint and memory type would add two hierarchy levels merely
     to factor out values typically shared by reference.
+
+    ``info`` currently identifies the descriptor's pool in ``pool_layout``; an empty
+    string names the single unnamed pool. This generic field may support additional
+    metadata conventions later.
     """
 
     end_point_name: Annotated[str, msgspec.Meta(min_length=1)]
@@ -38,7 +42,7 @@ class MemDescriptor:
     info: str = ""
 
 
-PinResult = tuple[PinHandle, Mapping[BlockKey, MemDescriptor | None]] | None
+PinResult = tuple[PinHandle, Mapping[BlockKey, list[MemDescriptor] | None]] | None
 
 
 class OpEntryStatus(Enum):
@@ -51,7 +55,7 @@ class OpEntryStatus(Enum):
 @dataclass(frozen=True)
 class OpEntryResult:
     status: OpEntryStatus
-    descriptor: MemDescriptor | None = None
+    descriptors: list[MemDescriptor] | None = None
     release_handle: ReleaseHandle | None = None
 
     @property

--- a/src/kvcr/types.py
+++ b/src/kvcr/types.py
@@ -15,6 +15,8 @@ PinRequestId = NewType("PinRequestId", int)
 OpHandle = int
 ReleaseHandle = NewType("ReleaseHandle", int)
 ReleaseResult = tuple[ReleaseHandle, bool]
+LocalDramRegions = list[tuple[str, int, int]]  # name, address, size in bytes
+PoolBlockLayouts = list[tuple[str, int]]  # name, block size in bytes
 
 
 @dataclass(frozen=True)
@@ -29,7 +31,7 @@ class MemDescriptor:
     its spans by endpoint and memory type would add two hierarchy levels merely
     to factor out values typically shared by reference.
 
-    ``info`` currently identifies the descriptor's pool in ``pool_layout``; an empty
+    ``info`` currently identifies the descriptor's pool in ``pool_layouts``; an empty
     string names the single unnamed pool. This generic field may support additional
     metadata conventions later.
     """

--- a/tests/unit/_kvcr_test_utils.py
+++ b/tests/unit/_kvcr_test_utils.py
@@ -203,7 +203,7 @@ class FakePrimaryPinning:
                     "pin",
                     {
                         key: (
-                            _mem_descriptor(addr=0)
+                            [_mem_descriptor(addr=0)]
                             if (
                                 (prefix_length is None or index < prefix_length)
                                 and index not in self.missing_indices
@@ -256,7 +256,7 @@ class PendingPrimaryPinning(FakePrimaryPinning):
                 (
                     pin_handle,
                     {
-                        key: None if index in missing_indices else _mem_descriptor()
+                        key: None if index in missing_indices else [_mem_descriptor()]
                         for index, key in enumerate(keys)
                     },
                 ),
@@ -380,14 +380,14 @@ class FakeBytesControl:
         return incoming
 
 
-def _mem_descriptor(addr: int = 128, size: int = 16) -> MemDescriptor:
+def _mem_descriptor(addr: int = 128, size: int = 16, info: str = "") -> MemDescriptor:
     return MemDescriptor(
         end_point_name="primary",
         mem_type="DRAM",
         addr=addr,
         size=size,
         device_Id=0,
-        info="",
+        info=info,
     )
 
 
@@ -460,7 +460,12 @@ def _new_kvcr(
     policy=None,
 ) -> KVCR:
     config = replace(
-        config or KVCRConfig(nixl_agent_name=name, inventory_report_interval_ms=0),
+        config
+        or KVCRConfig(
+            nixl_agent_name=name,
+            pool_layout=[(16, "")],
+            inventory_report_interval_ms=0,
+        ),
         nixl_agent_name=name,
         nixl_listen_port=1,
     )
@@ -504,6 +509,7 @@ def _new_local_kvcr(
         kvcr = KVCR(
             KVCRConfig(
                 nixl_agent_name="target",
+                pool_layout=[(len(local) // slot_count, "")],
                 nixl_listen_port=1,
                 inventory_report_interval_ms=0,
                 capacity_low_watermark_percent=capacity_low_watermark_percent,
@@ -519,8 +525,7 @@ def _new_local_kvcr(
             KVCRBackendConfigs(
                 local_dram=LocalDramOptions(
                     ctypes.addressof(local),
-                    len(local),
-                    slot_count,
+                    [(len(local), "")],
                     local_dram_backend,
                 ),
             ),

--- a/tests/unit/_kvcr_test_utils.py
+++ b/tests/unit/_kvcr_test_utils.py
@@ -463,7 +463,7 @@ def _new_kvcr(
         config
         or KVCRConfig(
             nixl_agent_name=name,
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             inventory_report_interval_ms=0,
         ),
         nixl_agent_name=name,
@@ -509,7 +509,7 @@ def _new_local_kvcr(
         kvcr = KVCR(
             KVCRConfig(
                 nixl_agent_name="target",
-                pool_layout=[(len(local) // slot_count, "")],
+                pool_layouts=[("", len(local) // slot_count)],
                 nixl_listen_port=1,
                 inventory_report_interval_ms=0,
                 capacity_low_watermark_percent=capacity_low_watermark_percent,
@@ -524,8 +524,7 @@ def _new_local_kvcr(
             ),
             KVCRBackendConfigs(
                 local_dram=LocalDramOptions(
-                    ctypes.addressof(local),
-                    [(len(local), "")],
+                    [("", ctypes.addressof(local), len(local))],
                     local_dram_backend,
                 ),
             ),

--- a/tests/unit/test_g3.py
+++ b/tests/unit/test_g3.py
@@ -164,12 +164,13 @@ def _new_g3_kvcr(
         agent or _FakeG3Agent(),
         FakePrimaryPinning(),
         control or FakeBytesControl(),
-        config=(
-            KVCRConfig(nixl_agent_name="target", enable_telemetry=True)
-            if telemetry
-            else None
+        config=KVCRConfig(
+            nixl_agent_name="target",
+            pool_layout=[(len(local) // slot_count, "")],
+            enable_telemetry=telemetry,
+            inventory_report_interval_ms=10 if telemetry else 0,
         ),
-        local_dram=LocalDramOptions(ctypes.addressof(local), len(local), slot_count),
+        local_dram=LocalDramOptions(ctypes.addressof(local), [(len(local), "")]),
         g3=G3Options(
             paths=((tmp_path / "g3.data",) if g3_paths is None else tuple(g3_paths)),
             capacity_bytes_per_file=page_size * g3_slot_count,
@@ -184,7 +185,7 @@ def _new_g3_kvcr(
 
 
 def _deposit(kvcr, key, address, size):
-    handle = kvcr.deposit({key: _mem_descriptor(address, size)})
+    handle = kvcr.deposit({key: [_mem_descriptor(address, size)]})
     return dict(_poll_until(kvcr, bool))[handle][key]
 
 
@@ -356,7 +357,7 @@ def test_g3_stripes_slots_across_files_and_reuses_an_evicted_slot(
     destination_addr = ctypes.addressof(destination)
     deliver = kvcr.deliver(
         {
-            key: _mem_descriptor(destination_addr + index * page_size, page_size)
+            key: [_mem_descriptor(destination_addr + index * page_size, page_size)]
             for index, key in enumerate(keys[:4])
         }
     )
@@ -382,7 +383,11 @@ def test_g3_stripes_slots_across_files_and_reuses_an_evicted_slot(
     assert replacement is not None and replacement.slot == evicted_slot
     replacement_destination = ctypes.create_string_buffer(page_size)
     replacement_deliver = kvcr.deliver(
-        {keys[4]: _mem_descriptor(ctypes.addressof(replacement_destination), page_size)}
+        {
+            keys[4]: [
+                _mem_descriptor(ctypes.addressof(replacement_destination), page_size)
+            ]
+        }
     )
     replacement_result = dict(
         _poll_until(kvcr, lambda done: replacement_deliver in dict(done))
@@ -450,7 +455,7 @@ def test_g3_recovery_rebuilds_free_slots_and_a_tier_recovered_full_frees_one(
     ]
 
     deliver = kvcr.deliver(
-        {second: _mem_descriptor(ctypes.addressof(destination), page_size)}
+        {second: [_mem_descriptor(ctypes.addressof(destination), page_size)]}
     )
     assert dict(_poll_until(kvcr, bool))[deliver][second].success
     assert destination.raw == b"s" * page_size
@@ -505,12 +510,12 @@ def test_g3_spill_deliver_and_fill_reuse_existing_progress(tmp_path) -> None:
     assert kvcr.query((first,)) == [(QueryStatus.FETCHABLE, CacheTier.G3)]
     assert kvcr._core._block_record_map[first].local_dram is None
     local_deliver = kvcr.deliver(
-        {second: _mem_descriptor(ctypes.addressof(destination), page_size)}
+        {second: [_mem_descriptor(ctypes.addressof(destination), page_size)]}
     )
     assert dict(_poll_until(kvcr, bool))[local_deliver][second].success
     now = 1.0
     deliver = kvcr.deliver(
-        {first: _mem_descriptor(ctypes.addressof(destination), page_size)}
+        {first: [_mem_descriptor(ctypes.addressof(destination), page_size)]}
     )
     assert dict(_poll_until(kvcr, bool))[deliver][first].success
     assert destination.raw == b"a" * page_size
@@ -519,8 +524,11 @@ def test_g3_spill_deliver_and_fill_reuse_existing_progress(tmp_path) -> None:
     now = 2.0
     fetch = kvcr.fetch((first,))
     fetch_result = dict(_poll_until(kvcr, bool))[fetch][first]
-    assert fetch_result.success and fetch_result.descriptor is not None
-    assert ctypes.string_at(fetch_result.descriptor.addr, page_size) == b"a" * page_size
+    assert fetch_result.success and fetch_result.descriptors is not None
+    assert (
+        ctypes.string_at(fetch_result.descriptors[0].addr, page_size)
+        == b"a" * page_size
+    )
     record = kvcr._core._block_record_map[first]
     assert record.local_dram is not None and record.g3 is not None
     assert [
@@ -775,7 +783,7 @@ def test_g3_spill_waits_until_local_source_claim_is_released(tmp_path) -> None:
 
     assert _deposit(kvcr, first, ctypes.addressof(primary), page_size).success
     deposit = kvcr.deposit(
-        {second: _mem_descriptor(ctypes.addressof(primary) + page_size, page_size)}
+        {second: [_mem_descriptor(ctypes.addressof(primary) + page_size, page_size)]}
     )
     fetch = kvcr.fetch((first,))
     fetch_result = dict(_poll_until(kvcr, lambda done: bool(done)))[fetch][first]
@@ -869,8 +877,11 @@ def test_fetch_falls_back_to_g3_while_a_local_fill_is_discarding(
     retry_result = dict(_poll_until(kvcr, lambda done: retry in dict(done)))[retry][
         first
     ]
-    assert retry_result.success and retry_result.descriptor is not None
-    assert ctypes.string_at(retry_result.descriptor.addr, page_size) == b"a" * page_size
+    assert retry_result.success and retry_result.descriptors is not None
+    assert (
+        ctypes.string_at(retry_result.descriptors[0].addr, page_size)
+        == b"a" * page_size
+    )
 
 
 def test_g3_deliver_rejects_a_destination_that_is_not_slot_sized(
@@ -895,11 +906,10 @@ def test_g3_deliver_rejects_a_destination_that_is_not_slot_sized(
     assert kvcr.query((first,)) == [(QueryStatus.FETCHABLE, CacheTier.G3)]
 
     reads = [operation for operation, *_ in agent.xfers if operation == "READ"]
-    deliver = kvcr.deliver(
-        {first: _mem_descriptor(ctypes.addressof(destination), page_size // 2)}
-    )
-    result = dict(_poll_until(kvcr, lambda done: deliver in dict(done)))
-    assert not result[deliver][first].success
+    with pytest.raises(ValueError, match="wrong byte count"):
+        kvcr.deliver(
+            {first: [_mem_descriptor(ctypes.addressof(destination), page_size // 2)]}
+        )
     # The undersized destination must never reach NIXL as a whole-slot read.
     assert [operation for operation, *_ in agent.xfers if operation == "READ"] == reads
     assert kvcr.query((first,)) == [(QueryStatus.FETCHABLE, CacheTier.G3)]
@@ -929,7 +939,7 @@ def test_closing_an_unfinished_spill_releases_its_capacity_reservation(
 
     assert _deposit(kvcr, first, ctypes.addressof(primary), page_size).success
     kvcr.deposit(
-        {second: _mem_descriptor(ctypes.addressof(primary) + page_size, page_size)}
+        {second: [_mem_descriptor(ctypes.addressof(primary) + page_size, page_size)]}
     )
     local_dram = kvcr._core._local_dram
     _poll_until(kvcr, lambda _: local_dram._capacity_eviction_key == first)

--- a/tests/unit/test_g3.py
+++ b/tests/unit/test_g3.py
@@ -166,11 +166,11 @@ def _new_g3_kvcr(
         control or FakeBytesControl(),
         config=KVCRConfig(
             nixl_agent_name="target",
-            pool_layout=[(len(local) // slot_count, "")],
+            pool_layouts=[("", len(local) // slot_count)],
             enable_telemetry=telemetry,
             inventory_report_interval_ms=10 if telemetry else 0,
         ),
-        local_dram=LocalDramOptions(ctypes.addressof(local), [(len(local), "")]),
+        local_dram=LocalDramOptions([("", ctypes.addressof(local), len(local))]),
         g3=G3Options(
             paths=((tmp_path / "g3.data",) if g3_paths is None else tuple(g3_paths)),
             capacity_bytes_per_file=page_size * g3_slot_count,

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -176,7 +176,7 @@ def test_a_serving_guard_reports_a_poll_failure_and_fences_its_core(caplog) -> N
     failure_callback = Mock()
     guard = _Guard(_TEST_SPEC, failure_callback, compatibility_digest=_TEST_DIGEST)
     guard._control = control
-    guard._configure(_TierConfig(16, None))
+    guard._configure(_TierConfig([(16, "")], None))
     guard._recovery._journal = journal
     guard._serving = True
     guard._core = core
@@ -210,7 +210,7 @@ def test_standby_guard_failure_releases_adopted_listener() -> None:
     journal.read_next.side_effect = error
     guard = _Guard(_TEST_SPEC, failure_callback, compatibility_digest=_TEST_DIGEST)
     guard._control = control
-    guard._configure(_TierConfig(16, None))
+    guard._configure(_TierConfig([(16, "")], None))
     guard._recovery._journal = journal
     guard._recovery.mirror = Mock()
 
@@ -280,7 +280,7 @@ def test_guard_lives_out_adopt_promote_and_readopt_in_ownership_order(
         backend="FILE",
         backend_options={},
     )
-    tier = _TierConfig(_PAGE_STRIDE, g3_config, "REMOTE")
+    tier = _TierConfig([(_PAGE_STRIDE, "")], g3_config, "REMOTE")
     guard = _Guard(_PAGE_SPEC, compatibility_digest=_TEST_DIGEST)
     # Driven directly, then the thread starts already busy: the actor blocks
     # on an empty mailbox when idle, so mutating around a sleeping thread
@@ -288,7 +288,7 @@ def test_guard_lives_out_adopt_promote_and_readopt_in_ownership_order(
     guard._started = True
     guard._recovery.prepare()
     # Unclaimed, so any tier shape is still available; the first claim fixes it.
-    guard._refuse_incompatible(_TierConfig(16, None))
+    guard._refuse_incompatible(_TierConfig([(16, "")], None))
     guard._adopt(new_channel(), tier)
     try:
         attach.assert_called_once_with(_PAGE_SPEC)
@@ -296,7 +296,7 @@ def test_guard_lives_out_adopt_promote_and_readopt_in_ownership_order(
         # Adoption only grants; a core exists once a promotion needs one.
         assert constructed == []
         with pytest.raises(RecoveryMirrorError, match="another tier configuration"):
-            guard._refuse_incompatible(_TierConfig(16, None))
+            guard._refuse_incompatible(_TierConfig([(16, "")], None))
 
         promoted_records = guard._recovery.mirror._records
         guard._promote()
@@ -308,7 +308,9 @@ def test_guard_lives_out_adopt_promote_and_readopt_in_ownership_order(
         assert config.nixl_listen_port == 0
         assert bindings.framework_control is channels[0]
         assert backends.local_dram == LocalDramOptions(
-            1234 + 8192, 2 * _PAGE_STRIDE, 2, "REMOTE"
+            1234 + 8192,
+            [(2 * _PAGE_STRIDE, "")],
+            "REMOTE",
         )
         assert backends.remote_fw_dram.backend == "REMOTE"
         # A Guard opens no G3: it serves the G2 half and keeps the rest for the
@@ -381,7 +383,7 @@ def test_a_pool_that_lost_its_recovery_stays_claimable_on_every_path(
     """Which reader finds the invalid journal is a race; none may take the service."""
     guard = _configurable_guard()
     # Every one of these readers runs on a pool a primary has already claimed.
-    guard._configured = _TierConfig(16, None)
+    guard._configured = _TierConfig([(16, "")], None)
     guard._recovery.mirror = _RecoveryMirror()
     guard._recovery.attachment = Mock()
     guard._control = None
@@ -433,11 +435,15 @@ def test_the_same_g3_paths_in_another_order_are_another_configuration() -> None:
     """A slot names its file by position, so reordering renames every slot."""
     guard = _configurable_guard()
     guard._configured = _TierConfig(
-        _PAGE_STRIDE, _G3Config(("/a", "/b"), _PAGE_STRIDE, "MOCK", {})
+        [(_PAGE_STRIDE, "")],
+        _G3Config(("/a", "/b"), _PAGE_STRIDE, "MOCK", {}),
     )
     with pytest.raises(RecoveryMirrorError, match="another tier configuration"):
         guard._refuse_incompatible(
-            _TierConfig(_PAGE_STRIDE, _G3Config(("/b", "/a"), _PAGE_STRIDE, "MOCK", {}))
+            _TierConfig(
+                [(_PAGE_STRIDE, "")],
+                _G3Config(("/b", "/a"), _PAGE_STRIDE, "MOCK", {}),
+            )
         )
 
 
@@ -451,7 +457,7 @@ def test_guard_closes_control_when_its_thread_does_not_start(monkeypatch) -> Non
     monkeypatch.setattr("kvcr.guard.RecoveryJournal", Mock())
     guard = _Guard(_TEST_SPEC, compatibility_digest=_TEST_DIGEST)
     guard._control = control
-    guard._configure(_TierConfig(16, None))
+    guard._configure(_TierConfig([(16, "")], None))
     guard._thread.start = Mock(side_effect=RuntimeError("thread start failed"))
 
     with pytest.raises(RuntimeError, match="thread start failed"):
@@ -529,7 +535,7 @@ def test_a_close_refused_by_a_moving_core_retains_the_pool_until_quiescent(
     core.is_quiescent.return_value = False
     guard = _Guard(_TEST_SPEC, compatibility_digest=_TEST_DIGEST)
     guard._control = control
-    guard._configure(_TierConfig(16, None))
+    guard._configure(_TierConfig([(16, "")], None))
     guard._core = core
     guard._recovery.attachment = attachment
     caplog.set_level(logging.WARNING, logger="kvcr.guard")
@@ -566,7 +572,7 @@ def test_only_a_claim_refused_before_the_pool_moves_costs_nothing(
 
     if refused_by == "hand-over":
         # A hand-back that fails cannot be reported as a refused claim.
-        guard._configured = _TierConfig(16, None)
+        guard._configured = _TierConfig([(16, "")], None)
         guard._serving = True
         guard._recovery.mirror = _RecoveryMirror()
         guard._core = Mock(_block_record_map={})
@@ -574,7 +580,7 @@ def test_only_a_claim_refused_before_the_pool_moves_costs_nothing(
         guard._hand_back = Mock(side_effect=failure)
 
         with pytest.raises(OSError, match="no space left"):
-            guard._adopt(control, _TierConfig(16, None))
+            guard._adopt(control, _TierConfig([(16, "")], None))
 
         assert reported == [failure]
         assert guard._failure is failure
@@ -584,11 +590,11 @@ def test_only_a_claim_refused_before_the_pool_moves_costs_nothing(
         )
         if refused_by == "geometry":
             expected: type[Exception] = ValueError
-            tier_config = _TierConfig(_TEST_SPEC.mapping_bytes, None)
+            tier_config = _TierConfig([(_TEST_SPEC.mapping_bytes, "")], None)
             handback = Mock(return_value=_RecoveryMirror())
         else:
             expected = RecoveryJournalError
-            tier_config = _TierConfig(16, None)
+            tier_config = _TierConfig([(16, "")], None)
             handback = Mock(side_effect=RecoveryJournalError("written for other terms"))
         monkeypatch.setattr("kvcr.guard.read_handback", handback)
 
@@ -602,7 +608,7 @@ def test_only_a_claim_refused_before_the_pool_moves_costs_nothing(
         guard._hand_back.assert_not_called()
         # Nothing was chosen, so a corrected claim can still have this pool.
         assert guard._configured is None
-        guard._refuse_incompatible(_TierConfig(32, None))
+        guard._refuse_incompatible(_TierConfig([(32, "")], None))
     control.close.assert_called_once_with()
 
 
@@ -653,13 +659,13 @@ def test_a_dropped_handback_still_leaves_the_new_lease_mirrored(code: int) -> No
     guard = _configurable_guard()
     guard._control = None
     guard._failure_callback = lambda *_args: None
-    guard._configured = _TierConfig(16, None)
+    guard._configured = _TierConfig([(16, "")], None)
     guard._recovery.mirror = _RecoveryMirror()
     _give_serving_core(guard)
     guard._recovery._journal = _Journal()
     guard._recovery._write_handback = Mock(side_effect=OSError(code, "No space left"))
 
-    guard._adopt(Mock(), _TierConfig(16, None))
+    guard._adopt(Mock(), _TierConfig([(16, "")], None))
 
     # The pool went cold, not fatal: the Guard stood down and dropped the core.
     assert guard._serving is False
@@ -709,7 +715,7 @@ def test_a_release_drops_its_mirror_after_handing_back_what_it_can(
     guard = _configurable_guard()
     control = Mock()
     guard._control = control
-    guard._configured = _TierConfig(16, None)
+    guard._configured = _TierConfig([(16, "")], None)
     guard._recovery.mirror = _RecoveryMirror()
     if mode == "serving":
         _give_serving_core(guard)
@@ -730,9 +736,9 @@ def test_a_release_drops_its_mirror_after_handing_back_what_it_can(
     assert guard._recovery.mirror is None
     control.close.assert_called_once_with()
     if mode == "accepts":
-        records, row_stride = guard._recovery._write_handback.call_args.args
+        records, pool_layout = guard._recovery._write_handback.call_args.args
         assert set(records) == {BlockKey(b"published"), BlockKey(b"tail")}
-        assert row_stride == 16
+        assert pool_layout == [(16, "")]
     elif mode == "serving":
         assert guard._serving is False
         assert guard._core is None

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -176,7 +176,7 @@ def test_a_serving_guard_reports_a_poll_failure_and_fences_its_core(caplog) -> N
     failure_callback = Mock()
     guard = _Guard(_TEST_SPEC, failure_callback, compatibility_digest=_TEST_DIGEST)
     guard._control = control
-    guard._configure(_TierConfig([(16, "")], None))
+    guard._configure(_TierConfig([("", 16)], None))
     guard._recovery._journal = journal
     guard._serving = True
     guard._core = core
@@ -210,7 +210,7 @@ def test_standby_guard_failure_releases_adopted_listener() -> None:
     journal.read_next.side_effect = error
     guard = _Guard(_TEST_SPEC, failure_callback, compatibility_digest=_TEST_DIGEST)
     guard._control = control
-    guard._configure(_TierConfig([(16, "")], None))
+    guard._configure(_TierConfig([("", 16)], None))
     guard._recovery._journal = journal
     guard._recovery.mirror = Mock()
 
@@ -280,7 +280,7 @@ def test_guard_lives_out_adopt_promote_and_readopt_in_ownership_order(
         backend="FILE",
         backend_options={},
     )
-    tier = _TierConfig([(_PAGE_STRIDE, "")], g3_config, "REMOTE")
+    tier = _TierConfig([("", _PAGE_STRIDE)], g3_config, "REMOTE")
     guard = _Guard(_PAGE_SPEC, compatibility_digest=_TEST_DIGEST)
     # Driven directly, then the thread starts already busy: the actor blocks
     # on an empty mailbox when idle, so mutating around a sleeping thread
@@ -288,7 +288,7 @@ def test_guard_lives_out_adopt_promote_and_readopt_in_ownership_order(
     guard._started = True
     guard._recovery.prepare()
     # Unclaimed, so any tier shape is still available; the first claim fixes it.
-    guard._refuse_incompatible(_TierConfig([(16, "")], None))
+    guard._refuse_incompatible(_TierConfig([("", 16)], None))
     guard._adopt(new_channel(), tier)
     try:
         attach.assert_called_once_with(_PAGE_SPEC)
@@ -296,7 +296,7 @@ def test_guard_lives_out_adopt_promote_and_readopt_in_ownership_order(
         # Adoption only grants; a core exists once a promotion needs one.
         assert constructed == []
         with pytest.raises(RecoveryMirrorError, match="another tier configuration"):
-            guard._refuse_incompatible(_TierConfig([(16, "")], None))
+            guard._refuse_incompatible(_TierConfig([("", 16)], None))
 
         promoted_records = guard._recovery.mirror._records
         guard._promote()
@@ -308,8 +308,7 @@ def test_guard_lives_out_adopt_promote_and_readopt_in_ownership_order(
         assert config.nixl_listen_port == 0
         assert bindings.framework_control is channels[0]
         assert backends.local_dram == LocalDramOptions(
-            1234 + 8192,
-            [(2 * _PAGE_STRIDE, "")],
+            [("", 1234 + 8192, 2 * _PAGE_STRIDE)],
             "REMOTE",
         )
         assert backends.remote_fw_dram.backend == "REMOTE"
@@ -383,7 +382,7 @@ def test_a_pool_that_lost_its_recovery_stays_claimable_on_every_path(
     """Which reader finds the invalid journal is a race; none may take the service."""
     guard = _configurable_guard()
     # Every one of these readers runs on a pool a primary has already claimed.
-    guard._configured = _TierConfig([(16, "")], None)
+    guard._configured = _TierConfig([("", 16)], None)
     guard._recovery.mirror = _RecoveryMirror()
     guard._recovery.attachment = Mock()
     guard._control = None
@@ -435,13 +434,13 @@ def test_the_same_g3_paths_in_another_order_are_another_configuration() -> None:
     """A slot names its file by position, so reordering renames every slot."""
     guard = _configurable_guard()
     guard._configured = _TierConfig(
-        [(_PAGE_STRIDE, "")],
+        [("", _PAGE_STRIDE)],
         _G3Config(("/a", "/b"), _PAGE_STRIDE, "MOCK", {}),
     )
     with pytest.raises(RecoveryMirrorError, match="another tier configuration"):
         guard._refuse_incompatible(
             _TierConfig(
-                [(_PAGE_STRIDE, "")],
+                [("", _PAGE_STRIDE)],
                 _G3Config(("/b", "/a"), _PAGE_STRIDE, "MOCK", {}),
             )
         )
@@ -457,7 +456,7 @@ def test_guard_closes_control_when_its_thread_does_not_start(monkeypatch) -> Non
     monkeypatch.setattr("kvcr.guard.RecoveryJournal", Mock())
     guard = _Guard(_TEST_SPEC, compatibility_digest=_TEST_DIGEST)
     guard._control = control
-    guard._configure(_TierConfig([(16, "")], None))
+    guard._configure(_TierConfig([("", 16)], None))
     guard._thread.start = Mock(side_effect=RuntimeError("thread start failed"))
 
     with pytest.raises(RuntimeError, match="thread start failed"):
@@ -535,7 +534,7 @@ def test_a_close_refused_by_a_moving_core_retains_the_pool_until_quiescent(
     core.is_quiescent.return_value = False
     guard = _Guard(_TEST_SPEC, compatibility_digest=_TEST_DIGEST)
     guard._control = control
-    guard._configure(_TierConfig([(16, "")], None))
+    guard._configure(_TierConfig([("", 16)], None))
     guard._core = core
     guard._recovery.attachment = attachment
     caplog.set_level(logging.WARNING, logger="kvcr.guard")
@@ -572,7 +571,7 @@ def test_only_a_claim_refused_before_the_pool_moves_costs_nothing(
 
     if refused_by == "hand-over":
         # A hand-back that fails cannot be reported as a refused claim.
-        guard._configured = _TierConfig([(16, "")], None)
+        guard._configured = _TierConfig([("", 16)], None)
         guard._serving = True
         guard._recovery.mirror = _RecoveryMirror()
         guard._core = Mock(_block_record_map={})
@@ -580,7 +579,7 @@ def test_only_a_claim_refused_before_the_pool_moves_costs_nothing(
         guard._hand_back = Mock(side_effect=failure)
 
         with pytest.raises(OSError, match="no space left"):
-            guard._adopt(control, _TierConfig([(16, "")], None))
+            guard._adopt(control, _TierConfig([("", 16)], None))
 
         assert reported == [failure]
         assert guard._failure is failure
@@ -590,11 +589,11 @@ def test_only_a_claim_refused_before_the_pool_moves_costs_nothing(
         )
         if refused_by == "geometry":
             expected: type[Exception] = ValueError
-            tier_config = _TierConfig([(_TEST_SPEC.mapping_bytes, "")], None)
+            tier_config = _TierConfig([("", _TEST_SPEC.mapping_bytes)], None)
             handback = Mock(return_value=_RecoveryMirror())
         else:
             expected = RecoveryJournalError
-            tier_config = _TierConfig([(16, "")], None)
+            tier_config = _TierConfig([("", 16)], None)
             handback = Mock(side_effect=RecoveryJournalError("written for other terms"))
         monkeypatch.setattr("kvcr.guard.read_handback", handback)
 
@@ -608,7 +607,7 @@ def test_only_a_claim_refused_before_the_pool_moves_costs_nothing(
         guard._hand_back.assert_not_called()
         # Nothing was chosen, so a corrected claim can still have this pool.
         assert guard._configured is None
-        guard._refuse_incompatible(_TierConfig([(32, "")], None))
+        guard._refuse_incompatible(_TierConfig([("", 32)], None))
     control.close.assert_called_once_with()
 
 
@@ -659,13 +658,13 @@ def test_a_dropped_handback_still_leaves_the_new_lease_mirrored(code: int) -> No
     guard = _configurable_guard()
     guard._control = None
     guard._failure_callback = lambda *_args: None
-    guard._configured = _TierConfig([(16, "")], None)
+    guard._configured = _TierConfig([("", 16)], None)
     guard._recovery.mirror = _RecoveryMirror()
     _give_serving_core(guard)
     guard._recovery._journal = _Journal()
     guard._recovery._write_handback = Mock(side_effect=OSError(code, "No space left"))
 
-    guard._adopt(Mock(), _TierConfig([(16, "")], None))
+    guard._adopt(Mock(), _TierConfig([("", 16)], None))
 
     # The pool went cold, not fatal: the Guard stood down and dropped the core.
     assert guard._serving is False
@@ -715,7 +714,7 @@ def test_a_release_drops_its_mirror_after_handing_back_what_it_can(
     guard = _configurable_guard()
     control = Mock()
     guard._control = control
-    guard._configured = _TierConfig([(16, "")], None)
+    guard._configured = _TierConfig([("", 16)], None)
     guard._recovery.mirror = _RecoveryMirror()
     if mode == "serving":
         _give_serving_core(guard)
@@ -736,9 +735,9 @@ def test_a_release_drops_its_mirror_after_handing_back_what_it_can(
     assert guard._recovery.mirror is None
     control.close.assert_called_once_with()
     if mode == "accepts":
-        records, pool_layout = guard._recovery._write_handback.call_args.args
+        records, pool_layouts = guard._recovery._write_handback.call_args.args
         assert set(records) == {BlockKey(b"published"), BlockKey(b"tail")}
-        assert pool_layout == [(16, "")]
+        assert pool_layouts == [("", 16)]
     elif mode == "serving":
         assert guard._serving is False
         assert guard._core is None

--- a/tests/unit/test_guard_integration.py
+++ b/tests/unit/test_guard_integration.py
@@ -118,6 +118,7 @@ def _make_kvcr(
         return KVCR(
             KVCRConfig(
                 nixl_agent_name=agent_name,
+                pool_layout=[(page_size, "")],
                 nixl_listen_port=0,
                 inventory_report_interval_ms=0,
             ),
@@ -147,7 +148,6 @@ def _make_kvcr(
             KVCRGuardConfig(
                 kvcr_service_socket_path=socket_path,
                 guard_index=0,
-                row_stride=page_size,
                 compatibility_digest=_DIGEST,
             ),
         )
@@ -160,7 +160,7 @@ def _deposit_two_blocks(kvcr: KVCR, source: int, block_bytes: int) -> None:
         (BlockKey(b"resident-b"), b"B" * block_bytes),
     ):
         ctypes.memmove(source, payload, block_bytes)
-        operation = kvcr.deposit({key: _mem_descriptor(source, block_bytes)})
+        operation = kvcr.deposit({key: [_mem_descriptor(source, block_bytes)]})
         assert dict(_poll_until(kvcr, bool))[operation][key].success, key
     assert kvcr.query((BlockKey(b"resident-a"),)) == [
         (QueryStatus.FETCHABLE, CacheTier.G3)
@@ -332,6 +332,7 @@ def test_a_promoted_guard_serves_real_nixl_transfers(
     target = KVCR(
         KVCRConfig(
             nixl_agent_name="real-target",
+            pool_layout=[(page_size, "")],
             nixl_listen_port=0,
             inventory_report_interval_ms=0,
             operation_timeout_ms=_REAL_NIXL_TIMEOUT_SECONDS * 1000,
@@ -355,7 +356,7 @@ def test_a_promoted_guard_serves_real_nixl_transfers(
         served_key = BlockKey(b"resident-b")
         target.submit_hint(_router_hint(source_endpoint), request_id="from-guard")
         operation = target.deliver(
-            {served_key: _mem_descriptor(ctypes.addressof(target_memory), page_size)},
+            {served_key: [_mem_descriptor(ctypes.addressof(target_memory), page_size)]},
             request_id="from-guard",
         )
         deadline = time.monotonic() + _REAL_NIXL_TIMEOUT_SECONDS
@@ -393,7 +394,7 @@ def test_a_promoted_guard_serves_real_nixl_transfers(
         ):
             ctypes.memset(destination, 0, len(payload))
             operation = replacement.deliver(
-                {key: _mem_descriptor(destination, len(payload))}
+                {key: [_mem_descriptor(destination, len(payload))]}
             )
             result = dict(
                 _poll_until(replacement, bool, timeout=_REAL_NIXL_TIMEOUT_SECONDS)
@@ -456,7 +457,11 @@ def test_request_timeout_during_promotion_then_retry_uses_guard(
             target_agent,
             FakePrimaryPinning(),
             target_control,
-            KVCRConfig(nixl_agent_name="target", operation_timeout_ms=5000),
+            KVCRConfig(
+                nixl_agent_name="target",
+                pool_layout=[(page_size, "")],
+                operation_timeout_ms=5000,
+            ),
             remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
             framework_dram=FrameworkDramInput(
                 ctypes.addressof(target_memory), len(target_memory)
@@ -469,7 +474,7 @@ def test_request_timeout_during_promotion_then_retry_uses_guard(
         stalled_destination = (ctypes.c_char * page_size).from_buffer(target_memory)
         target.submit_hint(_router_hint(source_endpoint), request_id="stalled")
         target.deliver(
-            {key: _mem_descriptor(ctypes.addressof(stalled_destination), page_size)},
+            {key: [_mem_descriptor(ctypes.addressof(stalled_destination), page_size)]},
             request_id="stalled",
         )
         _await_marker(child, "in-flight")
@@ -504,7 +509,7 @@ def test_request_timeout_during_promotion_then_retry_uses_guard(
         destination = (ctypes.c_char * page_size).from_buffer(target_memory, page_size)
         target.submit_hint(_router_hint(source_endpoint), request_id="retry")
         operation = target.deliver(
-            {key: _mem_descriptor(ctypes.addressof(destination), len(destination))},
+            {key: [_mem_descriptor(ctypes.addressof(destination), len(destination))]},
             request_id="retry",
         )
 
@@ -597,7 +602,7 @@ def test_replacement_primary_takes_the_cache_back_from_a_guard(
         ):
             destination = ctypes.create_string_buffer(len(payload))
             operation = replacement.deliver(
-                {key: _mem_descriptor(ctypes.addressof(destination), len(payload))}
+                {key: [_mem_descriptor(ctypes.addressof(destination), len(payload))]}
             )
             result = dict(_poll_until(replacement, bool))[operation][key]
             assert result.success, key

--- a/tests/unit/test_guard_integration.py
+++ b/tests/unit/test_guard_integration.py
@@ -118,7 +118,7 @@ def _make_kvcr(
         return KVCR(
             KVCRConfig(
                 nixl_agent_name=agent_name,
-                pool_layout=[(page_size, "")],
+                pool_layouts=[("", page_size)],
                 nixl_listen_port=0,
                 inventory_report_interval_ms=0,
             ),
@@ -332,7 +332,7 @@ def test_a_promoted_guard_serves_real_nixl_transfers(
     target = KVCR(
         KVCRConfig(
             nixl_agent_name="real-target",
-            pool_layout=[(page_size, "")],
+            pool_layouts=[("", page_size)],
             nixl_listen_port=0,
             inventory_report_interval_ms=0,
             operation_timeout_ms=_REAL_NIXL_TIMEOUT_SECONDS * 1000,
@@ -459,7 +459,7 @@ def test_request_timeout_during_promotion_then_retry_uses_guard(
             target_control,
             KVCRConfig(
                 nixl_agent_name="target",
-                pool_layout=[(page_size, "")],
+                pool_layouts=[("", page_size)],
                 operation_timeout_ms=5000,
             ),
             remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),

--- a/tests/unit/test_guard_protocol.py
+++ b/tests/unit/test_guard_protocol.py
@@ -39,7 +39,8 @@ _INODE = 42
 _DIGEST = "opaque digest: leave unchanged"
 _JOURNAL_BYTES = 2 * _JOURNAL_HEADER_BYTES
 _MAPPING_BYTES = _JOURNAL_BYTES + 8195
-_TIER_CONFIG = _TierConfig(_ROW_STRIDE, None)
+_POOL_LAYOUT = [(_ROW_STRIDE, "")]
+_TIER_CONFIG = _TierConfig(_POOL_LAYOUT, None)
 
 
 def test_close_swaps_the_pidfd_under_its_lock() -> None:
@@ -193,9 +194,8 @@ def _connect_with(
     )
 
 
-def test_g3_terms_no_claimant_could_open_are_refused_at_decode() -> None:
-    """The first claim fixes a pool's tiers forever, so terms the claimant's
-    G3 would reject must be refused before they bind."""
+def test_unsupported_tier_configuration_is_refused_at_decode() -> None:
+    """Refuse unsupported pool and G3 layouts before they bind the pool."""
     page = os.sysconf("SC_PAGE_SIZE")
     good = {
         "paths": ("/g3/a",),
@@ -203,13 +203,21 @@ def test_g3_terms_no_claimant_could_open_are_refused_at_decode() -> None:
         "backend": "FILE",
         "backend_options": {},
     }
+    with pytest.raises(ValueError, match="only a single pool"):
+        _TierConfig([(page, "full"), (page, "swa")], None)
     with pytest.raises(ValueError, match="page aligned"):
-        _TierConfig(page // 2, _G3Config(**good))
+        _TierConfig([(page // 2, "")], _G3Config(**good))
     with pytest.raises(ValueError, match="complete slots"):
-        _TierConfig(page, _G3Config(**{**good, "capacity_bytes_per_file": page + 1}))
+        _TierConfig(
+            [(page, "")],
+            _G3Config(**{**good, "capacity_bytes_per_file": page + 1}),
+        )
     with pytest.raises(ValueError, match="unique"):
-        _TierConfig(page, _G3Config(**{**good, "paths": ("/g3/a", "/g3//a")}))
-    _TierConfig(page, _G3Config(**good))
+        _TierConfig(
+            [(page, "")],
+            _G3Config(**{**good, "paths": ("/g3/a", "/g3//a")}),
+        )
+    _TierConfig([(page, "")], _G3Config(**good))
 
 
 def test_claim_and_release_round_trip_typed_messages_and_geometry(
@@ -224,7 +232,7 @@ def test_claim_and_release_round_trip_typed_messages_and_geometry(
     monkeypatch.setattr(protocol_module.KVCRPoolAttachment, "attach", attach)
 
     hold = KVCRClient("/unused").claim(
-        _GUARD_INDEX, _ROW_STRIDE, _DIGEST, ("127.0.0.1", 5555)
+        _GUARD_INDEX, _POOL_LAYOUT, _DIGEST, ("127.0.0.1", 5555)
     )
 
     assert msgspec.to_builtins(connection.sent[0]) == {
@@ -232,7 +240,7 @@ def test_claim_and_release_round_trip_typed_messages_and_geometry(
         "guard_index": _GUARD_INDEX,
         "compatibility_digest": _DIGEST,
         "tier_config": {
-            "row_stride": _ROW_STRIDE,
+            "pool_layout": [(_ROW_STRIDE, "")],
             "g3": None,
             "remote_fw_dram_backend": "UCX",
         },
@@ -253,14 +261,17 @@ def test_claim_and_release_round_trip_typed_messages_and_geometry(
             "journal_bytes": _JOURNAL_BYTES,
         },
         "tier_config": {
-            "row_stride": _ROW_STRIDE,
+            "pool_layout": [(_ROW_STRIDE, "")],
             "g3": None,
             "remote_fw_dram_backend": "UCX",
         },
         "version": 1,
     }
     attach.assert_called_once_with(_grant().spec)
-    assert hold.local_dram == LocalDramOptions(1234 + _JOURNAL_BYTES, 8192, 8)
+    assert hold.local_dram == LocalDramOptions(
+        1234 + _JOURNAL_BYTES,
+        [(8192, "")],
+    )
     # The endpoint a Guard will answer on, handed over with the grant.
     assert hold._control_listener_fd == connection.handed_fd
 
@@ -294,9 +305,9 @@ def test_claim_and_release_round_trip_typed_messages_and_geometry(
     [
         pytest.param(_grant(guard_index=_GUARD_INDEX + 1), None, id="wrong-guard"),
         pytest.param(
-            _grant(tier_config=_TierConfig(_ROW_STRIDE * 2, None)),
+            _grant(tier_config=_TierConfig([(_ROW_STRIDE * 2, "")], None)),
             None,
-            id="wrong-stride",
+            id="wrong-pool-layout",
         ),
         pytest.param(
             _grant(mapping_bytes=_JOURNAL_BYTES + _ROW_STRIDE - 1),
@@ -331,7 +342,7 @@ def test_a_failed_claim_is_released_without_masking_the_original(
         type(original) if original is not None else KVCRGuardProtocolError
     ) as raised:
         KVCRClient("/unused").claim(
-            _GUARD_INDEX, _ROW_STRIDE, _DIGEST, ("127.0.0.1", 5555)
+            _GUARD_INDEX, _POOL_LAYOUT, _DIGEST, ("127.0.0.1", 5555)
         )
 
     if original is not None:
@@ -355,7 +366,7 @@ def test_release_failures_leave_a_retry_and_report_a_lost_acknowledgement() -> N
         [ConnectionResetError("release acknowledgement was lost")], events
     )
     hold = KVCRPoolHold(
-        local_dram=LocalDramOptions(1234, 8192, 8),
+        local_dram=LocalDramOptions(1234, [(8192, "")]),
         _attachment=attachment,
         _connection=connection,
     )

--- a/tests/unit/test_guard_protocol.py
+++ b/tests/unit/test_guard_protocol.py
@@ -32,15 +32,15 @@ from kvcr.guard_protocol import (
 from kvcr.memory import _JOURNAL_HEADER_BYTES, KVCRPoolSpec
 
 _GUARD_INDEX = 3
-_ROW_STRIDE = 1024
+_BLOCK_SIZE_BYTES = 1024
 _GENERATION = "a" * 32
 _DEVICE = 2049
 _INODE = 42
 _DIGEST = "opaque digest: leave unchanged"
 _JOURNAL_BYTES = 2 * _JOURNAL_HEADER_BYTES
 _MAPPING_BYTES = _JOURNAL_BYTES + 8195
-_POOL_LAYOUT = [(_ROW_STRIDE, "")]
-_TIER_CONFIG = _TierConfig(_POOL_LAYOUT, None)
+_POOL_LAYOUTS = [("", _BLOCK_SIZE_BYTES)]
+_TIER_CONFIG = _TierConfig(_POOL_LAYOUTS, None)
 
 
 def test_close_swaps_the_pidfd_under_its_lock() -> None:
@@ -204,20 +204,20 @@ def test_unsupported_tier_configuration_is_refused_at_decode() -> None:
         "backend_options": {},
     }
     with pytest.raises(ValueError, match="only a single pool"):
-        _TierConfig([(page, "full"), (page, "swa")], None)
+        _TierConfig([("full", page), ("swa", page)], None)
     with pytest.raises(ValueError, match="page aligned"):
-        _TierConfig([(page // 2, "")], _G3Config(**good))
+        _TierConfig([("", page // 2)], _G3Config(**good))
     with pytest.raises(ValueError, match="complete slots"):
         _TierConfig(
-            [(page, "")],
+            [("", page)],
             _G3Config(**{**good, "capacity_bytes_per_file": page + 1}),
         )
     with pytest.raises(ValueError, match="unique"):
         _TierConfig(
-            [(page, "")],
+            [("", page)],
             _G3Config(**{**good, "paths": ("/g3/a", "/g3//a")}),
         )
-    _TierConfig([(page, "")], _G3Config(**good))
+    _TierConfig([("", page)], _G3Config(**good))
 
 
 def test_claim_and_release_round_trip_typed_messages_and_geometry(
@@ -232,7 +232,7 @@ def test_claim_and_release_round_trip_typed_messages_and_geometry(
     monkeypatch.setattr(protocol_module.KVCRPoolAttachment, "attach", attach)
 
     hold = KVCRClient("/unused").claim(
-        _GUARD_INDEX, _POOL_LAYOUT, _DIGEST, ("127.0.0.1", 5555)
+        _GUARD_INDEX, _POOL_LAYOUTS, _DIGEST, ("127.0.0.1", 5555)
     )
 
     assert msgspec.to_builtins(connection.sent[0]) == {
@@ -240,7 +240,7 @@ def test_claim_and_release_round_trip_typed_messages_and_geometry(
         "guard_index": _GUARD_INDEX,
         "compatibility_digest": _DIGEST,
         "tier_config": {
-            "pool_layout": [(_ROW_STRIDE, "")],
+            "pool_layouts": [("", _BLOCK_SIZE_BYTES)],
             "g3": None,
             "remote_fw_dram_backend": "UCX",
         },
@@ -261,17 +261,14 @@ def test_claim_and_release_round_trip_typed_messages_and_geometry(
             "journal_bytes": _JOURNAL_BYTES,
         },
         "tier_config": {
-            "pool_layout": [(_ROW_STRIDE, "")],
+            "pool_layouts": [("", _BLOCK_SIZE_BYTES)],
             "g3": None,
             "remote_fw_dram_backend": "UCX",
         },
         "version": 1,
     }
     attach.assert_called_once_with(_grant().spec)
-    assert hold.local_dram == LocalDramOptions(
-        1234 + _JOURNAL_BYTES,
-        [(8192, "")],
-    )
+    assert hold.local_dram == LocalDramOptions([("", 1234 + _JOURNAL_BYTES, 8192)])
     # The endpoint a Guard will answer on, handed over with the grant.
     assert hold._control_listener_fd == connection.handed_fd
 
@@ -305,12 +302,12 @@ def test_claim_and_release_round_trip_typed_messages_and_geometry(
     [
         pytest.param(_grant(guard_index=_GUARD_INDEX + 1), None, id="wrong-guard"),
         pytest.param(
-            _grant(tier_config=_TierConfig([(_ROW_STRIDE * 2, "")], None)),
+            _grant(tier_config=_TierConfig([("", _BLOCK_SIZE_BYTES * 2)], None)),
             None,
             id="wrong-pool-layout",
         ),
         pytest.param(
-            _grant(mapping_bytes=_JOURNAL_BYTES + _ROW_STRIDE - 1),
+            _grant(mapping_bytes=_JOURNAL_BYTES + _BLOCK_SIZE_BYTES - 1),
             None,
             id="short-mapping",
         ),
@@ -342,7 +339,7 @@ def test_a_failed_claim_is_released_without_masking_the_original(
         type(original) if original is not None else KVCRGuardProtocolError
     ) as raised:
         KVCRClient("/unused").claim(
-            _GUARD_INDEX, _POOL_LAYOUT, _DIGEST, ("127.0.0.1", 5555)
+            _GUARD_INDEX, _POOL_LAYOUTS, _DIGEST, ("127.0.0.1", 5555)
         )
 
     if original is not None:
@@ -366,7 +363,7 @@ def test_release_failures_leave_a_retry_and_report_a_lost_acknowledgement() -> N
         [ConnectionResetError("release acknowledgement was lost")], events
     )
     hold = KVCRPoolHold(
-        local_dram=LocalDramOptions(1234, [(8192, "")]),
+        local_dram=LocalDramOptions([("", 1234, 8192)]),
         _attachment=attachment,
         _connection=connection,
     )

--- a/tests/unit/test_kvcr.py
+++ b/tests/unit/test_kvcr.py
@@ -443,6 +443,32 @@ def test_kvcr_rejects_multi_pool_layout() -> None:
         )
 
 
+def test_kvcr_rejects_ambiguous_pool_names() -> None:
+    bindings = KVCRBindings(Mock(), Mock(), Mock())
+    for pool_layout, message in (
+        ([(8, ""), (8, "swa")], "empty"),
+        ([(8, "swa"), (8, "swa")], "unique"),
+    ):
+        config = KVCRConfig(nixl_agent_name="target", pool_layout=pool_layout)
+        with pytest.raises(ValueError, match=message):
+            KVCR(config, bindings, KVCRBackendConfigs())
+
+
+def test_fetch_requires_layout_for_a_named_single_pool() -> None:
+    local = ctypes.create_string_buffer(16)
+    kvcr = _new_kvcr(
+        FakeNixlAgent(),
+        FakePrimaryPinning(),
+        FakeBytesControl(),
+        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "named")]),
+        local_dram=LocalDramOptions(ctypes.addressof(local), [(16, "named")]),
+    )
+
+    with pytest.raises(ValueError, match="expected layout"):
+        kvcr.fetch((BlockKey(b"key"),))
+    kvcr.fetch((BlockKey(b"key"),), expected_layout=["named"])
+
+
 def test_get_stats_emits_public_state_metric_name() -> None:
     kvcr = _new_kvcr(
         FakeNixlAgent(),

--- a/tests/unit/test_kvcr.py
+++ b/tests/unit/test_kvcr.py
@@ -79,12 +79,14 @@ def test_local_dram_observer_reports_only_stable_slot_changes() -> None:
     backend.observe_residency(observe)
     address = ctypes.addressof(primary)
 
-    first = kvcr.deposit({keys[0]: _mem_descriptor(address, block_size)})
+    first = kvcr.deposit({keys[0]: [_mem_descriptor(address, block_size)]})
     _poll_until(kvcr, lambda done: first in dict(done))
     assert observed == [(keys[0], 0)]
 
     agent.state = "ERR"
-    failed = kvcr.deposit({keys[1]: _mem_descriptor(address + block_size, block_size)})
+    failed = kvcr.deposit(
+        {keys[1]: [_mem_descriptor(address + block_size, block_size)]}
+    )
     failed_result = dict(_poll_until(kvcr, lambda done: failed in dict(done)))[failed]
     assert not failed_result[keys[1]].success
     assert observed == [
@@ -94,7 +96,7 @@ def test_local_dram_observer_reports_only_stable_slot_changes() -> None:
 
     agent.state = "DONE"
     third = kvcr.deposit(
-        {keys[2]: _mem_descriptor(address + 2 * block_size, block_size)}
+        {keys[2]: [_mem_descriptor(address + 2 * block_size, block_size)]}
     )
     _poll_until(kvcr, lambda done: third in dict(done))
     backend.acquire_sources((keys[2],))
@@ -110,7 +112,6 @@ def test_local_dram_observer_reports_only_stable_slot_changes() -> None:
 _GUARD_CONFIG = KVCRGuardConfig(
     kvcr_service_socket_path="/tmp/kvcr.sock",
     guard_index=3,
-    row_stride=1024,
     compatibility_digest="Opaque-Digest",
 )
 # No Guard has handed anything back, so nothing is at its handback path.
@@ -160,7 +161,7 @@ def test_a_guarded_startup_that_fails_gives_back_everything_it_took(
     """Refused before the claim, or unwound after it: core closed, pool returned."""
     events: list[str] = []
     hold = _fake_hold(
-        local_dram=LocalDramOptions(1234, 8192, 8),
+        local_dram=LocalDramOptions(1234, [(8192, "")]),
         _attachment=_UNSERVED_POOL,
         _control_listener_fd=None,
         release=lambda **_kwargs: events.append("hold.release"),
@@ -216,7 +217,11 @@ def test_a_guarded_startup_that_fails_gives_back_everything_it_took(
 
     with pytest.raises(error, match=match):
         KVCR(
-            KVCRConfig(nixl_agent_name="target", nixl_listen_port=1),
+            KVCRConfig(
+                nixl_agent_name="target",
+                pool_layout=[(1024, "")],
+                nixl_listen_port=1,
+            ),
             KVCRBindings(Mock(), Mock(), Mock(), framework_control=control),
             KVCRBackendConfigs(),
             _GUARD_CONFIG,
@@ -239,7 +244,7 @@ def test_startup_timeout_retains_nonquiescent_resources(
     entered = threading.Event()
     unblock = threading.Event()
     hold = _fake_hold(
-        local_dram=LocalDramOptions(1234, 8192, 8),
+        local_dram=LocalDramOptions(1234, [(8192, "")]),
         _attachment=_UNSERVED_POOL,
         _control_listener_fd=None,
         release=Mock(),
@@ -275,7 +280,11 @@ def test_startup_timeout_retains_nonquiescent_resources(
     try:
         with pytest.raises(RuntimeError, match="progress thread did not start"):
             KVCR(
-                KVCRConfig(nixl_agent_name="target", nixl_listen_port=1),
+                KVCRConfig(
+                    nixl_agent_name="target",
+                    pool_layout=[(1024, "")],
+                    nixl_listen_port=1,
+                ),
                 KVCRBindings(
                     Mock(),
                     Mock(),
@@ -310,7 +319,7 @@ def test_service_journal_is_attached_before_primary_start(
     events: list[str] = []
     attachment = _UNSERVED_POOL
     hold = _fake_hold(
-        local_dram=LocalDramOptions(1234, 8192, 8),
+        local_dram=LocalDramOptions(1234, [(8192, "")]),
         _attachment=attachment,
         _control_listener_fd=7,
         release=lambda **_kwargs: events.append("hold.release"),
@@ -361,20 +370,19 @@ def test_service_journal_is_attached_before_primary_start(
         remote_fw_dram=RemoteFWDramOptions(backend="REMOTE"),
     )
     controller = KVCR(
-        KVCRConfig(nixl_agent_name="target"),
+        KVCRConfig(nixl_agent_name="target", pool_layout=[(1024, "")]),
         KVCRBindings(Mock(), Mock(), Mock(), framework_control=primary_control),
         backend_configs,
         KVCRGuardConfig(
             kvcr_service_socket_path="/tmp/kvcr.sock",
             guard_index=3,
-            row_stride=1024,
             compatibility_digest="Opaque-Digest",
         ),
     )
 
     claim.assert_called_once_with(
         3,
-        1024,
+        [(1024, "")],
         "Opaque-Digest",
         ("127.0.0.1", 5555),
         g3_config,
@@ -405,9 +413,9 @@ def test_service_dram_rejects_explicit_local_dram_before_claim(monkeypatch) -> N
 
     with pytest.raises(ValueError, match="local_dram"):
         KVCR(
-            KVCRConfig(nixl_agent_name="target"),
+            KVCRConfig(nixl_agent_name="target", pool_layout=[(1024, "")]),
             KVCRBindings(Mock(), Mock(), Mock()),
-            KVCRBackendConfigs(local_dram=LocalDramOptions(1234, 8192, 8)),
+            KVCRBackendConfigs(local_dram=LocalDramOptions(1234, [(8192, "")])),
             _GUARD_CONFIG,
         )
 
@@ -417,7 +425,19 @@ def test_service_dram_rejects_explicit_local_dram_before_claim(monkeypatch) -> N
 def test_kvcr_rejects_no_dram_backends() -> None:
     with pytest.raises(ValueError, match="at least one DRAM backend"):
         KVCR(
-            KVCRConfig(nixl_agent_name="target"),
+            KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
+            KVCRBindings(Mock(), Mock(), Mock()),
+            KVCRBackendConfigs(),
+        )
+
+
+def test_kvcr_rejects_multi_pool_layout() -> None:
+    with pytest.raises(ValueError, match="only a single pool"):
+        KVCR(
+            KVCRConfig(
+                nixl_agent_name="target",
+                pool_layout=[(8, "full"), (8, "swa")],
+            ),
             KVCRBindings(Mock(), Mock(), Mock()),
             KVCRBackendConfigs(),
         )
@@ -428,7 +448,11 @@ def test_get_stats_emits_public_state_metric_name() -> None:
         FakeNixlAgent(),
         FakePrimaryPinning(),
         FakeBytesControl(),
-        KVCRConfig(nixl_agent_name="target", enable_telemetry=True),
+        KVCRConfig(
+            nixl_agent_name="target",
+            pool_layout=[(16, "")],
+            enable_telemetry=True,
+        ),
     )
 
     stats = kvcr.get_stats()
@@ -471,6 +495,7 @@ def test_nixl_lifecycle_stays_on_progress_thread(
     kvcr = KVCR(
         KVCRConfig(
             nixl_agent_name="target",
+            pool_layout=[(64, "")],
             nixl_listen_port=1234,
         ),
         KVCRBindings(
@@ -483,7 +508,7 @@ def test_nixl_lifecycle_stays_on_progress_thread(
         ),
         KVCRBackendConfigs(
             framework_dram=FrameworkDramInput(128, 256),
-            local_dram=LocalDramOptions(384, 128, 2, "LOCAL"),
+            local_dram=LocalDramOptions(384, [(128, "")], "LOCAL"),
             remote_fw_dram=RemoteFWDramOptions(backend="REMOTE"),
         ),
     )

--- a/tests/unit/test_kvcr.py
+++ b/tests/unit/test_kvcr.py
@@ -161,7 +161,7 @@ def test_a_guarded_startup_that_fails_gives_back_everything_it_took(
     """Refused before the claim, or unwound after it: core closed, pool returned."""
     events: list[str] = []
     hold = _fake_hold(
-        local_dram=LocalDramOptions(1234, [(8192, "")]),
+        local_dram=LocalDramOptions([("", 1234, 8192)]),
         _attachment=_UNSERVED_POOL,
         _control_listener_fd=None,
         release=lambda **_kwargs: events.append("hold.release"),
@@ -219,7 +219,7 @@ def test_a_guarded_startup_that_fails_gives_back_everything_it_took(
         KVCR(
             KVCRConfig(
                 nixl_agent_name="target",
-                pool_layout=[(1024, "")],
+                pool_layouts=[("", 1024)],
                 nixl_listen_port=1,
             ),
             KVCRBindings(Mock(), Mock(), Mock(), framework_control=control),
@@ -244,7 +244,7 @@ def test_startup_timeout_retains_nonquiescent_resources(
     entered = threading.Event()
     unblock = threading.Event()
     hold = _fake_hold(
-        local_dram=LocalDramOptions(1234, [(8192, "")]),
+        local_dram=LocalDramOptions([("", 1234, 8192)]),
         _attachment=_UNSERVED_POOL,
         _control_listener_fd=None,
         release=Mock(),
@@ -282,7 +282,7 @@ def test_startup_timeout_retains_nonquiescent_resources(
             KVCR(
                 KVCRConfig(
                     nixl_agent_name="target",
-                    pool_layout=[(1024, "")],
+                    pool_layouts=[("", 1024)],
                     nixl_listen_port=1,
                 ),
                 KVCRBindings(
@@ -319,7 +319,7 @@ def test_service_journal_is_attached_before_primary_start(
     events: list[str] = []
     attachment = _UNSERVED_POOL
     hold = _fake_hold(
-        local_dram=LocalDramOptions(1234, [(8192, "")]),
+        local_dram=LocalDramOptions([("", 1234, 8192)]),
         _attachment=attachment,
         _control_listener_fd=7,
         release=lambda **_kwargs: events.append("hold.release"),
@@ -370,7 +370,7 @@ def test_service_journal_is_attached_before_primary_start(
         remote_fw_dram=RemoteFWDramOptions(backend="REMOTE"),
     )
     controller = KVCR(
-        KVCRConfig(nixl_agent_name="target", pool_layout=[(1024, "")]),
+        KVCRConfig(nixl_agent_name="target", pool_layouts=[("", 1024)]),
         KVCRBindings(Mock(), Mock(), Mock(), framework_control=primary_control),
         backend_configs,
         KVCRGuardConfig(
@@ -382,7 +382,7 @@ def test_service_journal_is_attached_before_primary_start(
 
     claim.assert_called_once_with(
         3,
-        [(1024, "")],
+        [("", 1024)],
         "Opaque-Digest",
         ("127.0.0.1", 5555),
         g3_config,
@@ -413,9 +413,9 @@ def test_service_dram_rejects_explicit_local_dram_before_claim(monkeypatch) -> N
 
     with pytest.raises(ValueError, match="local_dram"):
         KVCR(
-            KVCRConfig(nixl_agent_name="target", pool_layout=[(1024, "")]),
+            KVCRConfig(nixl_agent_name="target", pool_layouts=[("", 1024)]),
             KVCRBindings(Mock(), Mock(), Mock()),
-            KVCRBackendConfigs(local_dram=LocalDramOptions(1234, [(8192, "")])),
+            KVCRBackendConfigs(local_dram=LocalDramOptions([("", 1234, 8192)])),
             _GUARD_CONFIG,
         )
 
@@ -425,18 +425,18 @@ def test_service_dram_rejects_explicit_local_dram_before_claim(monkeypatch) -> N
 def test_kvcr_rejects_no_dram_backends() -> None:
     with pytest.raises(ValueError, match="at least one DRAM backend"):
         KVCR(
-            KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
+            KVCRConfig(nixl_agent_name="target", pool_layouts=[("", 16)]),
             KVCRBindings(Mock(), Mock(), Mock()),
             KVCRBackendConfigs(),
         )
 
 
-def test_kvcr_rejects_multi_pool_layout() -> None:
+def test_kvcr_rejects_multi_pool_layouts() -> None:
     with pytest.raises(ValueError, match="only a single pool"):
         KVCR(
             KVCRConfig(
                 nixl_agent_name="target",
-                pool_layout=[(8, "full"), (8, "swa")],
+                pool_layouts=[("full", 8), ("swa", 8)],
             ),
             KVCRBindings(Mock(), Mock(), Mock()),
             KVCRBackendConfigs(),
@@ -445,11 +445,11 @@ def test_kvcr_rejects_multi_pool_layout() -> None:
 
 def test_kvcr_rejects_ambiguous_pool_names() -> None:
     bindings = KVCRBindings(Mock(), Mock(), Mock())
-    for pool_layout, message in (
-        ([(8, ""), (8, "swa")], "empty"),
-        ([(8, "swa"), (8, "swa")], "unique"),
+    for pool_layouts, message in (
+        ([("", 8), ("swa", 8)], "empty"),
+        ([("swa", 8), ("swa", 8)], "unique"),
     ):
-        config = KVCRConfig(nixl_agent_name="target", pool_layout=pool_layout)
+        config = KVCRConfig(nixl_agent_name="target", pool_layouts=pool_layouts)
         with pytest.raises(ValueError, match=message):
             KVCR(config, bindings, KVCRBackendConfigs())
 
@@ -460,8 +460,8 @@ def test_fetch_requires_layout_for_a_named_single_pool() -> None:
         FakeNixlAgent(),
         FakePrimaryPinning(),
         FakeBytesControl(),
-        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "named")]),
-        local_dram=LocalDramOptions(ctypes.addressof(local), [(16, "named")]),
+        KVCRConfig(nixl_agent_name="target", pool_layouts=[("named", 16)]),
+        local_dram=LocalDramOptions([("named", ctypes.addressof(local), 16)]),
     )
 
     with pytest.raises(ValueError, match="expected layout"):
@@ -476,7 +476,7 @@ def test_get_stats_emits_public_state_metric_name() -> None:
         FakeBytesControl(),
         KVCRConfig(
             nixl_agent_name="target",
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             enable_telemetry=True,
         ),
     )
@@ -521,7 +521,7 @@ def test_nixl_lifecycle_stays_on_progress_thread(
     kvcr = KVCR(
         KVCRConfig(
             nixl_agent_name="target",
-            pool_layout=[(64, "")],
+            pool_layouts=[("", 64)],
             nixl_listen_port=1234,
         ),
         KVCRBindings(
@@ -534,7 +534,7 @@ def test_nixl_lifecycle_stays_on_progress_thread(
         ),
         KVCRBackendConfigs(
             framework_dram=FrameworkDramInput(128, 256),
-            local_dram=LocalDramOptions(384, [(128, "")], "LOCAL"),
+            local_dram=LocalDramOptions([("", 384, 128)], "LOCAL"),
             remote_fw_dram=RemoteFWDramOptions(backend="REMOTE"),
         ),
     )

--- a/tests/unit/test_kvcr_local_dram.py
+++ b/tests/unit/test_kvcr_local_dram.py
@@ -256,10 +256,9 @@ def test_local_claims_fetch_deliver_release_and_capacity() -> None:
     deposit = kvcr.deposit({first_key: [_mem_descriptor(primary_addr)]}, no_evict=True)
     _wait_until(lambda: bool(agent.transfers))
     assert capacity_requests == [1]
-    layouts = {first_key: [(16, "")], second_key: [(8, "")]}
-    with pytest.raises(ValueError, match="expected layouts"):
-        kvcr.fetch((first_key, second_key), expected_layouts=layouts)
-    fetch = kvcr.fetch((first_key,), expected_layouts={first_key: [(block_size, "")]})
+    with pytest.raises(ValueError, match="expected layout"):
+        kvcr.fetch((first_key, second_key), expected_layout=["unknown"])
+    fetch = kvcr.fetch((first_key,), expected_layout=[""])
     assert kvcr.query((first_key,)) == [(QueryStatus.FETCHING, CacheTier.LOCAL_G2)]
     assert list(kvcr.poll_completed()) == []
 

--- a/tests/unit/test_kvcr_local_dram.py
+++ b/tests/unit/test_kvcr_local_dram.py
@@ -54,13 +54,13 @@ def test_local_deposit_deduplicates_and_evicts_fifo() -> None:
 
     first = kvcr.deposit(
         {
-            key: _mem_descriptor(primary_addr + index * block_size)
+            key: [_mem_descriptor(primary_addr + index * block_size)]
             for index, key in enumerate(keys[:2])
         },
         hints={"priority": "test"},
     )
     _wait_until(lambda: len(agent.transfers) == 1)
-    filling_duplicate = kvcr.deposit({keys[0]: _mem_descriptor(primary_addr)})
+    filling_duplicate = kvcr.deposit({keys[0]: [_mem_descriptor(primary_addr)]})
     assert list(kvcr.poll_completed()) == []
     assert len(agent.transfers) == 1
     assert policy.ingested == []
@@ -81,7 +81,7 @@ def test_local_deposit_deduplicates_and_evicts_fifo() -> None:
         for meta, *_ in policy.ingested
     )
 
-    ready_duplicate = kvcr.deposit({keys[0]: _mem_descriptor(primary_addr)})
+    ready_duplicate = kvcr.deposit({keys[0]: [_mem_descriptor(primary_addr)]})
     assert list(kvcr.poll_completed()) == [
         (ready_duplicate, _op_entries({keys[0]: True}))
     ]
@@ -90,7 +90,7 @@ def test_local_deposit_deduplicates_and_evicts_fifo() -> None:
     assert len(policy.ingested) == 2
 
     replacement = kvcr.deposit(
-        {keys[2]: _mem_descriptor(primary_addr + 2 * block_size)}
+        {keys[2]: [_mem_descriptor(primary_addr + 2 * block_size)]}
     )
     completed = _poll_until(kvcr, lambda results: bool(results))
     assert completed == [(replacement, _op_entries({keys[2]: True}))]
@@ -105,6 +105,13 @@ def test_local_deposit_deduplicates_and_evicts_fifo() -> None:
         InventoryEvent((keys[0],), CacheTier.LOCAL_G2, True),
         InventoryEvent((keys[2],), CacheTier.LOCAL_G2, False),
     ]
+
+
+def test_local_transfer_rejects_multiple_descriptors() -> None:
+    kvcr = _new_local_kvcr(FakeNixlAgent(), ctypes.create_string_buffer(16), 1)
+
+    with pytest.raises(ValueError, match="exactly one descriptor"):
+        kvcr.deposit({BlockKey(b"key"): [_mem_descriptor(), _mem_descriptor()]})
 
 
 @pytest.mark.parametrize(
@@ -128,7 +135,7 @@ def test_builtin_policy_eviction_order(
 
     kvcr.deposit(
         {
-            key: _mem_descriptor(primary_addr + index * block_size)
+            key: [_mem_descriptor(primary_addr + index * block_size)]
             for index, key in enumerate(keys[:2])
         }
     )
@@ -143,7 +150,7 @@ def test_builtin_policy_eviction_order(
     assert first_claim is not None and second_claim is not None
     kvcr.release((second_claim, first_claim))
 
-    kvcr.deposit({keys[2]: _mem_descriptor(primary_addr + 2 * block_size)})
+    kvcr.deposit({keys[2]: [_mem_descriptor(primary_addr + 2 * block_size)]})
     _poll_until(kvcr, lambda results: bool(results))
     statuses = kvcr.query(keys)
     assert statuses.pop(evicted_index) == (QueryStatus.MISS, None)
@@ -170,7 +177,7 @@ def test_local_deposit_applies_optional_admission() -> None:
 
     op_handle = kvcr.deposit(
         {
-            key: _mem_descriptor(ctypes.addressof(primary) + index * block_size)
+            key: [_mem_descriptor(ctypes.addressof(primary) + index * block_size)]
             for index, key in enumerate(keys)
         },
         hints={"source": "framework"},
@@ -209,7 +216,7 @@ def test_policy_lifecycle_hook_failures_are_logged(caplog) -> None:
     with caplog.at_level(logging.WARNING, logger="kvcr.policy_runtime"):
         for index, key in enumerate(keys):
             op_handle = kvcr.deposit(
-                {key: _mem_descriptor(ctypes.addressof(primary) + index * block_size)}
+                {key: [_mem_descriptor(ctypes.addressof(primary) + index * block_size)]}
             )
             assert _poll_until(kvcr, lambda results: bool(results)) == [
                 (op_handle, _op_entries({key: True}))
@@ -246,10 +253,13 @@ def test_local_claims_fetch_deliver_release_and_capacity() -> None:
     kvcr._core._clock = lambda: now
     first_key, second_key = BlockKey(b"k0"), BlockKey(b"k1")
 
-    deposit = kvcr.deposit({first_key: _mem_descriptor(primary_addr)}, no_evict=True)
+    deposit = kvcr.deposit({first_key: [_mem_descriptor(primary_addr)]}, no_evict=True)
     _wait_until(lambda: bool(agent.transfers))
     assert capacity_requests == [1]
-    fetch = kvcr.fetch((first_key,))
+    layouts = {first_key: [(16, "")], second_key: [(8, "")]}
+    with pytest.raises(ValueError, match="expected layouts"):
+        kvcr.fetch((first_key, second_key), expected_layouts=layouts)
+    fetch = kvcr.fetch((first_key,), expected_layouts={first_key: [(block_size, "")]})
     assert kvcr.query((first_key,)) == [(QueryStatus.FETCHING, CacheTier.LOCAL_G2)]
     assert list(kvcr.poll_completed()) == []
 
@@ -257,14 +267,14 @@ def test_local_claims_fetch_deliver_release_and_capacity() -> None:
     completed = dict(_poll_until(kvcr, lambda results: len(results) == 2))
     deposit_result = completed[deposit][first_key]
     assert deposit_result.success
-    assert deposit_result.descriptor is not None
+    assert deposit_result.descriptors is None
     deposit_claim = deposit_result.release_handle
     assert deposit_claim is not None
 
     assert kvcr.query((first_key,)) == [(QueryStatus.HIT, CacheTier.LOCAL_G2)]
     fetch_result = completed[fetch][first_key]
     fetch_claim = fetch_result.release_handle
-    assert fetch_result.descriptor == deposit_result.descriptor
+    assert fetch_result.descriptors is not None
     assert fetch_claim is not None
 
     ready_fetch = kvcr.fetch((first_key,))
@@ -275,8 +285,8 @@ def test_local_claims_fetch_deliver_release_and_capacity() -> None:
     agent.state = "PROC"
     deliver = kvcr.deliver(
         {
-            first_key: _mem_descriptor(ctypes.addressof(destination)),
-            second_key: _mem_descriptor(ctypes.addressof(destination) + block_size),
+            first_key: [_mem_descriptor(ctypes.addressof(destination))],
+            second_key: [_mem_descriptor(ctypes.addressof(destination) + block_size)],
         }
     )
     _wait_until(lambda: len(agent.transfers) == 2)
@@ -287,7 +297,7 @@ def test_local_claims_fetch_deliver_release_and_capacity() -> None:
     ]
     assert kvcr.release((fetch_claim,)) == [(fetch_claim, False)]
 
-    blocked = kvcr.deposit({second_key: _mem_descriptor(primary_addr + block_size)})
+    blocked = kvcr.deposit({second_key: [_mem_descriptor(primary_addr + block_size)]})
     assert list(kvcr.poll_completed()) == [(blocked, _op_entries({second_key: False}))]
 
     agent.state = "DONE"
@@ -307,7 +317,9 @@ def test_local_claims_fetch_deliver_release_and_capacity() -> None:
     assert [meta.block_key for meta, *_ in policy.ingested] == [first_key]
     assert policy.removed == []
 
-    replacement = kvcr.deposit({second_key: _mem_descriptor(primary_addr + block_size)})
+    replacement = kvcr.deposit(
+        {second_key: [_mem_descriptor(primary_addr + block_size)]}
+    )
     assert capacity_requests == [1, 1]
     assert _poll_until(kvcr, lambda results: bool(results)) == [
         (replacement, _op_entries({second_key: True}))
@@ -373,7 +385,7 @@ def test_local_deposit_waits_for_safe_release(
     key = BlockKey(b"k0")
 
     op_handle = kvcr.deposit(
-        {key: _mem_descriptor(ctypes.addressof(primary), block_size)}
+        {key: [_mem_descriptor(ctypes.addressof(primary), block_size)]}
     )
     _wait_until(lambda: bool(agent.transfers))
     if failure == "timeout":
@@ -406,7 +418,7 @@ def test_local_initialize_failure_completes_without_failing_progress() -> None:
     key = BlockKey(b"k0")
 
     op_handle = kvcr.deposit(
-        {key: _mem_descriptor(ctypes.addressof(primary), len(primary))}
+        {key: [_mem_descriptor(ctypes.addressof(primary), len(primary))]}
     )
 
     assert _poll_until(kvcr, lambda results: bool(results)) == [
@@ -446,7 +458,7 @@ def test_a_recovered_pool_deposits_into_free_rows_then_evicts_to_admit_more() ->
     fresh = (BlockKey(b"fresh0"), BlockKey(b"fresh1"))
     operation = kvcr.deposit(
         {
-            key: _mem_descriptor(ctypes.addressof(primary) + index * block_size)
+            key: [_mem_descriptor(ctypes.addressof(primary) + index * block_size)]
             for index, key in enumerate(fresh)
         }
     )
@@ -465,7 +477,7 @@ def test_a_recovered_pool_deposits_into_free_rows_then_evicts_to_admit_more() ->
     assert not local_dram._free_slots
     extra = BlockKey(b"extra")
     operation = kvcr.deposit(
-        {extra: _mem_descriptor(ctypes.addressof(primary) + 2 * block_size)}
+        {extra: [_mem_descriptor(ctypes.addressof(primary) + 2 * block_size)]}
     )
     completed = dict(_poll_until(kvcr, lambda results: bool(results)))
 

--- a/tests/unit/test_kvcr_remote_source.py
+++ b/tests/unit/test_kvcr_remote_source.py
@@ -52,7 +52,11 @@ def test_kvcr_start_write_respects_framework_pin_deadline(
         source_agent,
         pinning,
         control,
-        KVCRConfig(nixl_agent_name="source", operation_timeout_ms=10_000),
+        KVCRConfig(
+            nixl_agent_name="source",
+            pool_layout=[(16, "")],
+            operation_timeout_ms=10_000,
+        ),
         name="source",
     )
     source._core._clock = clock
@@ -294,6 +298,7 @@ def test_kvcr_source_timeout_holds_pins_until_safe_release(
         control,
         KVCRConfig(
             nixl_agent_name="source",
+            pool_layout=[(16, "")],
             operation_timeout_ms=1000,
             enable_telemetry=True,
         ),
@@ -517,7 +522,11 @@ def test_source_telemetry_precedes_release_and_is_not_duplicated() -> None:
         agent,
         pinning,
         control,
-        KVCRConfig(nixl_agent_name="source", enable_telemetry=True),
+        KVCRConfig(
+            nixl_agent_name="source",
+            pool_layout=[(16, "")],
+            enable_telemetry=True,
+        ),
         name="source",
     )
 

--- a/tests/unit/test_kvcr_remote_source.py
+++ b/tests/unit/test_kvcr_remote_source.py
@@ -54,7 +54,7 @@ def test_kvcr_start_write_respects_framework_pin_deadline(
         control,
         KVCRConfig(
             nixl_agent_name="source",
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             operation_timeout_ms=10_000,
         ),
         name="source",
@@ -298,7 +298,7 @@ def test_kvcr_source_timeout_holds_pins_until_safe_release(
         control,
         KVCRConfig(
             nixl_agent_name="source",
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             operation_timeout_ms=1000,
             enable_telemetry=True,
         ),
@@ -524,7 +524,7 @@ def test_source_telemetry_precedes_release_and_is_not_duplicated() -> None:
         control,
         KVCRConfig(
             nixl_agent_name="source",
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             enable_telemetry=True,
         ),
         name="source",

--- a/tests/unit/test_kvcr_remote_target.py
+++ b/tests/unit/test_kvcr_remote_target.py
@@ -97,7 +97,7 @@ def test_kvcr_opportunistic_query_accepts_key_outside_hint():
     assert target.query((requested_key,), "req") == [
         (QueryStatus.FETCHABLE, CacheTier.REMOTE_G2)
     ]
-    target.deliver({requested_key: _mem_descriptor()}, request_id="req")
+    target.deliver({requested_key: [_mem_descriptor()]}, request_id="req")
 
     assert list(target.poll_completed()) == []
     _wait_until(lambda: bool(control.sent))
@@ -127,7 +127,7 @@ def test_remote_fetch_uses_local_then_framework_sources() -> None:
         source_control,
         name="source",
         local_dram=LocalDramOptions(
-            ctypes.addressof(source_local), len(source_local), 2
+            ctypes.addressof(source_local), [(len(source_local), "")]
         ),
         policy=source_policy,
     )
@@ -142,14 +142,14 @@ def test_remote_fetch_uses_local_then_framework_sources() -> None:
             eager_ctrl_connect=False,
         ),
         local_dram=LocalDramOptions(
-            ctypes.addressof(target_local), len(target_local), 2
+            ctypes.addressof(target_local), [(len(target_local), "")]
         ),
         inventory_sink=events.append,
         policy=policy,
     )
 
     source_deposit = source.deposit(
-        {keys[0]: _mem_descriptor(ctypes.addressof(source_primary), block_size)}
+        {keys[0]: [_mem_descriptor(ctypes.addressof(source_primary), block_size)]}
     )
     _wait_until(lambda: bool(source_agent.transfers))
     source_agent.state = "DONE"
@@ -205,7 +205,7 @@ def test_remote_fetch_uses_local_then_framework_sources() -> None:
     assert set(completed) == {fetch}
     assert all(result.success for result in completed[fetch].values())
     assert all(
-        result.descriptor is not None and result.release_handle is not None
+        result.descriptors is not None and result.release_handle is not None
         for result in completed[fetch].values()
     )
     assert target.query(keys, "req") == [
@@ -247,7 +247,7 @@ def test_remote_staging_commits_available_prefix() -> None:
         control,
         key_adapter=_ConstantHashAdapter(),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
-        local_dram=LocalDramOptions(ctypes.addressof(local), len(local), 2),
+        local_dram=LocalDramOptions(ctypes.addressof(local), [(len(local), "")]),
         inventory_sink=events.append,
     )
     target.submit_hint(_router_hint("tcp://source:1"), request_id="req")
@@ -262,7 +262,7 @@ def test_remote_staging_commits_available_prefix() -> None:
     assert len(completed) == 1 and completed[0][0] == fetch
     results = completed[0][1]
     assert results[keys[0]].success
-    assert results[keys[0]].descriptor is not None
+    assert results[keys[0]].descriptors is not None
     release_handle = results[keys[0]].release_handle
     assert release_handle is not None
     assert results[keys[1]] == OpEntryResult(OpEntryStatus.FAILED)
@@ -287,11 +287,12 @@ def test_remote_fetch_timeout_keeps_slot_until_source_is_terminal() -> None:
         control,
         KVCRConfig(
             nixl_agent_name="target",
+            pool_layout=[(16, "")],
             operation_timeout_ms=10,
         ),
         key_adapter=_ConstantHashAdapter(),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
-        local_dram=LocalDramOptions(ctypes.addressof(local), len(local), 1),
+        local_dram=LocalDramOptions(ctypes.addressof(local), [(len(local), "")]),
     )
     target._core._clock = lambda: now
     target.submit_hint(_router_hint("tcp://source:1"), request_id="req")
@@ -305,7 +306,7 @@ def test_remote_fetch_timeout_keeps_slot_until_source_is_terminal() -> None:
     ]
     assert target.query((key,), "req") == [(QueryStatus.FETCHABLE, CacheTier.REMOTE_G2)]
     assert _has_outstanding_operations(target)
-    blocked = target.deposit({replacement: _mem_descriptor(size=block_size)})
+    blocked = target.deposit({replacement: [_mem_descriptor(size=block_size)]})
     assert list(target.poll_completed()) == [
         (blocked, _op_entries({replacement: False}))
     ]
@@ -325,14 +326,14 @@ def test_kvcr_deliver_propagates_source_pin_miss():
         target_agent,
         FakePrimaryPinning(),
         target_control,
-        KVCRConfig(nixl_agent_name="target"),
+        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
     )
     source = _new_kvcr(
         source_agent,
         source_pinning,
         source_control,
-        KVCRConfig(nixl_agent_name="source"),
+        KVCRConfig(nixl_agent_name="source", pool_layout=[(16, "")]),
         name="source",
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
     )
@@ -340,7 +341,7 @@ def test_kvcr_deliver_propagates_source_pin_miss():
 
     target.submit_hint(_router_hint("tcp://source:1"), request_id="req")
     op_handle = target.deliver(
-        {key: _mem_descriptor()},
+        {key: [_mem_descriptor()]},
         request_id="req",
     )
     _wait_until(lambda: bool(target_control.sent))
@@ -369,7 +370,7 @@ def test_kvcr_deliver_propagates_source_pin_miss():
 
     target_control.sent = []
     retry_handle = target.deliver(
-        {key: _mem_descriptor()},
+        {key: [_mem_descriptor()]},
         request_id="req",
     )
     assert list(target.poll_completed()) == [(retry_handle, _op_entries({key: False}))]
@@ -389,7 +390,7 @@ def _acked_deliver(control, kvcr, source, key):
     control.sent = []
 
     kvcr.submit_hint(_router_hint(source), request_id="load")
-    op_handle = kvcr.deliver({key: _mem_descriptor()}, request_id="load")
+    op_handle = kvcr.deliver({key: [_mem_descriptor()]}, request_id="load")
     _wait_until(lambda: len(control.sent) == 1)
     sent = _decode_control_message(control.sent[-1][1])
     assert sent["type"] == "start_write"
@@ -404,7 +405,7 @@ def test_only_a_refusal_from_this_operation_s_source_finishes_it():
         FakeNixlAgent(metadata=b"target-md"),
         FakePrimaryPinning(),
         control,
-        KVCRConfig(nixl_agent_name="target"),
+        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
     )
     now = [0.0]
     kvcr._core._clock = lambda: now[0]
@@ -445,7 +446,7 @@ def test_kvcr_metadata_ack_retry_lifecycle():
         agent,
         pinning,
         control,
-        KVCRConfig(nixl_agent_name="target"),
+        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
     )
     now = [0.0]
     kvcr._core._clock = lambda: now[0]
@@ -477,7 +478,7 @@ def test_kvcr_metadata_ack_retry_lifecycle():
     key = BlockKey(b"k0")
     kvcr.submit_hint(_router_hint(source), request_id="load")
     control.send_result = False
-    op_handle = kvcr.deliver({key: _mem_descriptor()}, request_id="load")
+    op_handle = kvcr.deliver({key: [_mem_descriptor()]}, request_id="load")
     assert _poll_until(kvcr, lambda completed: bool(completed)) == [
         (op_handle, _op_entries({key: False}))
     ]
@@ -505,13 +506,17 @@ def test_kvcr_deliver_timeout_waits_for_terminal_notification(
         agent,
         FakePrimaryPinning(),
         control,
-        KVCRConfig(nixl_agent_name="target", operation_timeout_ms=1000),
+        KVCRConfig(
+            nixl_agent_name="target",
+            pool_layout=[(16, "")],
+            operation_timeout_ms=1000,
+        ),
     )
     kvcr._core._clock = lambda: now
     key = BlockKey(b"k0")
 
     kvcr.submit_hint(_router_hint("tcp://source:1"), request_id="req")
-    op_handle = kvcr.deliver({key: _mem_descriptor()}, request_id="req")
+    op_handle = kvcr.deliver({key: [_mem_descriptor()]}, request_id="req")
     _wait_until(
         lambda: any(
             _decode_control_message(message)["type"] == "start_write"
@@ -591,7 +596,7 @@ def test_kvcr_deliver_fails_closed_on_mixed_hint_sources():
         agent,
         FakePrimaryPinning(),
         control,
-        KVCRConfig(nixl_agent_name="target"),
+        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
     )
     key_a = _make_block_key(b"block-A", 0)
@@ -600,7 +605,7 @@ def test_kvcr_deliver_fails_closed_on_mixed_hint_sources():
     kvcr.submit_hint(_router_hint("tcp://source-B:1"), request_id="req")
 
     op_handle = kvcr.deliver(
-        {key_a: _mem_descriptor(), key_b: _mem_descriptor()}, request_id="req"
+        {key_a: [_mem_descriptor()], key_b: [_mem_descriptor()]}, request_id="req"
     )
 
     assert list(kvcr.poll_completed()) == [
@@ -615,7 +620,7 @@ def test_kvcr_deliver_fails_closed_when_hint_source_missing():
     kvcr = _new_kvcr(agent, FakePrimaryPinning(), control)
     key = _make_block_key(b"orphan", 0)
 
-    op_handle = kvcr.deliver({key: _mem_descriptor()}, request_id="req")
+    op_handle = kvcr.deliver({key: [_mem_descriptor()]}, request_id="req")
 
     assert list(kvcr.poll_completed()) == [(op_handle, _op_entries({key: False}))]
     assert control.sent == []
@@ -628,15 +633,15 @@ def test_kvcr_request_scoped_sources_do_not_overwrite():
         agent,
         FakePrimaryPinning(),
         control,
-        KVCRConfig(nixl_agent_name="target"),
+        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
     )
     key = _make_block_key(b"shared-block", 0)
 
     kvcr.submit_hint(_router_hint("tcp://source-A:1"), request_id="req-a")
     kvcr.submit_hint(_router_hint("tcp://source-B:1"), request_id="req-b")
-    op_a = kvcr.deliver({key: _mem_descriptor()}, request_id="req-a")
-    op_b = kvcr.deliver({key: _mem_descriptor()}, request_id="req-b")
+    op_a = kvcr.deliver({key: [_mem_descriptor()]}, request_id="req-a")
+    op_b = kvcr.deliver({key: [_mem_descriptor()]}, request_id="req-b")
 
     _wait_until(lambda: len(control.sent) == 2)
     assert [endpoint for endpoint, _ in control.sent] == [
@@ -668,7 +673,11 @@ def test_remote_framework_dram_transfers_available_prefix(
         target_agent,
         FakePrimaryPinning(),
         target_control,
-        KVCRConfig(nixl_agent_name="target", enable_telemetry=True),
+        KVCRConfig(
+            nixl_agent_name="target",
+            pool_layout=[(16, "")],
+            enable_telemetry=True,
+        ),
         key_adapter=_ConstantHashAdapter(),
         remote_options=RemoteFWDramOptions(
             eager_ctrl_connect=eager_ctrl_connect,
@@ -678,7 +687,11 @@ def test_remote_framework_dram_transfers_available_prefix(
         source_agent,
         source_pinning,
         source_control,
-        KVCRConfig(nixl_agent_name="source", enable_telemetry=True),
+        KVCRConfig(
+            nixl_agent_name="source",
+            pool_layout=[(16, "")],
+            enable_telemetry=True,
+        ),
         name="source",
         remote_options=RemoteFWDramOptions(backend="REMOTE"),
     )
@@ -698,7 +711,7 @@ def test_remote_framework_dram_transfers_available_prefix(
 
     op_handle = target.deliver(
         {
-            key: _mem_descriptor(addr=8192 + index * 16)
+            key: [_mem_descriptor(addr=8192 + index * 16)]
             for index, key in enumerate(keys)
         },
         request_id="req",

--- a/tests/unit/test_kvcr_remote_target.py
+++ b/tests/unit/test_kvcr_remote_target.py
@@ -127,7 +127,7 @@ def test_remote_fetch_uses_local_then_framework_sources() -> None:
         source_control,
         name="source",
         local_dram=LocalDramOptions(
-            ctypes.addressof(source_local), [(len(source_local), "")]
+            [("", ctypes.addressof(source_local), len(source_local))]
         ),
         policy=source_policy,
     )
@@ -142,7 +142,7 @@ def test_remote_fetch_uses_local_then_framework_sources() -> None:
             eager_ctrl_connect=False,
         ),
         local_dram=LocalDramOptions(
-            ctypes.addressof(target_local), [(len(target_local), "")]
+            [("", ctypes.addressof(target_local), len(target_local))]
         ),
         inventory_sink=events.append,
         policy=policy,
@@ -247,7 +247,7 @@ def test_remote_staging_commits_available_prefix() -> None:
         control,
         key_adapter=_ConstantHashAdapter(),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
-        local_dram=LocalDramOptions(ctypes.addressof(local), [(len(local), "")]),
+        local_dram=LocalDramOptions([("", ctypes.addressof(local), len(local))]),
         inventory_sink=events.append,
     )
     target.submit_hint(_router_hint("tcp://source:1"), request_id="req")
@@ -287,12 +287,12 @@ def test_remote_fetch_timeout_keeps_slot_until_source_is_terminal() -> None:
         control,
         KVCRConfig(
             nixl_agent_name="target",
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             operation_timeout_ms=10,
         ),
         key_adapter=_ConstantHashAdapter(),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
-        local_dram=LocalDramOptions(ctypes.addressof(local), [(len(local), "")]),
+        local_dram=LocalDramOptions([("", ctypes.addressof(local), len(local))]),
     )
     target._core._clock = lambda: now
     target.submit_hint(_router_hint("tcp://source:1"), request_id="req")
@@ -326,14 +326,14 @@ def test_kvcr_deliver_propagates_source_pin_miss():
         target_agent,
         FakePrimaryPinning(),
         target_control,
-        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
+        KVCRConfig(nixl_agent_name="target", pool_layouts=[("", 16)]),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
     )
     source = _new_kvcr(
         source_agent,
         source_pinning,
         source_control,
-        KVCRConfig(nixl_agent_name="source", pool_layout=[(16, "")]),
+        KVCRConfig(nixl_agent_name="source", pool_layouts=[("", 16)]),
         name="source",
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
     )
@@ -405,7 +405,7 @@ def test_only_a_refusal_from_this_operation_s_source_finishes_it():
         FakeNixlAgent(metadata=b"target-md"),
         FakePrimaryPinning(),
         control,
-        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
+        KVCRConfig(nixl_agent_name="target", pool_layouts=[("", 16)]),
     )
     now = [0.0]
     kvcr._core._clock = lambda: now[0]
@@ -446,7 +446,7 @@ def test_kvcr_metadata_ack_retry_lifecycle():
         agent,
         pinning,
         control,
-        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
+        KVCRConfig(nixl_agent_name="target", pool_layouts=[("", 16)]),
     )
     now = [0.0]
     kvcr._core._clock = lambda: now[0]
@@ -508,7 +508,7 @@ def test_kvcr_deliver_timeout_waits_for_terminal_notification(
         control,
         KVCRConfig(
             nixl_agent_name="target",
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             operation_timeout_ms=1000,
         ),
     )
@@ -596,7 +596,7 @@ def test_kvcr_deliver_fails_closed_on_mixed_hint_sources():
         agent,
         FakePrimaryPinning(),
         control,
-        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
+        KVCRConfig(nixl_agent_name="target", pool_layouts=[("", 16)]),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
     )
     key_a = _make_block_key(b"block-A", 0)
@@ -633,7 +633,7 @@ def test_kvcr_request_scoped_sources_do_not_overwrite():
         agent,
         FakePrimaryPinning(),
         control,
-        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
+        KVCRConfig(nixl_agent_name="target", pool_layouts=[("", 16)]),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
     )
     key = _make_block_key(b"shared-block", 0)
@@ -675,7 +675,7 @@ def test_remote_framework_dram_transfers_available_prefix(
         target_control,
         KVCRConfig(
             nixl_agent_name="target",
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             enable_telemetry=True,
         ),
         key_adapter=_ConstantHashAdapter(),
@@ -689,7 +689,7 @@ def test_remote_framework_dram_transfers_available_prefix(
         source_control,
         KVCRConfig(
             nixl_agent_name="source",
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             enable_telemetry=True,
         ),
         name="source",

--- a/tests/unit/test_kvcr_service.py
+++ b/tests/unit/test_kvcr_service.py
@@ -64,8 +64,9 @@ _TEST_JOURNAL_BYTES = 8192
 _TEST_POOL_SIZE_BYTES = 8192
 _TEST_POOL_SIZES_BYTES = (_TEST_POOL_SIZE_BYTES,)
 _TEST_ROW_STRIDE = 1024
+_TEST_POOL_LAYOUT = [(_TEST_ROW_STRIDE, "")]
 _TEST_DIGEST = "opaque digest: Preserve-Me EXACTLY"
-_TEST_TIER_CONFIG = _TierConfig(_TEST_ROW_STRIDE, None)
+_TEST_TIER_CONFIG = _TierConfig(_TEST_POOL_LAYOUT, None)
 # G3 terms are refused at decode unless a real claimant could open them, so
 # the one claim that carries G3 uses a page-aligned stride.
 _PAGE_STRIDE = os.sysconf("SC_PAGE_SIZE")
@@ -275,7 +276,10 @@ def test_registry_lifecycle_from_independent_leases_to_a_wedged_close(
     first, second, third = _FakeLiveness(), _FakeLiveness(), _FakeLiveness()
     first_spec, stale = _claim(registry, 0, first)
     _spec, _fd, _lease = registry.claim(
-        1, _TierConfig(_TEST_ROW_STRIDE * 2, None), second, _control_bind(1)
+        1,
+        _TierConfig([(_TEST_ROW_STRIDE * 2, "")], None),
+        second,
+        _control_bind(1),
     )
     os.close(_fd)
     # One pool's geometry says nothing about another's.
@@ -339,11 +343,11 @@ def test_refused_claims_do_not_bind_the_pool(tmp_path: Path) -> None:
 
         taken = (str(squatter.getsockname()[0]), int(squatter.getsockname()[1]))
         with pytest.raises(KVCRServiceError, match="control listener"):
-            harness.client.claim(0, _TEST_ROW_STRIDE, _TEST_DIGEST, control_bind=taken)
+            harness.client.claim(0, _TEST_POOL_LAYOUT, _TEST_DIGEST, control_bind=taken)
 
         # The rejected claims left the pool free to take normally.
         harness.client.claim(
-            0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_bind()
+            0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind()
         ).release()
 
 
@@ -396,10 +400,12 @@ def test_a_grant_tells_the_pools_guard_and_a_clean_release_stands_it_down(
         # Built and started with the pool, before any claim named it.
         assert guard._phase is _Phase.UNCONFIGURED
 
-        hold = harness.client.claim(1, _PAGE_STRIDE, _TEST_DIGEST, _control_bind(), g3)
+        hold = harness.client.claim(
+            1, [(_PAGE_STRIDE, "")], _TEST_DIGEST, _control_bind(), g3
+        )
         assert guard._phase is _Phase.PRIMARY and guard._control is control
         assert guard._configured == _TierConfig(
-            _PAGE_STRIDE,
+            [(_PAGE_STRIDE, "")],
             _G3Config(
                 paths=(str(g3.paths[0]),),
                 capacity_bytes_per_file=g3.capacity_bytes_per_file,
@@ -509,7 +515,7 @@ def test_a_standby_survives_failed_claims_and_hands_over_to_a_replacement(
         with pytest.raises(KVCRServiceError, match="another tier configuration"):
             registry.claim(
                 0,
-                _TierConfig(_TEST_ROW_STRIDE * 2, None),
+                _TierConfig([(_TEST_ROW_STRIDE * 2, "")], None),
                 _FakeLiveness(),
                 control_bind,
             )
@@ -595,11 +601,14 @@ def test_claim_refusals_and_internal_failures_do_not_bind(
         spec = harness.server._registry._guards[0]._owner.spec
         with pytest.raises(KVCRServiceError, match="compatibility digest"):
             harness.client.claim(
-                0, _TEST_ROW_STRIDE, _TEST_DIGEST.swapcase(), _control_bind()
+                0, _TEST_POOL_LAYOUT, _TEST_DIGEST.swapcase(), _control_bind()
             )
-        with pytest.raises(KVCRServiceError, match="one complete KV row"):
+        with pytest.raises(KVCRServiceError, match="one complete KV block"):
             harness.client.claim(
-                0, _TEST_POOL_SIZE_BYTES + 1, _TEST_DIGEST, _control_bind()
+                0,
+                [(_TEST_POOL_SIZE_BYTES + 1, "")],
+                _TEST_DIGEST,
+                _control_bind(),
             )
         assert "Unexpected failure while handling KVCR claim" not in caplog.text
 
@@ -611,7 +620,9 @@ def test_claim_refusals_and_internal_failures_do_not_bind(
                 Mock(side_effect=internal_error),
             )
             with pytest.raises(KVCRServiceError, match="internal KVCR service error"):
-                harness.client.claim(0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_bind())
+                harness.client.claim(
+                    0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind()
+                )
 
         log_record = next(
             record
@@ -623,7 +634,7 @@ def test_claim_refusals_and_internal_failures_do_not_bind(
         assert harness.server._registry._guards[0]._owner.spec is spec
         assert _holders_of(harness.server._registry) == {}
         harness.client.claim(
-            0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_bind()
+            0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind()
         ).release()
 
 
@@ -681,7 +692,7 @@ def test_fork_and_exec_do_not_preserve_claimant_access(
                 "import time",
                 "from kvcr.guard_protocol import KVCRClient",
                 f"hold = KVCRClient({str(harness.server.socket_path)!r}).claim("
-                f"0, {_TEST_ROW_STRIDE}, {_TEST_DIGEST!r}, {_control_bind()!r})",
+                f"0, {_TEST_POOL_LAYOUT!r}, {_TEST_DIGEST!r}, {_control_bind()!r})",
                 "forked_pid = os.fork()",
                 "if forked_pid == 0:",
                 "    hold._connection.close()",
@@ -712,7 +723,9 @@ def test_fork_and_exec_do_not_preserve_claimant_access(
             assert spec is not None
             assert spec.path not in Path(f"/proc/{forked_pid}/maps").read_text()
             with pytest.raises(KVCRServiceError, match="held"):
-                harness.client.claim(0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_bind())
+                harness.client.claim(
+                    0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind()
+                )
 
             child.terminate()
             child.wait(timeout=_SERVER_STOP_TIMEOUT_SECONDS)
@@ -1048,7 +1061,7 @@ def test_a_lease_older_than_the_idle_timeout_still_releases_cleanly(
     """The accept-time idle timeout must not sever a held connection."""
     monkeypatch.setattr("kvcr.kvcr_service._CLIENT_IDLE_TIMEOUT_SECONDS", 0.2)
     with _running_server(tmp_path) as harness:
-        hold = harness.client.claim(0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_bind())
+        hold = harness.client.claim(0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind())
         time.sleep(0.5)
 
         hold.release()
@@ -1218,7 +1231,7 @@ def test_a_close_in_progress_absorbs_races_and_answers_stragglers(
 
 def test_shutdown_drains_a_held_connection(tmp_path: Path) -> None:
     with _running_server(tmp_path) as harness:
-        hold = harness.client.claim(0, _TEST_ROW_STRIDE, _TEST_DIGEST, _control_bind())
+        hold = harness.client.claim(0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind())
         harness.stop()
         _wait_for_connection_state(harness.server, connected=False)
         hold._attachment.close()

--- a/tests/unit/test_kvcr_service.py
+++ b/tests/unit/test_kvcr_service.py
@@ -63,10 +63,10 @@ _TEST_GUARD_COUNT = 2
 _TEST_JOURNAL_BYTES = 8192
 _TEST_POOL_SIZE_BYTES = 8192
 _TEST_POOL_SIZES_BYTES = (_TEST_POOL_SIZE_BYTES,)
-_TEST_ROW_STRIDE = 1024
-_TEST_POOL_LAYOUT = [(_TEST_ROW_STRIDE, "")]
+_TEST_BLOCK_SIZE_BYTES = 1024
+_TEST_POOL_LAYOUTS = [("", _TEST_BLOCK_SIZE_BYTES)]
 _TEST_DIGEST = "opaque digest: Preserve-Me EXACTLY"
-_TEST_TIER_CONFIG = _TierConfig(_TEST_POOL_LAYOUT, None)
+_TEST_TIER_CONFIG = _TierConfig(_TEST_POOL_LAYOUTS, None)
 # G3 terms are refused at decode unless a real claimant could open them, so
 # the one claim that carries G3 uses a page-aligned stride.
 _PAGE_STRIDE = os.sysconf("SC_PAGE_SIZE")
@@ -277,7 +277,7 @@ def test_registry_lifecycle_from_independent_leases_to_a_wedged_close(
     first_spec, stale = _claim(registry, 0, first)
     _spec, _fd, _lease = registry.claim(
         1,
-        _TierConfig([(_TEST_ROW_STRIDE * 2, "")], None),
+        _TierConfig([("", _TEST_BLOCK_SIZE_BYTES * 2)], None),
         second,
         _control_bind(1),
     )
@@ -343,11 +343,13 @@ def test_refused_claims_do_not_bind_the_pool(tmp_path: Path) -> None:
 
         taken = (str(squatter.getsockname()[0]), int(squatter.getsockname()[1]))
         with pytest.raises(KVCRServiceError, match="control listener"):
-            harness.client.claim(0, _TEST_POOL_LAYOUT, _TEST_DIGEST, control_bind=taken)
+            harness.client.claim(
+                0, _TEST_POOL_LAYOUTS, _TEST_DIGEST, control_bind=taken
+            )
 
         # The rejected claims left the pool free to take normally.
         harness.client.claim(
-            0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind()
+            0, _TEST_POOL_LAYOUTS, _TEST_DIGEST, _control_bind()
         ).release()
 
 
@@ -401,11 +403,11 @@ def test_a_grant_tells_the_pools_guard_and_a_clean_release_stands_it_down(
         assert guard._phase is _Phase.UNCONFIGURED
 
         hold = harness.client.claim(
-            1, [(_PAGE_STRIDE, "")], _TEST_DIGEST, _control_bind(), g3
+            1, [("", _PAGE_STRIDE)], _TEST_DIGEST, _control_bind(), g3
         )
         assert guard._phase is _Phase.PRIMARY and guard._control is control
         assert guard._configured == _TierConfig(
-            [(_PAGE_STRIDE, "")],
+            [("", _PAGE_STRIDE)],
             _G3Config(
                 paths=(str(g3.paths[0]),),
                 capacity_bytes_per_file=g3.capacity_bytes_per_file,
@@ -515,7 +517,7 @@ def test_a_standby_survives_failed_claims_and_hands_over_to_a_replacement(
         with pytest.raises(KVCRServiceError, match="another tier configuration"):
             registry.claim(
                 0,
-                _TierConfig([(_TEST_ROW_STRIDE * 2, "")], None),
+                _TierConfig([("", _TEST_BLOCK_SIZE_BYTES * 2)], None),
                 _FakeLiveness(),
                 control_bind,
             )
@@ -601,12 +603,12 @@ def test_claim_refusals_and_internal_failures_do_not_bind(
         spec = harness.server._registry._guards[0]._owner.spec
         with pytest.raises(KVCRServiceError, match="compatibility digest"):
             harness.client.claim(
-                0, _TEST_POOL_LAYOUT, _TEST_DIGEST.swapcase(), _control_bind()
+                0, _TEST_POOL_LAYOUTS, _TEST_DIGEST.swapcase(), _control_bind()
             )
         with pytest.raises(KVCRServiceError, match="one complete KV block"):
             harness.client.claim(
                 0,
-                [(_TEST_POOL_SIZE_BYTES + 1, "")],
+                [("", _TEST_POOL_SIZE_BYTES + 1)],
                 _TEST_DIGEST,
                 _control_bind(),
             )
@@ -621,7 +623,7 @@ def test_claim_refusals_and_internal_failures_do_not_bind(
             )
             with pytest.raises(KVCRServiceError, match="internal KVCR service error"):
                 harness.client.claim(
-                    0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind()
+                    0, _TEST_POOL_LAYOUTS, _TEST_DIGEST, _control_bind()
                 )
 
         log_record = next(
@@ -634,7 +636,7 @@ def test_claim_refusals_and_internal_failures_do_not_bind(
         assert harness.server._registry._guards[0]._owner.spec is spec
         assert _holders_of(harness.server._registry) == {}
         harness.client.claim(
-            0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind()
+            0, _TEST_POOL_LAYOUTS, _TEST_DIGEST, _control_bind()
         ).release()
 
 
@@ -692,7 +694,7 @@ def test_fork_and_exec_do_not_preserve_claimant_access(
                 "import time",
                 "from kvcr.guard_protocol import KVCRClient",
                 f"hold = KVCRClient({str(harness.server.socket_path)!r}).claim("
-                f"0, {_TEST_POOL_LAYOUT!r}, {_TEST_DIGEST!r}, {_control_bind()!r})",
+                f"0, {_TEST_POOL_LAYOUTS!r}, {_TEST_DIGEST!r}, {_control_bind()!r})",
                 "forked_pid = os.fork()",
                 "if forked_pid == 0:",
                 "    hold._connection.close()",
@@ -724,7 +726,7 @@ def test_fork_and_exec_do_not_preserve_claimant_access(
             assert spec.path not in Path(f"/proc/{forked_pid}/maps").read_text()
             with pytest.raises(KVCRServiceError, match="held"):
                 harness.client.claim(
-                    0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind()
+                    0, _TEST_POOL_LAYOUTS, _TEST_DIGEST, _control_bind()
                 )
 
             child.terminate()
@@ -1061,7 +1063,9 @@ def test_a_lease_older_than_the_idle_timeout_still_releases_cleanly(
     """The accept-time idle timeout must not sever a held connection."""
     monkeypatch.setattr("kvcr.kvcr_service._CLIENT_IDLE_TIMEOUT_SECONDS", 0.2)
     with _running_server(tmp_path) as harness:
-        hold = harness.client.claim(0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind())
+        hold = harness.client.claim(
+            0, _TEST_POOL_LAYOUTS, _TEST_DIGEST, _control_bind()
+        )
         time.sleep(0.5)
 
         hold.release()
@@ -1231,7 +1235,9 @@ def test_a_close_in_progress_absorbs_races_and_answers_stragglers(
 
 def test_shutdown_drains_a_held_connection(tmp_path: Path) -> None:
     with _running_server(tmp_path) as harness:
-        hold = harness.client.claim(0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind())
+        hold = harness.client.claim(
+            0, _TEST_POOL_LAYOUTS, _TEST_DIGEST, _control_bind()
+        )
         harness.stop()
         _wait_for_connection_state(harness.server, connected=False)
         hold._attachment.close()

--- a/tests/unit/test_kvcr_service_workflow.py
+++ b/tests/unit/test_kvcr_service_workflow.py
@@ -75,7 +75,10 @@ def _claim_when_ready(
     while time.monotonic() < deadline:
         try:
             return client.claim(
-                guard_index, _ROW_STRIDE, _DIGEST, _control_bind(guard_index)
+                guard_index,
+                [(_ROW_STRIDE, "")],
+                _DIGEST,
+                _control_bind(guard_index),
             )
         except KVCRSocketError:
             if process.poll() is not None:
@@ -153,14 +156,16 @@ def test_pools_persist_bytes_and_a_held_pool_refuses_claims(tmp_path: Path) -> N
 
     with _running_service(pool_dir) as socket_path:
         client = KVCRClient(socket_path)
-        first = client.claim(0, _ROW_STRIDE, _DIGEST, _control_bind(0))
-        second = client.claim(1, _ROW_STRIDE, _DIGEST, _control_bind(1))
+        first = client.claim(0, [(_ROW_STRIDE, "")], _DIGEST, _control_bind(0))
+        second = client.claim(1, [(_ROW_STRIDE, "")], _DIGEST, _control_bind(1))
         try:
             assert first.local_dram.address != second.local_dram.address
             ctypes.memmove(first.local_dram.address, payload, len(payload))
 
             first.release()
-            replacement = client.claim(0, _ROW_STRIDE, _DIGEST, _control_bind(0))
+            replacement = client.claim(
+                0, [(_ROW_STRIDE, "")], _DIGEST, _control_bind(0)
+            )
             try:
                 assert (
                     ctypes.string_at(replacement.local_dram.address, len(payload))
@@ -176,7 +181,11 @@ def test_pools_persist_bytes_and_a_held_pool_refuses_claims(tmp_path: Path) -> N
             control = ZmqPeerControlChannel(host, port, host)
             with _use_nixl_agent(FakeNixlAgent()):
                 controller = KVCR(
-                    KVCRConfig(nixl_agent_name="target", nixl_listen_port=1),
+                    KVCRConfig(
+                        nixl_agent_name="target",
+                        pool_layout=[(_ROW_STRIDE, "")],
+                        nixl_listen_port=1,
+                    ),
                     KVCRBindings(
                         pinning.request_pin,
                         pinning.poll_pin_results,
@@ -187,19 +196,18 @@ def test_pools_persist_bytes_and_a_held_pool_refuses_claims(tmp_path: Path) -> N
                     KVCRGuardConfig(
                         kvcr_service_socket_path=str(socket_path),
                         guard_index=0,
-                        row_stride=_ROW_STRIDE,
                         compatibility_digest=_DIGEST,
                     ),
                 )
             try:
                 with pytest.raises(KVCRServiceError, match="held"):
-                    client.claim(0, _ROW_STRIDE, _DIGEST, (host, port))
+                    client.claim(0, [(_ROW_STRIDE, "")], _DIGEST, (host, port))
             finally:
                 controller.close()
                 control.close()
 
             # Closing the worker released the pool: the next claim is served.
-            reclaimed = client.claim(0, _ROW_STRIDE, _DIGEST, (host, port))
+            reclaimed = client.claim(0, [(_ROW_STRIDE, "")], _DIGEST, (host, port))
             reclaimed.release()
         finally:
             second.release()
@@ -220,13 +228,11 @@ def test_cli_daemon_sets_geometry_and_restart_reclaims_only_unattached(
             pools = list(pool_dir.iterdir())
             assert len(pools) == 2, "--guard-count pools at startup"
             pool_bytes = int(float(_CLI_POOL_SIZE_GB) * (1 << 30))
-            client_rows = pool_bytes // _ROW_STRIDE
             assert all(
                 path.stat().st_size == _DEFAULT_JOURNAL_BYTES + pool_bytes
                 for path in pools
             )
-            assert hold.local_dram.length == client_rows * _ROW_STRIDE
-            assert hold.local_dram.slot_count == client_rows
+            assert hold.local_dram.pool_sizes_bytes == [(pool_bytes, "")]
 
             attached_pool = next(pool_dir.glob("kvcr-pool_0-*"))
             unclaimed_pool = next(pool_dir.glob("kvcr-pool_1-*"))

--- a/tests/unit/test_kvcr_service_workflow.py
+++ b/tests/unit/test_kvcr_service_workflow.py
@@ -33,7 +33,7 @@ from kvcr.config import KVCRBackendConfigs, KVCRConfig, KVCRGuardConfig
 from kvcr.control_channels import ZmqPeerControlChannel
 from kvcr.kvcr_service import _DEFAULT_JOURNAL_BYTES, _KVCRService
 
-_ROW_STRIDE = 1024
+_BLOCK_SIZE_BYTES = 1024
 _DIGEST = "opaque workflow digest: Preserve-Me EXACTLY"
 _JOURNAL_BYTES = 8192
 _POOL_SIZE_BYTES = 8192
@@ -76,7 +76,7 @@ def _claim_when_ready(
         try:
             return client.claim(
                 guard_index,
-                [(_ROW_STRIDE, "")],
+                [("", _BLOCK_SIZE_BYTES)],
                 _DIGEST,
                 _control_bind(guard_index),
             )
@@ -156,19 +156,20 @@ def test_pools_persist_bytes_and_a_held_pool_refuses_claims(tmp_path: Path) -> N
 
     with _running_service(pool_dir) as socket_path:
         client = KVCRClient(socket_path)
-        first = client.claim(0, [(_ROW_STRIDE, "")], _DIGEST, _control_bind(0))
-        second = client.claim(1, [(_ROW_STRIDE, "")], _DIGEST, _control_bind(1))
+        first = client.claim(0, [("", _BLOCK_SIZE_BYTES)], _DIGEST, _control_bind(0))
+        second = client.claim(1, [("", _BLOCK_SIZE_BYTES)], _DIGEST, _control_bind(1))
         try:
-            assert first.local_dram.address != second.local_dram.address
-            ctypes.memmove(first.local_dram.address, payload, len(payload))
+            first_address = first.local_dram.pools[0][1]
+            assert first_address != second.local_dram.pools[0][1]
+            ctypes.memmove(first_address, payload, len(payload))
 
             first.release()
             replacement = client.claim(
-                0, [(_ROW_STRIDE, "")], _DIGEST, _control_bind(0)
+                0, [("", _BLOCK_SIZE_BYTES)], _DIGEST, _control_bind(0)
             )
             try:
                 assert (
-                    ctypes.string_at(replacement.local_dram.address, len(payload))
+                    ctypes.string_at(replacement.local_dram.pools[0][1], len(payload))
                     == payload
                 )
             finally:
@@ -183,7 +184,7 @@ def test_pools_persist_bytes_and_a_held_pool_refuses_claims(tmp_path: Path) -> N
                 controller = KVCR(
                     KVCRConfig(
                         nixl_agent_name="target",
-                        pool_layout=[(_ROW_STRIDE, "")],
+                        pool_layouts=[("", _BLOCK_SIZE_BYTES)],
                         nixl_listen_port=1,
                     ),
                     KVCRBindings(
@@ -201,13 +202,15 @@ def test_pools_persist_bytes_and_a_held_pool_refuses_claims(tmp_path: Path) -> N
                 )
             try:
                 with pytest.raises(KVCRServiceError, match="held"):
-                    client.claim(0, [(_ROW_STRIDE, "")], _DIGEST, (host, port))
+                    client.claim(0, [("", _BLOCK_SIZE_BYTES)], _DIGEST, (host, port))
             finally:
                 controller.close()
                 control.close()
 
             # Closing the worker released the pool: the next claim is served.
-            reclaimed = client.claim(0, [(_ROW_STRIDE, "")], _DIGEST, (host, port))
+            reclaimed = client.claim(
+                0, [("", _BLOCK_SIZE_BYTES)], _DIGEST, (host, port)
+            )
             reclaimed.release()
         finally:
             second.release()
@@ -232,7 +235,9 @@ def test_cli_daemon_sets_geometry_and_restart_reclaims_only_unattached(
                 path.stat().st_size == _DEFAULT_JOURNAL_BYTES + pool_bytes
                 for path in pools
             )
-            assert hold.local_dram.pool_sizes_bytes == [(pool_bytes, "")]
+            pool_name, address, size_bytes = hold.local_dram.pools[0]
+            assert (pool_name, size_bytes) == ("", pool_bytes)
+            assert address > 0
 
             attached_pool = next(pool_dir.glob("kvcr-pool_0-*"))
             unclaimed_pool = next(pool_dir.glob("kvcr-pool_1-*"))

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -43,11 +43,11 @@ def pool_owner(tmp_path: Path) -> Iterator[_KVCRPoolOwner]:
 
 
 @pytest.mark.parametrize(
-    ("requested_bytes", "row_stride", "expected"),
+    ("requested_bytes", "block_size_bytes", "expected"),
     [
         (4096, 1024, nullcontext((4096, 4))),
         (4097, 1024, nullcontext((4096, 4))),
-        (1023, 1024, pytest.raises(ValueError, match="one complete KV row")),
+        (1023, 1024, pytest.raises(ValueError, match="one complete KV block")),
         (True, 1, pytest.raises(TypeError)),
         (0, 1, pytest.raises(ValueError)),
         (1, True, pytest.raises(TypeError)),
@@ -56,12 +56,12 @@ def pool_owner(tmp_path: Path) -> Iterator[_KVCRPoolOwner]:
 )
 def test_pool_geometry_is_row_aligned_and_validated(
     requested_bytes: int,
-    row_stride: int,
+    block_size_bytes: int,
     expected: AbstractContextManager[tuple[int, int] | None],
 ) -> None:
-    """Geometry snaps down to whole KV rows and refuses non-positive or bool input."""
+    """Geometry snaps down to whole KV blocks and refuses invalid input."""
     with expected as geometry:
-        assert _compute_pool_geometry(requested_bytes, row_stride) == geometry
+        assert _compute_pool_geometry(requested_bytes, block_size_bytes) == geometry
 
 
 def test_an_allocated_pool_serves_attachments_and_only_its_owner_unlinks_it(

--- a/tests/unit/test_recovery_journal.py
+++ b/tests/unit/test_recovery_journal.py
@@ -279,7 +279,7 @@ def test_a_handback_region_lives_and_dies_inside_the_pool_file(tmp_path: Path) -
     """Replayed whole under its own terms, discardable when torn, gone once released."""
     with _attached(tmp_path) as pool:
         path = Path(pool._spec.path)
-        terms = canonical_pool_terms(_TEST_DIGEST, 4096, pool._spec)
+        terms = canonical_pool_terms(_TEST_DIGEST, [(4096, "")], pool._spec)
         assert list(read_recovery_snapshot(pool, terms)) == []
 
         records = {
@@ -301,8 +301,8 @@ def test_a_handback_region_lives_and_dies_inside_the_pool_file(tmp_path: Path) -
 
         # A slot number only means the same bytes under the same geometry.
         for other in (
-            canonical_pool_terms("another-digest", 4096, pool._spec),
-            canonical_pool_terms(_TEST_DIGEST, 8192, pool._spec),
+            canonical_pool_terms("another-digest", [(4096, "")], pool._spec),
+            canonical_pool_terms(_TEST_DIGEST, [(8192, "")], pool._spec),
         ):
             with pytest.raises(RecoveryJournalError, match="other terms"):
                 list(read_recovery_snapshot(pool, other))
@@ -328,7 +328,7 @@ def test_a_handback_region_lives_and_dies_inside_the_pool_file(tmp_path: Path) -
             region[: _SNAPSHOT_HEADER.size] = bytes(_SNAPSHOT_HEADER.size)
         with pytest.raises(RecoveryJournalTornError, match="unfinished"):
             list(read_recovery_snapshot(pool, terms))
-        assert read_handback(pool, _TEST_DIGEST, 4096)._records == {}
+        assert read_handback(pool, _TEST_DIGEST, [(4096, "")])._records == {}
         assert list(read_recovery_snapshot(pool, terms)) == []
 
         # A released region is truncated away, so it replays nothing.

--- a/tests/unit/test_recovery_journal.py
+++ b/tests/unit/test_recovery_journal.py
@@ -279,7 +279,7 @@ def test_a_handback_region_lives_and_dies_inside_the_pool_file(tmp_path: Path) -
     """Replayed whole under its own terms, discardable when torn, gone once released."""
     with _attached(tmp_path) as pool:
         path = Path(pool._spec.path)
-        terms = canonical_pool_terms(_TEST_DIGEST, [(4096, "")], pool._spec)
+        terms = canonical_pool_terms(_TEST_DIGEST, [("", 4096)], pool._spec)
         assert list(read_recovery_snapshot(pool, terms)) == []
 
         records = {
@@ -301,8 +301,8 @@ def test_a_handback_region_lives_and_dies_inside_the_pool_file(tmp_path: Path) -
 
         # A slot number only means the same bytes under the same geometry.
         for other in (
-            canonical_pool_terms("another-digest", [(4096, "")], pool._spec),
-            canonical_pool_terms(_TEST_DIGEST, [(8192, "")], pool._spec),
+            canonical_pool_terms("another-digest", [("", 4096)], pool._spec),
+            canonical_pool_terms(_TEST_DIGEST, [("", 8192)], pool._spec),
         ):
             with pytest.raises(RecoveryJournalError, match="other terms"):
                 list(read_recovery_snapshot(pool, other))
@@ -328,7 +328,7 @@ def test_a_handback_region_lives_and_dies_inside_the_pool_file(tmp_path: Path) -
             region[: _SNAPSHOT_HEADER.size] = bytes(_SNAPSHOT_HEADER.size)
         with pytest.raises(RecoveryJournalTornError, match="unfinished"):
             list(read_recovery_snapshot(pool, terms))
-        assert read_handback(pool, _TEST_DIGEST, [(4096, "")])._records == {}
+        assert read_handback(pool, _TEST_DIGEST, [("", 4096)])._records == {}
         assert list(read_recovery_snapshot(pool, terms)) == []
 
         # A released region is truncated away, so it replays nothing.


### PR DESCRIPTION
Updates KVCR APIs so each block key can reference an ordered list of memory descriptors, laying the groundwork for data spanning multiple pools. Introduces named pool layouts in KVCR configuration and the Guard protocol, with each descriptor’s `info` field identifying its pool. This PR focuses on the API foundation; full multi-pool functionality will follow.