### PR TITLE
Define named pool layout and region lists

### DIFF
--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -136,7 +136,7 @@ The framework and KVCR interact through the following API.
 # Python-style pseudocode
 # Framework → KVCR
 kvcr = KVCR(
-    pool_layout=[(block_size_bytes, pool_name), ...],
+    pool_layouts=[(pool_name, block_size_bytes), ...],
     compatibility_manifest=compatibility_manifest,
     kvcr_guard_endpoint=None,
     peer_control_endpoint=peer_control_endpoint,
@@ -165,9 +165,9 @@ framework.release_pin(pin_handle)                                               
 The list-shaped API allows a key to span multiple pools. A descriptor's `info`
 can identify its pool and may be extended for other descriptor metadata.
 `fetch` may receive the expected layout shared by its keys as an ordered list
-of pool names so KVCR can allocate the destinations. Repeated
-names represent multiple descriptors from the same pool. A single-pool caller
-using the empty pool name may omit it.
+of pool names so KVCR can allocate the destinations. Repeated names represent
+multiple descriptors from the same pool. A single-pool caller using the empty
+pool name may omit it.
 
 ### Operating flow
 

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -215,7 +215,7 @@ from kvcr.config import KVCRBackendConfigs, KVCRConfig
 runner = KVCR(
     config=KVCRConfig(
         nixl_agent_name="worker-0",
-        pool_layout=[(block_size_bytes, "")],
+        pool_layouts=[("", block_size_bytes)],
     ),
     bindings=KVCRBindings(
         request_pin=request_pin,
@@ -344,12 +344,13 @@ GiB plus the journal for every Guard. The current claim path exposes those
 regions as one combined data area.
 
 The pre-release wire protocol remains version 1. A worker calls
-`KVCRClient.claim(guard_index, pool_layout, compatibility_digest, control_bind)`,
+`KVCRClient.claim(guard_index, pool_layouts, compatibility_digest, control_bind)`,
 naming the address its Guard will answer on. The digest must match the service
-exactly, and callers must change it whenever the pool layout or any other KV-cache
-term changes. The returned `KVCRPoolHold` describes the mapped local DRAM and
-owns an exclusive lease on the pool. Only one pool-layout entry is currently
-supported; an empty string is a valid pool name.
+exactly, and each pool-layout entry is `(pool_name, block_size_bytes)`. Callers must
+change the digest whenever the pool layout or any other KV-cache term changes.
+The returned `KVCRPoolHold` describes the mapped local DRAM and owns an exclusive
+lease on the pool. Only one pool-layout entry is currently supported; an empty
+string is a valid pool name.
 
 **A pool's configuration is fixed by its first claim.** Every later claim on
 that pool must name the same pool layout and, when G3 is configured, the same

--- a/src/kvcr/config.py
+++ b/src/kvcr/config.py
@@ -10,31 +10,32 @@ from typing import Protocol
 from .types import (
     BlockKey,
     InventoryEvent,
+    LocalDramRegions,
+    PoolBlockLayouts,
 )
 
 InventorySink = Callable[[InventoryEvent], None]
 
 
-def _validate_pool_layout(pool_layout: list[tuple[int, str]]) -> None:
-    if not pool_layout:
-        raise ValueError("pool_layout must contain at least one pool")
+def _validate_pool_layouts(pool_layouts: PoolBlockLayouts) -> None:
+    if not pool_layouts:
+        raise ValueError("pool_layouts must contain at least one pool")
     names = []
-    for block_size_bytes, pool_name in pool_layout:
-        if type(block_size_bytes) is not int or block_size_bytes <= 0:
-            raise ValueError("pool_layout block size must be a positive integer")
+    for pool_name, block_size_bytes in pool_layouts:
         if not isinstance(pool_name, str):
-            raise ValueError("pool_layout pool name must be a string")
+            raise ValueError("pool_layouts pool name must be a string")
+        if type(block_size_bytes) is not int or block_size_bytes <= 0:
+            raise ValueError("pool_layouts block size must be a positive integer")
         names.append(pool_name)
     if len(names) != len(set(names)):
-        raise ValueError("pool_layout pool names must be unique")
+        raise ValueError("pool_layouts pool names must be unique")
     if len(names) > 1 and "" in names:
-        raise ValueError("pool_layout cannot use an empty name with multiple pools")
+        raise ValueError("pool_layouts cannot use an empty name with multiple pools")
 
 
 @dataclass(frozen=True)
 class LocalDramOptions:
-    address: int
-    pool_sizes_bytes: list[tuple[int, str]]
+    pools: LocalDramRegions
     backend: str = "UCX"
 
 
@@ -120,7 +121,7 @@ class KeyAdapter(Protocol):
 @dataclass(frozen=True)
 class KVCRConfig:
     nixl_agent_name: str
-    pool_layout: list[tuple[int, str]]
+    pool_layouts: PoolBlockLayouts
     enable_telemetry: bool = False
     operation_timeout_ms: int = 1000
     inventory_report_interval_ms: int = 10

--- a/src/kvcr/core.py
+++ b/src/kvcr/core.py
@@ -14,7 +14,7 @@ from .config import (
     KVCRBackendConfigs,
     KVCRConfig,
     TelemetryStats,
-    _validate_pool_layout,
+    _validate_pool_layouts,
 )
 from .hint_parser import _parse_kv_hint
 from .local_disk import _G3, _G3Residency
@@ -116,12 +116,12 @@ class _KVCRCore:
         backend_configs: KVCRBackendConfigs,
     ) -> None:
         self.config = config
-        self.pool_layout = list(config.pool_layout)
-        _validate_pool_layout(self.pool_layout)
+        self.pool_layouts = list(config.pool_layouts)
+        _validate_pool_layouts(self.pool_layouts)
         # TODO: Support multiple pools after remote fetch and G3 discover layouts.
-        if len(self.pool_layout) != 1:
+        if len(self.pool_layouts) != 1:
             raise ValueError("only a single pool is currently supported")
-        self.block_size_bytes = self.pool_layout[0][0]
+        self.block_size_bytes = self.pool_layouts[0][1]
         if self.config.operation_timeout_ms <= 0:
             raise ValueError("operation_timeout_ms must be positive")
         if self.config.inventory_report_interval_ms < 0:
@@ -430,8 +430,8 @@ class _KVCRCore:
         hints: object | None = None,
     ) -> OpHandle:
         expected_layout = [""] if expected_layout is None else expected_layout
-        if expected_layout != [self.pool_layout[0][1]]:
-            raise ValueError("expected layout must match the configured pool_layout")
+        if expected_layout != [self.pool_layouts[0][0]]:
+            raise ValueError("expected layout must match the configured pool_layouts")
         op_handle = self._next_op_handle
         self._next_op_handle += 1
         local_dram = self._local_dram
@@ -701,7 +701,7 @@ class _KVCRCore:
         if len(descriptors) != 1 or not isinstance(descriptors[0], MemDescriptor):
             raise ValueError("each block requires exactly one descriptor")
         descriptor = descriptors[0]
-        if descriptor.info != self.pool_layout[0][1]:
+        if descriptor.info != self.pool_layouts[0][0]:
             raise ValueError(f"unknown descriptor pool {descriptor.info!r}")
         if descriptor.size != self.block_size_bytes:
             raise ValueError("block descriptor has the wrong byte count")

--- a/src/kvcr/guard.py
+++ b/src/kvcr/guard.py
@@ -44,7 +44,7 @@ from .recovery_journal import (
     read_handback,
     write_recovery_snapshot,
 )
-from .types import BlockKey
+from .types import BlockKey, PoolBlockLayouts
 
 logger = logging.getLogger(__name__)
 
@@ -187,11 +187,11 @@ class _RecoveryState:
         self.attachment = KVCRPoolAttachment.attach(self._spec)
         self._journal = RecoveryJournal(self.attachment)
 
-    def recover(self, pool_layout: list[tuple[int, str]]) -> _RecoveryMirror:
+    def recover(self, pool_layouts: PoolBlockLayouts) -> _RecoveryMirror:
         """Return held recovery or read the prior handback under this pool layout."""
         if self.mirror is not None:
             return self.mirror
-        return read_handback(self.attachment, self._compatibility_digest, pool_layout)
+        return read_handback(self.attachment, self._compatibility_digest, pool_layouts)
 
     def start_primary(self) -> None:
         """Arm recovery for the accepted primary and reset its journal."""
@@ -254,8 +254,7 @@ class _RecoveryState:
         backend: str,
     ) -> LocalDramOptions:
         return LocalDramOptions(
-            self.attachment.data_address,
-            [(effective_bytes, pool_name)],
+            [(pool_name, self.attachment.data_address, effective_bytes)],
             backend,
         )
 
