### PR TITLE
Used a class to pass parsing results to core.py, and some clean ups.

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -11,11 +11,10 @@ without editing source code in any of those projects.
 > merged and released in vLLM.
 
 > [!WARNING]
-> [KVCR PR #18](https://github.com/ai-dynamo/kvcr/pull/18) adopts the versioned
-> Dynamo-to-KVCR KV hint contract. Once that KVCR change is merged, use Dynamo with
-> [PR #13134](https://github.com/ai-dynamo/dynamo/pull/13134), or a later Dynamo
-> release that includes it. Older Dynamo versions produce an incompatible KV hint
-> contract, so KVCR cannot perform remote reuse.
+> KVCR uses the versioned Dynamo-to-KVCR KV hint contract introduced by
+> [Dynamo `8b030e0`](https://github.com/ai-dynamo/dynamo/commit/8b030e0ec138724e8427099c8710e90c5b5d3d93).
+> Use that revision or later; older versions produce incompatible hints, so KVCR
+> cannot perform remote reuse.
 
 For source builds, editable installs, API development, or test workflows, use
 the [developer guide](dev-guide.md).

--- a/src/kvcr/core.py
+++ b/src/kvcr/core.py
@@ -16,7 +16,7 @@ from .config import (
     TelemetryStats,
     _validate_pool_layouts,
 )
-from .hint_parser import _parse_kv_hint
+from .hint_parser import _KVFetchHint
 from .local_disk import _G3, _G3Residency
 from .local_dram import _LocalDram, _LocalDramResidency, _LocalDramState
 from .policy import G3LRUPolicy, LRUPolicy
@@ -315,11 +315,10 @@ class _KVCRCore:
         hints: Mapping[str, object],
         request_id: str | None = None,
     ) -> None:
-        src, block_hashes, mode = _parse_kv_hint(hints)
-        # TODO: Let policy consume mode="move" and no_retain hints.
-        if mode != "copy":
-            raise ValueError("only copy mode is currently supported")
-        self._remote_fw_dram.submit_hint(src, block_hashes, request_id)
+        hint = _KVFetchHint.from_hint(hints)
+        self._remote_fw_dram.submit_hint(
+            hint.source_endpoint, hint.block_hashes, request_id
+        )
 
     def discard_hint(self, request_id: str) -> None:
         self._remote_fw_dram.discard_hint(request_id)

--- a/src/kvcr/hint_parser.py
+++ b/src/kvcr/hint_parser.py
@@ -4,7 +4,7 @@
 """Parse KV hint envelopes for KVCR fetch metadata.
 
 Hints are advisory request metadata. This module validates versioned KV hint
-envelopes, extracts the first usable ``kv.fetch`` action, and parses the
+envelopes, extracts the first ``kv.fetch`` action, and parses the
 fields KVCR consumes. Integration constants are exported by ``kvcr.__init__``.
 """
 
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
+from dataclasses import dataclass
 
 # Public integration constants exported by kvcr.__init__.
 ROUTER_HINT_KEY = "kv_hint"
@@ -28,14 +29,6 @@ logger = logging.getLogger(__name__)
 _LOGGED_HINT_ISSUES: set[str] = set()
 
 
-def _warn_once(issue: str, message: str, *args: object) -> None:
-    """Log a parser warning at most once per issue kind."""
-    if issue in _LOGGED_HINT_ISSUES:
-        return
-    _LOGGED_HINT_ISSUES.add(issue)
-    logger.warning(message, *args)
-
-
 def _warn_version_mismatch(
     *,
     supported: object,
@@ -44,103 +37,88 @@ def _warn_version_mismatch(
     message: str,
 ) -> None:
     """Warn once when a supported schema version does not match received value."""
-    if received == supported:
+    if received == supported or issue in _LOGGED_HINT_ISSUES:
         return
-    _warn_once(issue, message, supported, received)
+    _LOGGED_HINT_ISSUES.add(issue)
+    logger.warning(message, supported, received)
 
 
-def _parse_kv_hint(
-    hint: Mapping[str, object],
-) -> tuple[str | None, frozenset[int], str]:
-    """Parse a KV hint envelope into KVCR fetch metadata.
+@dataclass(frozen=True, slots=True)
+class _KVFetchHint:
+    """Fields KVCR currently supports from the first ``kv.fetch`` action."""
 
-    Hints are advisory and parsed on the request path. Version mismatches warn
-    once per issue kind and are interpreted with the schema KVCR currently
-    supports. KVCR consumes the first valid ``kv.fetch`` action in the envelope.
-    """
-    if not isinstance(hint, Mapping):
-        raise ValueError("invalid router hint")
+    source_endpoint: str
+    block_hashes: frozenset[int]
 
-    _warn_version_mismatch(
-        supported=_KV_HINT_PROTOCOL_VERSION,
-        received=hint.get("protocol_version"),
-        issue="protocol-version-mismatch",
-        message="KV hint protocol_version mismatch; supported=%r received=%r",
-    )
+    @classmethod
+    def from_hint(cls, hint: Mapping[str, object]) -> _KVFetchHint:
+        """Parse and validate a KV hint envelope."""
+        if not isinstance(hint, Mapping):
+            raise ValueError("invalid router hint")
 
-    fetch_payload = _extract_kv_fetch_payload(hint)
-    return _parse_fetch_payload(fetch_payload)
+        _warn_version_mismatch(
+            supported=_KV_HINT_PROTOCOL_VERSION,
+            received=hint.get("protocol_version"),
+            issue="protocol-version-mismatch",
+            message="KV hint protocol_version mismatch; supported=%r received=%r",
+        )
 
+        actions = hint.get("actions")
+        if not isinstance(actions, list):
+            raise ValueError("invalid router hint")
 
-def _parse_fetch_action(action: object) -> Mapping[str, object] | None:
-    """Parse one envelope action as a ``kv.fetch`` payload."""
-    if not isinstance(action, Mapping):
-        return None
-    if action.get("action_type") != _KV_FETCH_ACTION_TYPE:
-        return None
+        fetch_payload = None
+        for action in actions:
+            if not isinstance(action, Mapping):
+                continue
+            if action.get("action_type") != _KV_FETCH_ACTION_TYPE:
+                continue
+            _warn_version_mismatch(
+                supported=_KV_FETCH_ACTION_VERSION,
+                received=action.get("action_version"),
+                issue="fetch-version-mismatch",
+                message=(
+                    "kv.fetch action_version mismatch; supported=%r received=%r; "
+                    "processing with supported schema"
+                ),
+            )
+            fetch_payload = action.get("payload")
+            break
 
-    action_version = action.get("action_version")
-    _warn_version_mismatch(
-        supported=_KV_FETCH_ACTION_VERSION,
-        received=action_version,
-        issue=f"fetch-version-mismatch:{action_version}",
-        message=(
-            "kv.fetch action_version mismatch; supported=%r received=%r; "
-            "processing with supported schema"
-        ),
-    )
+        if not isinstance(fetch_payload, Mapping):
+            raise ValueError("invalid router hint")
 
-    fetch_payload = action.get("payload")
-    if not isinstance(fetch_payload, Mapping):
-        raise ValueError("invalid router hint")
-    return fetch_payload
+        # TODO: Add mode and no_retain when KVCR starts consuming them.
+        if "no_retain" in fetch_payload:
+            raise ValueError("no_retain is not currently supported")
 
+        mode = fetch_payload.get("mode", "copy")
+        if mode != "copy":
+            raise ValueError("only copy mode is currently supported")
 
-def _extract_kv_fetch_payload(
-    hint: Mapping[str, object],
-) -> Mapping[str, object]:
-    """Extract the first ``kv.fetch`` action payload from a hint envelope."""
-    actions = hint.get("actions")
-    if not isinstance(actions, list):
-        raise ValueError("invalid router hint")
+        source = fetch_payload.get("source_control_endpoint")
+        if source is None:
+            raise ValueError("source-less hints are not currently supported")
 
-    for action in actions:
-        payload = _parse_fetch_action(action)
-        if payload is not None:
-            return payload
-
-    raise ValueError("invalid router hint")
-
-
-def _parse_fetch_payload(
-    payload: Mapping[str, object],
-) -> tuple[str | None, frozenset[int], str]:
-    """Parse and validate fields from a ``kv.fetch`` action payload."""
-
-    source = payload.get("source_control_endpoint")
-    block_hashes = payload.get("block_hashes")
-    mode = payload.get("mode", "copy")
-    if (
-        not isinstance(source, str)
-        or not source
-        or not isinstance(block_hashes, list)
-        or not isinstance(mode, str)
-        or mode not in ("copy", "move")
-        or not isinstance(payload.get("no_retain", False), bool)
-    ):
-        raise ValueError("invalid router hint")
-
-    hashes: set[int] = set()
-    for block_hash in block_hashes:
+        block_hashes = fetch_payload.get("block_hashes")
         if (
-            isinstance(block_hash, bool)
-            or not isinstance(block_hash, int)
-            or not 0 <= block_hash < 1 << 64
+            not isinstance(source, str)
+            or not source
+            or not isinstance(block_hashes, list)
         ):
             raise ValueError("invalid router hint")
-        hashes.add(block_hash)
-    if not hashes:
-        raise ValueError("invalid router hint")
 
-    # Add other fields to the parsed result when KVCR starts consuming them.
-    return source, frozenset(hashes), mode
+        hashes: set[int] = set()
+        for block_hash in block_hashes:
+            if (
+                isinstance(block_hash, bool)
+                or not isinstance(block_hash, int)
+                or not 0 <= block_hash < 1 << 64
+            ):
+                raise ValueError("invalid router hint")
+            hashes.add(block_hash)
+        if not hashes:
+            raise ValueError("invalid router hint")
+
+        # Add other fields to the parsed result when KVCR starts consuming them.
+        return cls(source, frozenset(hashes))

--- a/tests/unit/_kvcr_test_utils.py
+++ b/tests/unit/_kvcr_test_utils.py
@@ -48,19 +48,12 @@ _HANDED_OUT: set[int] = set()
 def _router_hint(
     source: str | None,
     block_hashes: Collection[int] = (123,),
-    *,
-    mode: str = "copy",
-    no_retain: bool | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "block_hashes": list(block_hashes),
     }
     if source is not None:
         payload["source_control_endpoint"] = source
-    if mode != "copy":
-        payload["mode"] = mode
-    if no_retain is not None:
-        payload["no_retain"] = no_retain
     return {
         "protocol_version": "0.1",
         "message_id": "test-message",

--- a/tests/unit/test_hint_parser.py
+++ b/tests/unit/test_hint_parser.py
@@ -2,16 +2,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import logging
-from collections.abc import Callable
+from typing import cast
 
 import pytest
 from _kvcr_test_utils import _router_hint
 
-from kvcr.hint_parser import _LOGGED_HINT_ISSUES, _parse_kv_hint
+from kvcr.hint_parser import _LOGGED_HINT_ISSUES, _KVFetchHint
 
 
-def test_parse_kv_hint_extracts_first_fetch_action() -> None:
+def test_kv_fetch_hint_parses_first_fetch_action() -> None:
     fetch_hint = _router_hint("tcp://source:1234", (123, 456, 123))
+    later_fetch_hint = _router_hint("tcp://other:1234", (789,))
     payload = {
         "protocol_version": "0.1",
         "message_id": "test-message",
@@ -23,46 +24,34 @@ def test_parse_kv_hint_extracts_first_fetch_action() -> None:
                 "payload": {"opaque": True},
             },
             fetch_hint["actions"][0],
+            later_fetch_hint["actions"][0],
         ],
     }
 
-    assert _parse_kv_hint(payload) == (
-        "tcp://source:1234",
-        frozenset({123, 456}),
-        "copy",
+    assert _KVFetchHint.from_hint(payload) == _KVFetchHint(
+        source_endpoint="tcp://source:1234",
+        block_hashes=frozenset({123, 456}),
     )
 
 
-@pytest.mark.parametrize(
-    ("mutate_hint", "warning_text"),
-    [
-        (
-            lambda kv_hint: kv_hint.__setitem__("protocol_version", "9.0"),
-            "KV hint protocol_version mismatch",
-        ),
-        (
-            lambda kv_hint: kv_hint["actions"][0].__setitem__(
-                "action_version", "2.0"
-            ),
-            "kv.fetch action_version mismatch",
-        ),
-    ],
-)
-def test_parse_kv_hint_warns_but_reads_mismatched_versions(
+def test_kv_fetch_hint_warns_once_per_mismatched_version_field(
     caplog: pytest.LogCaptureFixture,
-    mutate_hint: Callable[[dict[str, object]], None],
-    warning_text: str,
 ) -> None:
-    """Treat envelope/action version mismatches as advisory, not fatal."""
     _LOGGED_HINT_ISSUES.clear()
     kv_hint = _router_hint("tcp://source:1234", (123,))
-    mutate_hint(kv_hint)
+    action = cast(list[dict[str, object]], kv_hint["actions"])[0]
+    kv_hint["protocol_version"] = "9.0"
+    action["action_version"] = "2.0"
 
     with caplog.at_level(logging.WARNING):
-        parsed = _parse_kv_hint(kv_hint)
+        parsed = _KVFetchHint.from_hint(kv_hint)
+        kv_hint["protocol_version"] = "10.0"
+        action["action_version"] = "3.0"
+        _KVFetchHint.from_hint(kv_hint)
 
-    assert parsed == ("tcp://source:1234", frozenset({123}), "copy")
-    assert warning_text in caplog.text
+    assert parsed == _KVFetchHint("tcp://source:1234", frozenset({123}))
+    assert caplog.text.count("KV hint protocol_version mismatch") == 1
+    assert caplog.text.count("kv.fetch action_version mismatch") == 1
 
 
 @pytest.mark.parametrize(
@@ -95,9 +84,9 @@ def test_parse_kv_hint_warns_but_reads_mismatched_versions(
         },
     ],
 )
-def test_parse_kv_hint_rejects_invalid_protocol(kv_hint: object) -> None:
+def test_kv_fetch_hint_rejects_invalid_envelope(kv_hint: object) -> None:
     with pytest.raises(ValueError, match="invalid router hint"):
-        _parse_kv_hint(kv_hint)  # type: ignore[arg-type]
+        _KVFetchHint.from_hint(kv_hint)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(
@@ -112,12 +101,16 @@ def test_parse_kv_hint_rejects_invalid_protocol(kv_hint: object) -> None:
         {
             "source_control_endpoint": "tcp://source:1",
             "block_hashes": [1],
-            "mode": "invalid",
+            "mode": "move",
         },
-        {"block_hashes": [1], "no_retain": "yes"},
+        {
+            "source_control_endpoint": "tcp://source:1",
+            "block_hashes": [1],
+            "no_retain": True,
+        },
     ],
 )
-def test_parse_kv_hint_rejects_invalid_fetch_payload(fetch_payload: object) -> None:
+def test_kv_fetch_hint_rejects_invalid_payload(fetch_payload: object) -> None:
     """Reject malformed payloads on a matching ``kv.fetch`` action."""
     kv_hint = _router_hint("tcp://source:1")
     kv_hint["actions"] = [
@@ -129,5 +122,5 @@ def test_parse_kv_hint_rejects_invalid_fetch_payload(fetch_payload: object) -> N
         }
     ]
 
-    with pytest.raises(ValueError, match="invalid router hint"):
-        _parse_kv_hint(kv_hint)
+    with pytest.raises(ValueError):
+        _KVFetchHint.from_hint(kv_hint)

--- a/tests/unit/test_kvcr_remote_target.py
+++ b/tests/unit/test_kvcr_remote_target.py
@@ -59,19 +59,6 @@ def test_submit_hint_filters_unlisted_hash():
     assert target.query((BlockKey(b"k"),), "req") == [(QueryStatus.MISS, None)]
 
 
-def test_submit_hint_rejects_source_less_protocol_hint():
-    target = _new_kvcr(
-        FakeNixlAgent(),
-        FakePrimaryPinning(),
-        FakeBytesControl("tcp://target:1"),
-        key_adapter=_ConstantHashAdapter(),
-        remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
-    )
-
-    with pytest.raises(ValueError, match="invalid router hint"):
-        target.submit_hint(_router_hint(None, (1,), no_retain=True), request_id="req")
-
-
 def test_kvcr_opportunistic_query_accepts_key_outside_hint():
     control = FakeBytesControl("tcp://target:1")
     target = _new_kvcr(


### PR DESCRIPTION
Consolidates KV hint parsing into a validated object and rejects unsupported modes, no_retain, and source-less hints at the parser boundary. Removes redundant parsing and test plumbing, and updates the Quick Start with the compatible Dynamo revision.