@@ -271,13 +270,13 @@ class _RecoveryState:
     def hand_back(
         self,
         records: dict[BlockKey, _BlockRecord],
-        pool_layout: list[tuple[int, str]],
+        pool_layouts: PoolBlockLayouts,
     ) -> None:
         """Write and mirror a closed core's map under its pool layout."""
         mirror = self.mirror
         records = _with_g3(records, self._g3_records)
         try:
-            self._write_handback(records, pool_layout)
+            self._write_handback(records, pool_layouts)
         except OSError as error:
             if error.errno not in _RECOVERY_CAPACITY_ERRORS:
                 raise
@@ -287,13 +286,13 @@ class _RecoveryState:
             mirror.adopt(records)
         self._g3_records = {}
 
-    def release(self, pool_layout: list[tuple[int, str]]) -> None:
+    def release(self, pool_layouts: PoolBlockLayouts) -> None:
         """Write the current primary's journal tail, then drop its mirror."""
         mirror = self.mirror
         try:
             while (frame := self._journal.read_next()) is not None:
                 mirror.apply(*frame)
-            self._write_handback(mirror.take_records(), pool_layout)
+            self._write_handback(mirror.take_records(), pool_layouts)
         except RecoveryJournalError as error:
             self._drop_recovery(error)
         except OSError as error:
@@ -312,11 +311,11 @@ class _RecoveryState:
     def _write_handback(
         self,
         records: Mapping[BlockKey, _BlockRecord],
-        pool_layout: list[tuple[int, str]],
+        pool_layouts: PoolBlockLayouts,
     ) -> None:
         write_recovery_snapshot(
             self.attachment,
-            canonical_pool_terms(self._compatibility_digest, pool_layout, self._spec),
+            canonical_pool_terms(self._compatibility_digest, pool_layouts, self._spec),
             _recovery_frames(records),
         )
 
@@ -736,11 +735,11 @@ class _Guard:
             if self._failure is not None:
                 raise self._failure
             self._refuse_incompatible(tier_config)
-            served_under = self._configured.pool_layout if self._configured else ()
+            served_under = self._configured.pool_layouts if self._configured else ()
             # The prior handback is this lease's baseline. Read now, under
             # the claim's pool layout: refusing at promotion stops the service,
             # and a claimant dying in between takes everything with it.
-            recovered = self._recovery.recover(tier_config.pool_layout)
+            recovered = self._recovery.recover(tier_config.pool_layouts)
             # Last, once nothing left can refuse this claim: a pool whose handback
             # would not replay has not chosen anything, and a corrected claim can
             # still have it.
@@ -775,11 +774,11 @@ class _Guard:
         if self._failure is not None:
             raise self._failure
         if self._serving:
-            self._hand_back(self._configured.pool_layout)
+            self._hand_back(self._configured.pool_layouts)
             # Re-adopt lets start_primary() retain or replace the mirror.
             self._recovery.mirror = None
         elif self._recovery.mirror is not None:
-            self._recovery.release(self._configured.pool_layout)
+            self._recovery.release(self._configured.pool_layouts)
         if self._control is not None:
             self._control.close()
             self._control = None
@@ -798,7 +797,7 @@ class _Guard:
         """Take up this primary's tiers: the geometry check runs before the
         assignment, so a bad configuration leaves the old one intact.
         """
-        _compute_pool_geometry(self._spec.data_bytes, tier_config.pool_layout[0][0])
+        _compute_pool_geometry(self._spec.data_bytes, tier_config.pool_layouts[0][1])
         self._configured = tier_config
 
     def _poll(self) -> bool:
@@ -857,7 +856,7 @@ class _Guard:
         def reject_pin(keys: object) -> int:
             raise RuntimeError("Guard has no framework-owned memory")
 
-        block_size, pool_name = self._configured.pool_layout[0]
+        pool_name, block_size = self._configured.pool_layouts[0]
         effective_bytes, _ = _compute_pool_geometry(self._spec.data_bytes, block_size)
         dram = self._recovery.local_dram_info(
             effective_bytes,
@@ -867,7 +866,7 @@ class _Guard:
         core = _KVCRCore(
             KVCRConfig(
                 nixl_agent_name=f"KVCR-Guard-{uuid.uuid4()}",
-                pool_layout=list(self._configured.pool_layout),
+                pool_layouts=list(self._configured.pool_layouts),
                 inventory_report_interval_ms=0,
                 nixl_listen_port=0,
             ),
@@ -893,7 +892,7 @@ class _Guard:
         core.start()
         self._serving = True
 
-    def _hand_back(self, pool_layout: list[tuple[int, str]]) -> None:
+    def _hand_back(self, pool_layouts: PoolBlockLayouts) -> None:
         """Stop serving, leaving this pool's state where the next primary looks.
         The core closes first: the Guard stops answering, and region and
         records both come from the map close leaves behind.
@@ -902,7 +901,7 @@ class _Guard:
         if core is None or self._recovery.mirror is None:
             raise RecoveryMirrorError("a serving Guard has no state to hand back")
         core.close()
-        self._recovery.hand_back(core._block_record_map, pool_layout)
+        self._recovery.hand_back(core._block_record_map, pool_layouts)
         self._core = None
         self._serving = False
 

--- a/src/kvcr/guard_protocol.py
+++ b/src/kvcr/guard_protocol.py
@@ -15,7 +15,7 @@ from typing import Annotated, Literal
 
 import msgspec
 
-from .config import G3Options, LocalDramOptions, _validate_pool_layout
+from .config import G3Options, LocalDramOptions, _validate_pool_layouts
 from .control_channels import (
     FramedConnection,
     KVCRGuardProtocolError,
@@ -23,6 +23,7 @@ from .control_channels import (
     KVCRSocketError,
 )
 from .memory import KVCRPoolAttachment, KVCRPoolSpec, _compute_pool_geometry
+from .types import PoolBlockLayouts
 
 logger = logging.getLogger(__name__)
 
@@ -48,16 +49,16 @@ class _G3Config(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
 
 
 class _TierConfig(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
-    pool_layout: list[tuple[int, str]]
+    pool_layouts: PoolBlockLayouts
     g3: _G3Config | None
     remote_fw_dram_backend: Annotated[str, msgspec.Meta(min_length=1)] = "UCX"
 
     def __post_init__(self) -> None:
-        _validate_pool_layout(self.pool_layout)
+        _validate_pool_layouts(self.pool_layouts)
         # TODO: Support multiple pools after fetch and storage can discover layouts.
-        if len(self.pool_layout) != 1:
+        if len(self.pool_layouts) != 1:
             raise ValueError("only a single pool is currently supported")
-        block_size_bytes = self.pool_layout[0][0]
+        block_size_bytes = self.pool_layouts[0][1]
         # Mirrors what the claimant's _G3 will enforce. The first claim fixes
         # the pool's tiers forever, so a config no claimant could ever open
         # must be refused here, before it binds.
@@ -218,7 +219,7 @@ class KVCRClient:
     def claim(
         self,
         guard_index: int,
-        pool_layout: list[tuple[int, str]],
+        pool_layouts: PoolBlockLayouts,
         compatibility_digest: str,
         control_bind: tuple[str, int],
         g3: G3Options | None = None,
@@ -238,7 +239,7 @@ class KVCRClient:
                 "guard_index": guard_index,
                 "compatibility_digest": compatibility_digest,
                 "tier_config": {
-                    "pool_layout": pool_layout,
+                    "pool_layouts": pool_layouts,
                     "g3": g3_config,
                     "remote_fw_dram_backend": remote_fw_dram_backend,
                 },
@@ -267,7 +268,7 @@ class KVCRClient:
                     "claim was granted without the endpoint it answers on"
                 )
             try:
-                block_size, pool_name = request.tier_config.pool_layout[0]
+                pool_name, block_size = request.tier_config.pool_layouts[0]
                 effective_bytes, _ = _compute_pool_geometry(spec.data_bytes, block_size)
             except ValueError as geometry_error:
                 raise KVCRGuardProtocolError(
@@ -276,8 +277,7 @@ class KVCRClient:
             attachment = KVCRPoolAttachment.attach(spec)
             return KVCRPoolHold(
                 local_dram=LocalDramOptions(
-                    attachment.data_address,
-                    [(effective_bytes, pool_name)],
+                    [(pool_name, attachment.data_address, effective_bytes)],
                     request.tier_config.remote_fw_dram_backend,
                 ),
                 _attachment=attachment,

--- a/src/kvcr/local_dram.py
+++ b/src/kvcr/local_dram.py
@@ -142,21 +142,21 @@ class _LocalDram:
         kvcr: "_KVCRCore",
         region: LocalDramOptions,
     ) -> None:
-        if region.address <= 0:
-            raise ValueError("local DRAM address must be positive")
-        if len(region.pool_sizes_bytes) != 1:
+        if len(region.pools) != 1:
             raise ValueError("local DRAM supports only a single pool")
-        length, pool_name = region.pool_sizes_bytes[0]
+        pool_name, address, length = region.pools[0]
+        if address <= 0:
+            raise ValueError("local DRAM address must be positive")
         if type(length) is not int or length <= 0:
             raise ValueError("local DRAM pool size must be a positive integer")
-        if pool_name != kvcr.pool_layout[0][1]:
-            raise ValueError("local DRAM pool name must match pool_layout")
+        if pool_name != kvcr.pool_layouts[0][0]:
+            raise ValueError("local DRAM pool name must match pool_layouts")
         if not region.backend:
             raise ValueError("local DRAM NIXL backend must be non-empty")
 
         self._kvcr = kvcr
         self._backend = region.backend
-        self._address = region.address
+        self._address = address
         self._length = length
         self._slot_size = kvcr.block_size_bytes
         slot_count = length // self._slot_size
@@ -1040,7 +1040,7 @@ class _LocalDram:
             addr=self._address + slot * self._slot_size,
             size=self._slot_size,
             device_Id=0,
-            info=self._kvcr.pool_layout[0][1],
+            info=self._kvcr.pool_layouts[0][0],
         )
 
     def _update_capacity_pressure(self) -> None:

--- a/src/kvcr/recovery_journal.py
+++ b/src/kvcr/recovery_journal.py
@@ -23,7 +23,7 @@ from .guard_protocol import KVCRClient, KVCRPoolHold
 from .local_disk import _G3, _G3Residency
 from .local_dram import _LocalDram, _LocalDramResidency, _LocalDramState
 from .memory import _JOURNAL_HEADER_BYTES, KVCRPoolAttachment, KVCRPoolSpec
-from .types import BlockKey, RecoveryMirrorError
+from .types import BlockKey, PoolBlockLayouts, RecoveryMirrorError
 
 if TYPE_CHECKING:
     from .api import KVCRBindings
@@ -443,7 +443,7 @@ def claim_guarded_pool(
         )
     hold = KVCRClient(guard_config.kvcr_service_socket_path).claim(
         guard_config.guard_index,
-        config.pool_layout,
+        config.pool_layouts,
         guard_config.compatibility_digest,
         bind_address(),
         backend_configs.g3,
@@ -456,7 +456,7 @@ def claim_guarded_pool(
         recovered = read_handback(
             hold._attachment,
             guard_config.compatibility_digest,
-            config.pool_layout,
+            config.pool_layouts,
         )
     except BaseException:
         # A failing release must not mask the error that made the claim unusable.
@@ -548,7 +548,7 @@ _SNAPSHOT_TERMS = struct.Struct("<QQQQ")
 
 def canonical_pool_terms(
     compatibility_digest: str,
-    pool_layout: list[tuple[int, str]],
+    pool_layouts: PoolBlockLayouts,
     spec: "KVCRPoolSpec",
 ) -> bytes:
     """Encode what a handback region must not be replayed across."""
@@ -557,7 +557,7 @@ def canonical_pool_terms(
         + compatibility_digest.encode()
         + b"\0"
         + bytes.fromhex(spec.generation)
-        + msgspec.msgpack.encode(pool_layout)
+        + msgspec.msgpack.encode(pool_layouts)
         + _SNAPSHOT_TERMS.pack(
             spec.journal_bytes,
             spec.mapping_bytes,
@@ -662,7 +662,7 @@ def read_recovery_snapshot(
 def read_handback(
     pool: KVCRPoolAttachment,
     compatibility_digest: str,
-    pool_layout: list[tuple[int, str]],
+    pool_layouts: PoolBlockLayouts,
 ) -> _RecoveryMirror:
     """Replay whatever the last Guard left for this pool, if anything.
 
@@ -673,7 +673,7 @@ def read_handback(
     else ever would, and it would refuse every later claim on this pool too.
     """
     mirror = _RecoveryMirror()
-    terms = canonical_pool_terms(compatibility_digest, pool_layout, pool._spec)
+    terms = canonical_pool_terms(compatibility_digest, pool_layouts, pool._spec)
     try:
         for frame in read_recovery_snapshot(pool, terms):
             mirror.apply(*frame)

--- a/src/kvcr/types.py
+++ b/src/kvcr/types.py
@@ -15,6 +15,8 @@ PinRequestId = NewType("PinRequestId", int)
 OpHandle = int
 ReleaseHandle = NewType("ReleaseHandle", int)
 ReleaseResult = tuple[ReleaseHandle, bool]
+LocalDramRegions = list[tuple[str, int, int]]  # name, address, size in bytes
+PoolBlockLayouts = list[tuple[str, int]]  # name, block size in bytes
 
 
 @dataclass(frozen=True)
@@ -29,7 +31,7 @@ class MemDescriptor:
     its spans by endpoint and memory type would add two hierarchy levels merely
     to factor out values typically shared by reference.
 
-    ``info`` currently identifies the descriptor's pool in ``pool_layout``; an empty
+    ``info`` currently identifies the descriptor's pool in ``pool_layouts``; an empty
     string names the single unnamed pool. This generic field may support additional
     metadata conventions later.
     """

--- a/tests/unit/_kvcr_test_utils.py
+++ b/tests/unit/_kvcr_test_utils.py
@@ -463,7 +463,7 @@ def _new_kvcr(
         config
         or KVCRConfig(
             nixl_agent_name=name,
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             inventory_report_interval_ms=0,
         ),
         nixl_agent_name=name,
@@ -509,7 +509,7 @@ def _new_local_kvcr(
         kvcr = KVCR(
             KVCRConfig(
                 nixl_agent_name="target",
-                pool_layout=[(len(local) // slot_count, "")],
+                pool_layouts=[("", len(local) // slot_count)],
                 nixl_listen_port=1,
                 inventory_report_interval_ms=0,
                 capacity_low_watermark_percent=capacity_low_watermark_percent,
@@ -524,8 +524,7 @@ def _new_local_kvcr(
             ),
             KVCRBackendConfigs(
                 local_dram=LocalDramOptions(
-                    ctypes.addressof(local),
-                    [(len(local), "")],
+                    [("", ctypes.addressof(local), len(local))],
                     local_dram_backend,
                 ),
             ),

--- a/tests/unit/test_g3.py
+++ b/tests/unit/test_g3.py
@@ -166,11 +166,11 @@ def _new_g3_kvcr(
         control or FakeBytesControl(),
         config=KVCRConfig(
             nixl_agent_name="target",
-            pool_layout=[(len(local) // slot_count, "")],
+            pool_layouts=[("", len(local) // slot_count)],
             enable_telemetry=telemetry,
             inventory_report_interval_ms=10 if telemetry else 0,
         ),
-        local_dram=LocalDramOptions(ctypes.addressof(local), [(len(local), "")]),
+        local_dram=LocalDramOptions([("", ctypes.addressof(local), len(local))]),
         g3=G3Options(
             paths=((tmp_path / "g3.data",) if g3_paths is None else tuple(g3_paths)),
             capacity_bytes_per_file=page_size * g3_slot_count,

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -176,7 +176,7 @@ def test_a_serving_guard_reports_a_poll_failure_and_fences_its_core(caplog) -> N
     failure_callback = Mock()
     guard = _Guard(_TEST_SPEC, failure_callback, compatibility_digest=_TEST_DIGEST)
     guard._control = control
-    guard._configure(_TierConfig([(16, "")], None))
+    guard._configure(_TierConfig([("", 16)], None))
     guard._recovery._journal = journal
     guard._serving = True
     guard._core = core
@@ -210,7 +210,7 @@ def test_standby_guard_failure_releases_adopted_listener() -> None:
     journal.read_next.side_effect = error
     guard = _Guard(_TEST_SPEC, failure_callback, compatibility_digest=_TEST_DIGEST)
     guard._control = control
-    guard._configure(_TierConfig([(16, "")], None))
+    guard._configure(_TierConfig([("", 16)], None))
     guard._recovery._journal = journal
     guard._recovery.mirror = Mock()
 
@@ -280,7 +280,7 @@ def test_guard_lives_out_adopt_promote_and_readopt_in_ownership_order(
         backend="FILE",
         backend_options={},
     )
-    tier = _TierConfig([(_PAGE_STRIDE, "")], g3_config, "REMOTE")
+    tier = _TierConfig([("", _PAGE_STRIDE)], g3_config, "REMOTE")
     guard = _Guard(_PAGE_SPEC, compatibility_digest=_TEST_DIGEST)
     # Driven directly, then the thread starts already busy: the actor blocks
     # on an empty mailbox when idle, so mutating around a sleeping thread
@@ -288,7 +288,7 @@ def test_guard_lives_out_adopt_promote_and_readopt_in_ownership_order(
     guard._started = True
     guard._recovery.prepare()
     # Unclaimed, so any tier shape is still available; the first claim fixes it.
-    guard._refuse_incompatible(_TierConfig([(16, "")], None))
+    guard._refuse_incompatible(_TierConfig([("", 16)], None))
     guard._adopt(new_channel(), tier)
     try:
         attach.assert_called_once_with(_PAGE_SPEC)
@@ -296,7 +296,7 @@ def test_guard_lives_out_adopt_promote_and_readopt_in_ownership_order(
         # Adoption only grants; a core exists once a promotion needs one.
         assert constructed == []
         with pytest.raises(RecoveryMirrorError, match="another tier configuration"):
-            guard._refuse_incompatible(_TierConfig([(16, "")], None))
+            guard._refuse_incompatible(_TierConfig([("", 16)], None))
 
         promoted_records = guard._recovery.mirror._records
         guard._promote()
@@ -308,8 +308,7 @@ def test_guard_lives_out_adopt_promote_and_readopt_in_ownership_order(
         assert config.nixl_listen_port == 0
         assert bindings.framework_control is channels[0]
         assert backends.local_dram == LocalDramOptions(
-            1234 + 8192,
-            [(2 * _PAGE_STRIDE, "")],
+            [("", 1234 + 8192, 2 * _PAGE_STRIDE)],
             "REMOTE",
         )
         assert backends.remote_fw_dram.backend == "REMOTE"
@@ -383,7 +382,7 @@ def test_a_pool_that_lost_its_recovery_stays_claimable_on_every_path(
     """Which reader finds the invalid journal is a race; none may take the service."""
     guard = _configurable_guard()
     # Every one of these readers runs on a pool a primary has already claimed.
-    guard._configured = _TierConfig([(16, "")], None)
+    guard._configured = _TierConfig([("", 16)], None)
     guard._recovery.mirror = _RecoveryMirror()
     guard._recovery.attachment = Mock()
     guard._control = None
@@ -435,13 +434,13 @@ def test_the_same_g3_paths_in_another_order_are_another_configuration() -> None:
     """A slot names its file by position, so reordering renames every slot."""
     guard = _configurable_guard()
     guard._configured = _TierConfig(
-        [(_PAGE_STRIDE, "")],
+        [("", _PAGE_STRIDE)],
         _G3Config(("/a", "/b"), _PAGE_STRIDE, "MOCK", {}),
     )
     with pytest.raises(RecoveryMirrorError, match="another tier configuration"):
         guard._refuse_incompatible(
             _TierConfig(
-                [(_PAGE_STRIDE, "")],
+                [("", _PAGE_STRIDE)],
                 _G3Config(("/b", "/a"), _PAGE_STRIDE, "MOCK", {}),
             )
         )
@@ -457,7 +456,7 @@ def test_guard_closes_control_when_its_thread_does_not_start(monkeypatch) -> Non
     monkeypatch.setattr("kvcr.guard.RecoveryJournal", Mock())
     guard = _Guard(_TEST_SPEC, compatibility_digest=_TEST_DIGEST)
     guard._control = control
-    guard._configure(_TierConfig([(16, "")], None))
+    guard._configure(_TierConfig([("", 16)], None))
     guard._thread.start = Mock(side_effect=RuntimeError("thread start failed"))
 
     with pytest.raises(RuntimeError, match="thread start failed"):
@@ -535,7 +534,7 @@ def test_a_close_refused_by_a_moving_core_retains_the_pool_until_quiescent(
     core.is_quiescent.return_value = False
     guard = _Guard(_TEST_SPEC, compatibility_digest=_TEST_DIGEST)
     guard._control = control
-    guard._configure(_TierConfig([(16, "")], None))
+    guard._configure(_TierConfig([("", 16)], None))
     guard._core = core
     guard._recovery.attachment = attachment
     caplog.set_level(logging.WARNING, logger="kvcr.guard")
@@ -572,7 +571,7 @@ def test_only_a_claim_refused_before_the_pool_moves_costs_nothing(
 
     if refused_by == "hand-over":
         # A hand-back that fails cannot be reported as a refused claim.
-        guard._configured = _TierConfig([(16, "")], None)
+        guard._configured = _TierConfig([("", 16)], None)
         guard._serving = True
         guard._recovery.mirror = _RecoveryMirror()
         guard._core = Mock(_block_record_map={})
@@ -580,7 +579,7 @@ def test_only_a_claim_refused_before_the_pool_moves_costs_nothing(
         guard._hand_back = Mock(side_effect=failure)
 
         with pytest.raises(OSError, match="no space left"):
-            guard._adopt(control, _TierConfig([(16, "")], None))
+            guard._adopt(control, _TierConfig([("", 16)], None))
 
         assert reported == [failure]
         assert guard._failure is failure
@@ -590,11 +589,11 @@ def test_only_a_claim_refused_before_the_pool_moves_costs_nothing(
         )
         if refused_by == "geometry":
             expected: type[Exception] = ValueError
-            tier_config = _TierConfig([(_TEST_SPEC.mapping_bytes, "")], None)
+            tier_config = _TierConfig([("", _TEST_SPEC.mapping_bytes)], None)
             handback = Mock(return_value=_RecoveryMirror())
         else:
             expected = RecoveryJournalError
-            tier_config = _TierConfig([(16, "")], None)
+            tier_config = _TierConfig([("", 16)], None)
             handback = Mock(side_effect=RecoveryJournalError("written for other terms"))
         monkeypatch.setattr("kvcr.guard.read_handback", handback)
 
@@ -608,7 +607,7 @@ def test_only_a_claim_refused_before_the_pool_moves_costs_nothing(
         guard._hand_back.assert_not_called()
         # Nothing was chosen, so a corrected claim can still have this pool.
         assert guard._configured is None
-        guard._refuse_incompatible(_TierConfig([(32, "")], None))
+        guard._refuse_incompatible(_TierConfig([("", 32)], None))
     control.close.assert_called_once_with()
 
 
@@ -659,13 +658,13 @@ def test_a_dropped_handback_still_leaves_the_new_lease_mirrored(code: int) -> No
     guard = _configurable_guard()
     guard._control = None
     guard._failure_callback = lambda *_args: None
-    guard._configured = _TierConfig([(16, "")], None)
+    guard._configured = _TierConfig([("", 16)], None)
     guard._recovery.mirror = _RecoveryMirror()
     _give_serving_core(guard)
     guard._recovery._journal = _Journal()
     guard._recovery._write_handback = Mock(side_effect=OSError(code, "No space left"))
 
-    guard._adopt(Mock(), _TierConfig([(16, "")], None))
+    guard._adopt(Mock(), _TierConfig([("", 16)], None))
 
     # The pool went cold, not fatal: the Guard stood down and dropped the core.
     assert guard._serving is False
@@ -715,7 +714,7 @@ def test_a_release_drops_its_mirror_after_handing_back_what_it_can(
     guard = _configurable_guard()
     control = Mock()
     guard._control = control
-    guard._configured = _TierConfig([(16, "")], None)
+    guard._configured = _TierConfig([("", 16)], None)
     guard._recovery.mirror = _RecoveryMirror()
     if mode == "serving":
         _give_serving_core(guard)
@@ -736,9 +735,9 @@ def test_a_release_drops_its_mirror_after_handing_back_what_it_can(
     assert guard._recovery.mirror is None
     control.close.assert_called_once_with()
     if mode == "accepts":
-        records, pool_layout = guard._recovery._write_handback.call_args.args
+        records, pool_layouts = guard._recovery._write_handback.call_args.args
         assert set(records) == {BlockKey(b"published"), BlockKey(b"tail")}
-        assert pool_layout == [(16, "")]
+        assert pool_layouts == [("", 16)]
     elif mode == "serving":
         assert guard._serving is False
         assert guard._core is None

--- a/tests/unit/test_guard_integration.py
+++ b/tests/unit/test_guard_integration.py
@@ -118,7 +118,7 @@ def _make_kvcr(
         return KVCR(
             KVCRConfig(
                 nixl_agent_name=agent_name,
-                pool_layout=[(page_size, "")],
+                pool_layouts=[("", page_size)],
                 nixl_listen_port=0,
                 inventory_report_interval_ms=0,
             ),
@@ -332,7 +332,7 @@ def test_a_promoted_guard_serves_real_nixl_transfers(
     target = KVCR(
         KVCRConfig(
             nixl_agent_name="real-target",
-            pool_layout=[(page_size, "")],
+            pool_layouts=[("", page_size)],
             nixl_listen_port=0,
             inventory_report_interval_ms=0,
             operation_timeout_ms=_REAL_NIXL_TIMEOUT_SECONDS * 1000,
@@ -459,7 +459,7 @@ def test_request_timeout_during_promotion_then_retry_uses_guard(
             target_control,
             KVCRConfig(
                 nixl_agent_name="target",
-                pool_layout=[(page_size, "")],
+                pool_layouts=[("", page_size)],
                 operation_timeout_ms=5000,
             ),
             remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),

--- a/tests/unit/test_guard_protocol.py
+++ b/tests/unit/test_guard_protocol.py
@@ -32,15 +32,15 @@ from kvcr.guard_protocol import (
 from kvcr.memory import _JOURNAL_HEADER_BYTES, KVCRPoolSpec
 
 _GUARD_INDEX = 3
-_ROW_STRIDE = 1024
+_BLOCK_SIZE_BYTES = 1024
 _GENERATION = "a" * 32
 _DEVICE = 2049
 _INODE = 42
 _DIGEST = "opaque digest: leave unchanged"
 _JOURNAL_BYTES = 2 * _JOURNAL_HEADER_BYTES
 _MAPPING_BYTES = _JOURNAL_BYTES + 8195
-_POOL_LAYOUT = [(_ROW_STRIDE, "")]
-_TIER_CONFIG = _TierConfig(_POOL_LAYOUT, None)
+_POOL_LAYOUTS = [("", _BLOCK_SIZE_BYTES)]
+_TIER_CONFIG = _TierConfig(_POOL_LAYOUTS, None)
 
 
 def test_close_swaps_the_pidfd_under_its_lock() -> None:
@@ -204,20 +204,20 @@ def test_unsupported_tier_configuration_is_refused_at_decode() -> None:
         "backend_options": {},
     }
     with pytest.raises(ValueError, match="only a single pool"):
-        _TierConfig([(page, "full"), (page, "swa")], None)
+        _TierConfig([("full", page), ("swa", page)], None)
     with pytest.raises(ValueError, match="page aligned"):
-        _TierConfig([(page // 2, "")], _G3Config(**good))
+        _TierConfig([("", page // 2)], _G3Config(**good))
     with pytest.raises(ValueError, match="complete slots"):
         _TierConfig(
-            [(page, "")],
+            [("", page)],
             _G3Config(**{**good, "capacity_bytes_per_file": page + 1}),
         )
     with pytest.raises(ValueError, match="unique"):
         _TierConfig(
-            [(page, "")],
+            [("", page)],
             _G3Config(**{**good, "paths": ("/g3/a", "/g3//a")}),
         )
-    _TierConfig([(page, "")], _G3Config(**good))
+    _TierConfig([("", page)], _G3Config(**good))
 
 
 def test_claim_and_release_round_trip_typed_messages_and_geometry(
@@ -232,7 +232,7 @@ def test_claim_and_release_round_trip_typed_messages_and_geometry(
     monkeypatch.setattr(protocol_module.KVCRPoolAttachment, "attach", attach)
 
     hold = KVCRClient("/unused").claim(
-        _GUARD_INDEX, _POOL_LAYOUT, _DIGEST, ("127.0.0.1", 5555)
+        _GUARD_INDEX, _POOL_LAYOUTS, _DIGEST, ("127.0.0.1", 5555)
     )
 
     assert msgspec.to_builtins(connection.sent[0]) == {
@@ -240,7 +240,7 @@ def test_claim_and_release_round_trip_typed_messages_and_geometry(
         "guard_index": _GUARD_INDEX,
         "compatibility_digest": _DIGEST,
         "tier_config": {
-            "pool_layout": [(_ROW_STRIDE, "")],
+            "pool_layouts": [("", _BLOCK_SIZE_BYTES)],
             "g3": None,
             "remote_fw_dram_backend": "UCX",
         },
@@ -261,17 +261,14 @@ def test_claim_and_release_round_trip_typed_messages_and_geometry(
             "journal_bytes": _JOURNAL_BYTES,
         },
         "tier_config": {
-            "pool_layout": [(_ROW_STRIDE, "")],
+            "pool_layouts": [("", _BLOCK_SIZE_BYTES)],
             "g3": None,
             "remote_fw_dram_backend": "UCX",
         },
         "version": 1,
     }
     attach.assert_called_once_with(_grant().spec)
-    assert hold.local_dram == LocalDramOptions(
-        1234 + _JOURNAL_BYTES,
-        [(8192, "")],
-    )
+    assert hold.local_dram == LocalDramOptions([("", 1234 + _JOURNAL_BYTES, 8192)])
     # The endpoint a Guard will answer on, handed over with the grant.
     assert hold._control_listener_fd == connection.handed_fd
 
@@ -305,12 +302,12 @@ def test_claim_and_release_round_trip_typed_messages_and_geometry(
     [
         pytest.param(_grant(guard_index=_GUARD_INDEX + 1), None, id="wrong-guard"),
         pytest.param(
-            _grant(tier_config=_TierConfig([(_ROW_STRIDE * 2, "")], None)),
+            _grant(tier_config=_TierConfig([("", _BLOCK_SIZE_BYTES * 2)], None)),
             None,
             id="wrong-pool-layout",
         ),
         pytest.param(
-            _grant(mapping_bytes=_JOURNAL_BYTES + _ROW_STRIDE - 1),
+            _grant(mapping_bytes=_JOURNAL_BYTES + _BLOCK_SIZE_BYTES - 1),
             None,
             id="short-mapping",
         ),
@@ -342,7 +339,7 @@ def test_a_failed_claim_is_released_without_masking_the_original(
         type(original) if original is not None else KVCRGuardProtocolError
     ) as raised:
         KVCRClient("/unused").claim(
-            _GUARD_INDEX, _POOL_LAYOUT, _DIGEST, ("127.0.0.1", 5555)
+            _GUARD_INDEX, _POOL_LAYOUTS, _DIGEST, ("127.0.0.1", 5555)
         )
 
     if original is not None:
@@ -366,7 +363,7 @@ def test_release_failures_leave_a_retry_and_report_a_lost_acknowledgement() -> N
         [ConnectionResetError("release acknowledgement was lost")], events
     )
     hold = KVCRPoolHold(
-        local_dram=LocalDramOptions(1234, [(8192, "")]),
+        local_dram=LocalDramOptions([("", 1234, 8192)]),
         _attachment=attachment,
         _connection=connection,
     )

--- a/tests/unit/test_kvcr.py
+++ b/tests/unit/test_kvcr.py
@@ -161,7 +161,7 @@ def test_a_guarded_startup_that_fails_gives_back_everything_it_took(
     """Refused before the claim, or unwound after it: core closed, pool returned."""
     events: list[str] = []
     hold = _fake_hold(
-        local_dram=LocalDramOptions(1234, [(8192, "")]),
+        local_dram=LocalDramOptions([("", 1234, 8192)]),
         _attachment=_UNSERVED_POOL,
         _control_listener_fd=None,
         release=lambda **_kwargs: events.append("hold.release"),
@@ -219,7 +219,7 @@ def test_a_guarded_startup_that_fails_gives_back_everything_it_took(
         KVCR(
             KVCRConfig(
                 nixl_agent_name="target",
-                pool_layout=[(1024, "")],
+                pool_layouts=[("", 1024)],
                 nixl_listen_port=1,
             ),
             KVCRBindings(Mock(), Mock(), Mock(), framework_control=control),
@@ -244,7 +244,7 @@ def test_startup_timeout_retains_nonquiescent_resources(
     entered = threading.Event()
     unblock = threading.Event()
     hold = _fake_hold(
-        local_dram=LocalDramOptions(1234, [(8192, "")]),
+        local_dram=LocalDramOptions([("", 1234, 8192)]),
         _attachment=_UNSERVED_POOL,
         _control_listener_fd=None,
         release=Mock(),
@@ -282,7 +282,7 @@ def test_startup_timeout_retains_nonquiescent_resources(
             KVCR(
                 KVCRConfig(
                     nixl_agent_name="target",
-                    pool_layout=[(1024, "")],
+                    pool_layouts=[("", 1024)],
                     nixl_listen_port=1,
                 ),
                 KVCRBindings(
@@ -319,7 +319,7 @@ def test_service_journal_is_attached_before_primary_start(
     events: list[str] = []
     attachment = _UNSERVED_POOL
     hold = _fake_hold(
-        local_dram=LocalDramOptions(1234, [(8192, "")]),
+        local_dram=LocalDramOptions([("", 1234, 8192)]),
         _attachment=attachment,
         _control_listener_fd=7,
         release=lambda **_kwargs: events.append("hold.release"),
@@ -370,7 +370,7 @@ def test_service_journal_is_attached_before_primary_start(
         remote_fw_dram=RemoteFWDramOptions(backend="REMOTE"),
     )
     controller = KVCR(
-        KVCRConfig(nixl_agent_name="target", pool_layout=[(1024, "")]),
+        KVCRConfig(nixl_agent_name="target", pool_layouts=[("", 1024)]),
         KVCRBindings(Mock(), Mock(), Mock(), framework_control=primary_control),
         backend_configs,
         KVCRGuardConfig(
@@ -382,7 +382,7 @@ def test_service_journal_is_attached_before_primary_start(
 
     claim.assert_called_once_with(
         3,
-        [(1024, "")],
+        [("", 1024)],
         "Opaque-Digest",
         ("127.0.0.1", 5555),
         g3_config,
@@ -413,9 +413,9 @@ def test_service_dram_rejects_explicit_local_dram_before_claim(monkeypatch) -> N
 
     with pytest.raises(ValueError, match="local_dram"):
         KVCR(
-            KVCRConfig(nixl_agent_name="target", pool_layout=[(1024, "")]),
+            KVCRConfig(nixl_agent_name="target", pool_layouts=[("", 1024)]),
             KVCRBindings(Mock(), Mock(), Mock()),
-            KVCRBackendConfigs(local_dram=LocalDramOptions(1234, [(8192, "")])),
+            KVCRBackendConfigs(local_dram=LocalDramOptions([("", 1234, 8192)])),
             _GUARD_CONFIG,
         )
 
@@ -425,18 +425,18 @@ def test_service_dram_rejects_explicit_local_dram_before_claim(monkeypatch) -> N
 def test_kvcr_rejects_no_dram_backends() -> None:
     with pytest.raises(ValueError, match="at least one DRAM backend"):
         KVCR(
-            KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
+            KVCRConfig(nixl_agent_name="target", pool_layouts=[("", 16)]),
             KVCRBindings(Mock(), Mock(), Mock()),
             KVCRBackendConfigs(),
         )
 
 
-def test_kvcr_rejects_multi_pool_layout() -> None:
+def test_kvcr_rejects_multi_pool_layouts() -> None:
     with pytest.raises(ValueError, match="only a single pool"):
         KVCR(
             KVCRConfig(
                 nixl_agent_name="target",
-                pool_layout=[(8, "full"), (8, "swa")],
+                pool_layouts=[("full", 8), ("swa", 8)],
             ),
             KVCRBindings(Mock(), Mock(), Mock()),
             KVCRBackendConfigs(),
@@ -445,11 +445,11 @@ def test_kvcr_rejects_multi_pool_layout() -> None:
 
 def test_kvcr_rejects_ambiguous_pool_names() -> None:
     bindings = KVCRBindings(Mock(), Mock(), Mock())
-    for pool_layout, message in (
-        ([(8, ""), (8, "swa")], "empty"),
-        ([(8, "swa"), (8, "swa")], "unique"),
+    for pool_layouts, message in (
+        ([("", 8), ("swa", 8)], "empty"),
+        ([("swa", 8), ("swa", 8)], "unique"),
     ):
-        config = KVCRConfig(nixl_agent_name="target", pool_layout=pool_layout)
+        config = KVCRConfig(nixl_agent_name="target", pool_layouts=pool_layouts)
         with pytest.raises(ValueError, match=message):
             KVCR(config, bindings, KVCRBackendConfigs())
 
@@ -460,8 +460,8 @@ def test_fetch_requires_layout_for_a_named_single_pool() -> None:
         FakeNixlAgent(),
         FakePrimaryPinning(),
         FakeBytesControl(),
-        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "named")]),
-        local_dram=LocalDramOptions(ctypes.addressof(local), [(16, "named")]),
+        KVCRConfig(nixl_agent_name="target", pool_layouts=[("named", 16)]),
+        local_dram=LocalDramOptions([("named", ctypes.addressof(local), 16)]),
     )
 
     with pytest.raises(ValueError, match="expected layout"):
@@ -476,7 +476,7 @@ def test_get_stats_emits_public_state_metric_name() -> None:
         FakeBytesControl(),
         KVCRConfig(
             nixl_agent_name="target",
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             enable_telemetry=True,
         ),
     )
@@ -521,7 +521,7 @@ def test_nixl_lifecycle_stays_on_progress_thread(
     kvcr = KVCR(
         KVCRConfig(
             nixl_agent_name="target",
-            pool_layout=[(64, "")],
+            pool_layouts=[("", 64)],
             nixl_listen_port=1234,
         ),
         KVCRBindings(
@@ -534,7 +534,7 @@ def test_nixl_lifecycle_stays_on_progress_thread(
         ),
         KVCRBackendConfigs(
             framework_dram=FrameworkDramInput(128, 256),
-            local_dram=LocalDramOptions(384, [(128, "")], "LOCAL"),
+            local_dram=LocalDramOptions([("", 384, 128)], "LOCAL"),
             remote_fw_dram=RemoteFWDramOptions(backend="REMOTE"),
         ),
     )

--- a/tests/unit/test_kvcr_remote_source.py
+++ b/tests/unit/test_kvcr_remote_source.py
@@ -54,7 +54,7 @@ def test_kvcr_start_write_respects_framework_pin_deadline(
         control,
         KVCRConfig(
             nixl_agent_name="source",
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             operation_timeout_ms=10_000,
         ),
         name="source",
@@ -298,7 +298,7 @@ def test_kvcr_source_timeout_holds_pins_until_safe_release(
         control,
         KVCRConfig(
             nixl_agent_name="source",
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             operation_timeout_ms=1000,
             enable_telemetry=True,
         ),
@@ -524,7 +524,7 @@ def test_source_telemetry_precedes_release_and_is_not_duplicated() -> None:
         control,
         KVCRConfig(
             nixl_agent_name="source",
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             enable_telemetry=True,
         ),
         name="source",

--- a/tests/unit/test_kvcr_remote_target.py
+++ b/tests/unit/test_kvcr_remote_target.py
@@ -127,7 +127,7 @@ def test_remote_fetch_uses_local_then_framework_sources() -> None:
         source_control,
         name="source",
         local_dram=LocalDramOptions(
-            ctypes.addressof(source_local), [(len(source_local), "")]
+            [("", ctypes.addressof(source_local), len(source_local))]
         ),
         policy=source_policy,
     )
@@ -142,7 +142,7 @@ def test_remote_fetch_uses_local_then_framework_sources() -> None:
             eager_ctrl_connect=False,
         ),
         local_dram=LocalDramOptions(
-            ctypes.addressof(target_local), [(len(target_local), "")]
+            [("", ctypes.addressof(target_local), len(target_local))]
         ),
         inventory_sink=events.append,
         policy=policy,
@@ -247,7 +247,7 @@ def test_remote_staging_commits_available_prefix() -> None:
         control,
         key_adapter=_ConstantHashAdapter(),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
-        local_dram=LocalDramOptions(ctypes.addressof(local), [(len(local), "")]),
+        local_dram=LocalDramOptions([("", ctypes.addressof(local), len(local))]),
         inventory_sink=events.append,
     )
     target.submit_hint(_router_hint("tcp://source:1"), request_id="req")
@@ -287,12 +287,12 @@ def test_remote_fetch_timeout_keeps_slot_until_source_is_terminal() -> None:
         control,
         KVCRConfig(
             nixl_agent_name="target",
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             operation_timeout_ms=10,
         ),
         key_adapter=_ConstantHashAdapter(),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
-        local_dram=LocalDramOptions(ctypes.addressof(local), [(len(local), "")]),
+        local_dram=LocalDramOptions([("", ctypes.addressof(local), len(local))]),
     )
     target._core._clock = lambda: now
     target.submit_hint(_router_hint("tcp://source:1"), request_id="req")
@@ -326,14 +326,14 @@ def test_kvcr_deliver_propagates_source_pin_miss():
         target_agent,
         FakePrimaryPinning(),
         target_control,
-        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
+        KVCRConfig(nixl_agent_name="target", pool_layouts=[("", 16)]),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
     )
     source = _new_kvcr(
         source_agent,
         source_pinning,
         source_control,
-        KVCRConfig(nixl_agent_name="source", pool_layout=[(16, "")]),
+        KVCRConfig(nixl_agent_name="source", pool_layouts=[("", 16)]),
         name="source",
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
     )
@@ -405,7 +405,7 @@ def test_only_a_refusal_from_this_operation_s_source_finishes_it():
         FakeNixlAgent(metadata=b"target-md"),
         FakePrimaryPinning(),
         control,
-        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
+        KVCRConfig(nixl_agent_name="target", pool_layouts=[("", 16)]),
     )
     now = [0.0]
     kvcr._core._clock = lambda: now[0]
@@ -446,7 +446,7 @@ def test_kvcr_metadata_ack_retry_lifecycle():
         agent,
         pinning,
         control,
-        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
+        KVCRConfig(nixl_agent_name="target", pool_layouts=[("", 16)]),
     )
     now = [0.0]
     kvcr._core._clock = lambda: now[0]
@@ -508,7 +508,7 @@ def test_kvcr_deliver_timeout_waits_for_terminal_notification(
         control,
         KVCRConfig(
             nixl_agent_name="target",
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             operation_timeout_ms=1000,
         ),
     )
@@ -596,7 +596,7 @@ def test_kvcr_deliver_fails_closed_on_mixed_hint_sources():
         agent,
         FakePrimaryPinning(),
         control,
-        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
+        KVCRConfig(nixl_agent_name="target", pool_layouts=[("", 16)]),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
     )
     key_a = _make_block_key(b"block-A", 0)
@@ -633,7 +633,7 @@ def test_kvcr_request_scoped_sources_do_not_overwrite():
         agent,
         FakePrimaryPinning(),
         control,
-        KVCRConfig(nixl_agent_name="target", pool_layout=[(16, "")]),
+        KVCRConfig(nixl_agent_name="target", pool_layouts=[("", 16)]),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
     )
     key = _make_block_key(b"shared-block", 0)
@@ -675,7 +675,7 @@ def test_remote_framework_dram_transfers_available_prefix(
         target_control,
         KVCRConfig(
             nixl_agent_name="target",
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             enable_telemetry=True,
         ),
         key_adapter=_ConstantHashAdapter(),
@@ -689,7 +689,7 @@ def test_remote_framework_dram_transfers_available_prefix(
         source_control,
         KVCRConfig(
             nixl_agent_name="source",
-            pool_layout=[(16, "")],
+            pool_layouts=[("", 16)],
             enable_telemetry=True,
         ),
         name="source",

--- a/tests/unit/test_kvcr_service.py
+++ b/tests/unit/test_kvcr_service.py
@@ -63,10 +63,10 @@ _TEST_GUARD_COUNT = 2
 _TEST_JOURNAL_BYTES = 8192
 _TEST_POOL_SIZE_BYTES = 8192
 _TEST_POOL_SIZES_BYTES = (_TEST_POOL_SIZE_BYTES,)
-_TEST_ROW_STRIDE = 1024
-_TEST_POOL_LAYOUT = [(_TEST_ROW_STRIDE, "")]
+_TEST_BLOCK_SIZE_BYTES = 1024
+_TEST_POOL_LAYOUTS = [("", _TEST_BLOCK_SIZE_BYTES)]
 _TEST_DIGEST = "opaque digest: Preserve-Me EXACTLY"
-_TEST_TIER_CONFIG = _TierConfig(_TEST_POOL_LAYOUT, None)
+_TEST_TIER_CONFIG = _TierConfig(_TEST_POOL_LAYOUTS, None)
 # G3 terms are refused at decode unless a real claimant could open them, so
 # the one claim that carries G3 uses a page-aligned stride.
 _PAGE_STRIDE = os.sysconf("SC_PAGE_SIZE")
@@ -277,7 +277,7 @@ def test_registry_lifecycle_from_independent_leases_to_a_wedged_close(
     first_spec, stale = _claim(registry, 0, first)
     _spec, _fd, _lease = registry.claim(
         1,
-        _TierConfig([(_TEST_ROW_STRIDE * 2, "")], None),
+        _TierConfig([("", _TEST_BLOCK_SIZE_BYTES * 2)], None),
         second,
         _control_bind(1),
     )
@@ -343,11 +343,13 @@ def test_refused_claims_do_not_bind_the_pool(tmp_path: Path) -> None:
 
         taken = (str(squatter.getsockname()[0]), int(squatter.getsockname()[1]))
         with pytest.raises(KVCRServiceError, match="control listener"):
-            harness.client.claim(0, _TEST_POOL_LAYOUT, _TEST_DIGEST, control_bind=taken)
+            harness.client.claim(
+                0, _TEST_POOL_LAYOUTS, _TEST_DIGEST, control_bind=taken
+            )
 
         # The rejected claims left the pool free to take normally.
         harness.client.claim(
-            0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind()
+            0, _TEST_POOL_LAYOUTS, _TEST_DIGEST, _control_bind()
         ).release()
 
 
@@ -401,11 +403,11 @@ def test_a_grant_tells_the_pools_guard_and_a_clean_release_stands_it_down(
         assert guard._phase is _Phase.UNCONFIGURED
 
         hold = harness.client.claim(
-            1, [(_PAGE_STRIDE, "")], _TEST_DIGEST, _control_bind(), g3
+            1, [("", _PAGE_STRIDE)], _TEST_DIGEST, _control_bind(), g3
         )
         assert guard._phase is _Phase.PRIMARY and guard._control is control
         assert guard._configured == _TierConfig(
-            [(_PAGE_STRIDE, "")],
+            [("", _PAGE_STRIDE)],
             _G3Config(
                 paths=(str(g3.paths[0]),),
                 capacity_bytes_per_file=g3.capacity_bytes_per_file,
@@ -515,7 +517,7 @@ def test_a_standby_survives_failed_claims_and_hands_over_to_a_replacement(
         with pytest.raises(KVCRServiceError, match="another tier configuration"):
             registry.claim(
                 0,
-                _TierConfig([(_TEST_ROW_STRIDE * 2, "")], None),
+                _TierConfig([("", _TEST_BLOCK_SIZE_BYTES * 2)], None),
                 _FakeLiveness(),
                 control_bind,
             )
@@ -601,12 +603,12 @@ def test_claim_refusals_and_internal_failures_do_not_bind(
         spec = harness.server._registry._guards[0]._owner.spec
         with pytest.raises(KVCRServiceError, match="compatibility digest"):
             harness.client.claim(
-                0, _TEST_POOL_LAYOUT, _TEST_DIGEST.swapcase(), _control_bind()
+                0, _TEST_POOL_LAYOUTS, _TEST_DIGEST.swapcase(), _control_bind()
             )
         with pytest.raises(KVCRServiceError, match="one complete KV block"):
             harness.client.claim(
                 0,
-                [(_TEST_POOL_SIZE_BYTES + 1, "")],
+                [("", _TEST_POOL_SIZE_BYTES + 1)],
                 _TEST_DIGEST,
                 _control_bind(),
             )
@@ -621,7 +623,7 @@ def test_claim_refusals_and_internal_failures_do_not_bind(
             )
             with pytest.raises(KVCRServiceError, match="internal KVCR service error"):
                 harness.client.claim(
-                    0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind()
+                    0, _TEST_POOL_LAYOUTS, _TEST_DIGEST, _control_bind()
                 )
 
         log_record = next(
@@ -634,7 +636,7 @@ def test_claim_refusals_and_internal_failures_do_not_bind(
         assert harness.server._registry._guards[0]._owner.spec is spec
         assert _holders_of(harness.server._registry) == {}
         harness.client.claim(
-            0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind()
+            0, _TEST_POOL_LAYOUTS, _TEST_DIGEST, _control_bind()
         ).release()
 
 
@@ -692,7 +694,7 @@ def test_fork_and_exec_do_not_preserve_claimant_access(
                 "import time",
                 "from kvcr.guard_protocol import KVCRClient",
                 f"hold = KVCRClient({str(harness.server.socket_path)!r}).claim("
-                f"0, {_TEST_POOL_LAYOUT!r}, {_TEST_DIGEST!r}, {_control_bind()!r})",
+                f"0, {_TEST_POOL_LAYOUTS!r}, {_TEST_DIGEST!r}, {_control_bind()!r})",
                 "forked_pid = os.fork()",
                 "if forked_pid == 0:",
                 "    hold._connection.close()",
@@ -724,7 +726,7 @@ def test_fork_and_exec_do_not_preserve_claimant_access(
             assert spec.path not in Path(f"/proc/{forked_pid}/maps").read_text()
             with pytest.raises(KVCRServiceError, match="held"):
                 harness.client.claim(
-                    0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind()
+                    0, _TEST_POOL_LAYOUTS, _TEST_DIGEST, _control_bind()
                 )
 
             child.terminate()
@@ -1061,7 +1063,9 @@ def test_a_lease_older_than_the_idle_timeout_still_releases_cleanly(
     """The accept-time idle timeout must not sever a held connection."""
     monkeypatch.setattr("kvcr.kvcr_service._CLIENT_IDLE_TIMEOUT_SECONDS", 0.2)
     with _running_server(tmp_path) as harness:
-        hold = harness.client.claim(0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind())
+        hold = harness.client.claim(
+            0, _TEST_POOL_LAYOUTS, _TEST_DIGEST, _control_bind()
+        )
         time.sleep(0.5)
 
         hold.release()
@@ -1231,7 +1235,9 @@ def test_a_close_in_progress_absorbs_races_and_answers_stragglers(
 
 def test_shutdown_drains_a_held_connection(tmp_path: Path) -> None:
     with _running_server(tmp_path) as harness:
-        hold = harness.client.claim(0, _TEST_POOL_LAYOUT, _TEST_DIGEST, _control_bind())
+        hold = harness.client.claim(
+            0, _TEST_POOL_LAYOUTS, _TEST_DIGEST, _control_bind()
+        )
         harness.stop()
         _wait_for_connection_state(harness.server, connected=False)
         hold._attachment.close()

--- a/tests/unit/test_kvcr_service_workflow.py
+++ b/tests/unit/test_kvcr_service_workflow.py
@@ -33,7 +33,7 @@ from kvcr.config import KVCRBackendConfigs, KVCRConfig, KVCRGuardConfig
 from kvcr.control_channels import ZmqPeerControlChannel
 from kvcr.kvcr_service import _DEFAULT_JOURNAL_BYTES, _KVCRService
 
-_ROW_STRIDE = 1024
+_BLOCK_SIZE_BYTES = 1024
 _DIGEST = "opaque workflow digest: Preserve-Me EXACTLY"
 _JOURNAL_BYTES = 8192
 _POOL_SIZE_BYTES = 8192
@@ -76,7 +76,7 @@ def _claim_when_ready(
         try:
             return client.claim(
                 guard_index,
-                [(_ROW_STRIDE, "")],
+                [("", _BLOCK_SIZE_BYTES)],
                 _DIGEST,
                 _control_bind(guard_index),
             )
@@ -156,19 +156,20 @@ def test_pools_persist_bytes_and_a_held_pool_refuses_claims(tmp_path: Path) -> N
 
     with _running_service(pool_dir) as socket_path:
         client = KVCRClient(socket_path)
-        first = client.claim(0, [(_ROW_STRIDE, "")], _DIGEST, _control_bind(0))
-        second = client.claim(1, [(_ROW_STRIDE, "")], _DIGEST, _control_bind(1))
+        first = client.claim(0, [("", _BLOCK_SIZE_BYTES)], _DIGEST, _control_bind(0))
+        second = client.claim(1, [("", _BLOCK_SIZE_BYTES)], _DIGEST, _control_bind(1))
         try:
-            assert first.local_dram.address != second.local_dram.address
-            ctypes.memmove(first.local_dram.address, payload, len(payload))
+            first_address = first.local_dram.pools[0][1]
+            assert first_address != second.local_dram.pools[0][1]
+            ctypes.memmove(first_address, payload, len(payload))
 
             first.release()
             replacement = client.claim(
-                0, [(_ROW_STRIDE, "")], _DIGEST, _control_bind(0)
+                0, [("", _BLOCK_SIZE_BYTES)], _DIGEST, _control_bind(0)
             )
             try:
                 assert (
-                    ctypes.string_at(replacement.local_dram.address, len(payload))
+                    ctypes.string_at(replacement.local_dram.pools[0][1], len(payload))
                     == payload
                 )
             finally:
@@ -183,7 +184,7 @@ def test_pools_persist_bytes_and_a_held_pool_refuses_claims(tmp_path: Path) -> N
                 controller = KVCR(
                     KVCRConfig(
                         nixl_agent_name="target",
-                        pool_layout=[(_ROW_STRIDE, "")],
+                        pool_layouts=[("", _BLOCK_SIZE_BYTES)],
                         nixl_listen_port=1,
                     ),
                     KVCRBindings(
@@ -201,13 +202,15 @@ def test_pools_persist_bytes_and_a_held_pool_refuses_claims(tmp_path: Path) -> N
                 )
             try:
                 with pytest.raises(KVCRServiceError, match="held"):
-                    client.claim(0, [(_ROW_STRIDE, "")], _DIGEST, (host, port))
+                    client.claim(0, [("", _BLOCK_SIZE_BYTES)], _DIGEST, (host, port))
             finally:
                 controller.close()
                 control.close()
 
             # Closing the worker released the pool: the next claim is served.
-            reclaimed = client.claim(0, [(_ROW_STRIDE, "")], _DIGEST, (host, port))
+            reclaimed = client.claim(
+                0, [("", _BLOCK_SIZE_BYTES)], _DIGEST, (host, port)
+            )
             reclaimed.release()
         finally:
             second.release()
@@ -232,7 +235,9 @@ def test_cli_daemon_sets_geometry_and_restart_reclaims_only_unattached(
                 path.stat().st_size == _DEFAULT_JOURNAL_BYTES + pool_bytes
                 for path in pools
             )
-            assert hold.local_dram.pool_sizes_bytes == [(pool_bytes, "")]
+            pool_name, address, size_bytes = hold.local_dram.pools[0]
+            assert (pool_name, size_bytes) == ("", pool_bytes)
+            assert address > 0
 
             attached_pool = next(pool_dir.glob("kvcr-pool_0-*"))
             unclaimed_pool = next(pool_dir.glob("kvcr-pool_1-*"))

--- a/tests/unit/test_recovery_journal.py
+++ b/tests/unit/test_recovery_journal.py
@@ -279,7 +279,7 @@ def test_a_handback_region_lives_and_dies_inside_the_pool_file(tmp_path: Path) -
     """Replayed whole under its own terms, discardable when torn, gone once released."""
     with _attached(tmp_path) as pool:
         path = Path(pool._spec.path)
-        terms = canonical_pool_terms(_TEST_DIGEST, [(4096, "")], pool._spec)
+        terms = canonical_pool_terms(_TEST_DIGEST, [("", 4096)], pool._spec)
         assert list(read_recovery_snapshot(pool, terms)) == []
 
         records = {
@@ -301,8 +301,8 @@ def test_a_handback_region_lives_and_dies_inside_the_pool_file(tmp_path: Path) -
 
         # A slot number only means the same bytes under the same geometry.
         for other in (
-            canonical_pool_terms("another-digest", [(4096, "")], pool._spec),
-            canonical_pool_terms(_TEST_DIGEST, [(8192, "")], pool._spec),
+            canonical_pool_terms("another-digest", [("", 4096)], pool._spec),
+            canonical_pool_terms(_TEST_DIGEST, [("", 8192)], pool._spec),
         ):
             with pytest.raises(RecoveryJournalError, match="other terms"):
                 list(read_recovery_snapshot(pool, other))
@@ -328,7 +328,7 @@ def test_a_handback_region_lives_and_dies_inside_the_pool_file(tmp_path: Path) -
             region[: _SNAPSHOT_HEADER.size] = bytes(_SNAPSHOT_HEADER.size)
         with pytest.raises(RecoveryJournalTornError, match="unfinished"):
             list(read_recovery_snapshot(pool, terms))
-        assert read_handback(pool, _TEST_DIGEST, [(4096, "")])._records == {}
+        assert read_handback(pool, _TEST_DIGEST, [("", 4096)])._records == {}
         assert list(read_recovery_snapshot(pool, terms)) == []
 
         # A released region is truncated away, so it replays nothing.


### PR DESCRIPTION
Stacked on #19.

## Summary

- add `PoolBlockLayouts = list[tuple[str, int]]` for ordered `(pool_name, block_size_bytes)` entries
- add `LocalDramRegions = list[tuple[str, int, int]]` for ordered `(pool_name, address, size_bytes)` entries
- rename the collection API from `pool_layout` to `pool_layouts`
- replace `LocalDramOptions.address` and `pool_sizes_bytes` with `pools`
- keep `fetch(expected_layout)` as `list[str]` of ordered pool names

## Testing

- `277 passed`
- `ruff check src/kvcr tests/unit`
- `ruff format --check src/kvcr tests/unit`

This is a breaking pre-release API change and remains single-pool at runtime until the Guard/service implementation lands.
