### PR TITLE
Preserve remote G2 hits across missing keys

### DIFF
--- a/src/kvcr/remote_fw_dram.py
+++ b/src/kvcr/remote_fw_dram.py
@@ -59,6 +59,7 @@ class _RequestHint:
     block_hashes: frozenset[int]
     submitted_at: float | None
     failed: bool = False
+    missing_keys: frozenset[BlockKey] = frozenset()
 
 
 class _TargetPullState(Enum):
@@ -141,15 +142,15 @@ class _TargetPullOp(_RemoteOp):
                 )
             )
             try:
-                if success and "completed_count" in event:
-                    completed_count = _notification_completed_count(
+                if success:
+                    completed_indices = _notification_completed_indices(
                         event, len(self.ordered_keys)
                     )
-                    if set(self.ordered_keys) != self.keys:
-                        raise TypeError("missing ordered keys")
-                    completed_keys = set(self.ordered_keys[:completed_count])
+                    completed_keys = {
+                        self.ordered_keys[index] for index in completed_indices
+                    }
                 else:
-                    completed_keys = set(self.keys) if success else set()
+                    completed_keys = set()
             except TypeError:
                 success = False
                 completed_keys = set()
@@ -225,14 +226,13 @@ class _SourceWriteOp(_RemoteOp):
     state: _SourceWriteState
     remote_agent: bytes
     op_handle: int
-    ordered_keys: tuple[BlockKey, ...]
     dst_descriptors: tuple[tuple[MemDescriptor, ...], ...]
     _backend: "_RemoteFWDram" = field(repr=False, compare=False)
     framework_pins: set[PinHandle] = field(default_factory=set)
     src_descriptors: tuple[tuple[MemDescriptor, ...], ...] = ()
     transfer_id: int | None = None
     success: bool = False
-    completed_count: int = 0
+    completed_indices: tuple[int, ...] = ()
     route: tuple[str, int] = ("", 0)
 
     def progress(
@@ -266,22 +266,28 @@ class _SourceWriteOp(_RemoteOp):
                 # refusal instead of receiving the dead generation's bytes.
                 self.state = _SourceWriteState.NOTIFY_FAILURE
                 return False, True
+            if not self.src_descriptors:
+                backend._send_write_done(
+                    progress, self.remote_agent, self.op_handle, True
+                )
+                self.success = True
+                self.state = _SourceWriteState.FINISHED
+                backend._record_progress_duration(
+                    "source_write", self.started_at, "failed"
+                )
+                return True, True
             submit_started_at = backend._kvcr._timer()
             try:
                 transfer_id, submitted = progress.submit_transfer(
                     "WRITE",
                     tuple(chain.from_iterable(self.src_descriptors)),
-                    tuple(
-                        chain.from_iterable(
-                            self.dst_descriptors[: self.completed_count]
-                        )
-                    ),
+                    tuple(chain.from_iterable(self.dst_descriptors)),
                     remote_side_agent=self.remote_agent,
                     backend=backend._options.backend,
                     notif_msg=_write_done_notif(
                         self.op_handle,
                         True,
-                        completed_count=self.completed_count,
+                        completed_indices=self.completed_indices,
                     ),
                     capture_telemetry=backend._telemetry_enabled,
                 )
@@ -465,6 +471,7 @@ class _RemoteFWDram:
             request_hint is None
             or request_hint.source is None
             or request_hint.failed
+            or key in request_hint.missing_keys
             or adapter is None
         ):
             return False
@@ -491,7 +498,9 @@ class _RemoteFWDram:
         current_hint = (
             self._request_hints.get(request_id) if request_id is not None else None
         )
-        if current_hint is not None and current_hint.failed:
+        if current_hint is not None and (
+            current_hint.failed or current_hint.missing_keys.issuperset(keys)
+        ):
             kvcr._record_duration(scope, started_at, "failed")
             return False
 
@@ -654,17 +663,26 @@ class _RemoteFWDram:
         kvcr = self._kvcr
         kvcr._remove_block_dependencies(op)
         completed_keys = op.completed_keys if op.success else set()
-        if completed_keys != op.keys:
+        if not op.success:
             self._fail_request_hint(op.request_id)
+        elif (
+            op.request_id is not None
+            and (hint := self._request_hints.get(op.request_id)) is not None
+        ):
+            self._request_hints[op.request_id] = replace(
+                hint,
+                missing_keys=(hint.missing_keys | op.keys) - completed_keys,
+            )
         if op.local_fill:
-            completed_count = len(completed_keys)
-            if completed_count:
+            if completed_keys:
                 kvcr._complete_local_dram_fill(
-                    op.ordered_keys[:completed_count], success=True
+                    tuple(key for key in op.ordered_keys if key in completed_keys),
+                    success=True,
                 )
-            if completed_count < len(op.ordered_keys):
+            if completed_keys != op.keys:
                 kvcr._complete_local_dram_fill(
-                    op.ordered_keys[completed_count:], success=False
+                    tuple(key for key in op.ordered_keys if key not in completed_keys),
+                    success=False,
                 )
             return
         kvcr._complete(
@@ -672,7 +690,7 @@ class _RemoteFWDram:
             {
                 key: OpEntryResult(
                     OpEntryStatus.SUCCESS
-                    if bool(op.success) and key in completed_keys
+                    if key in completed_keys
                     else OpEntryStatus.FAILED
                 )
                 for key in op.keys
@@ -979,12 +997,12 @@ class _RemoteFWDram:
             and record.fw_mem is not None
         }
         sources = {} if force_failure else {**framework_sources, **local_sources}
-        completed_count = 0
+        completed_indices = []
         for index, key in enumerate(source_pin.ordered_keys):
             source = sources.get(key)
             destination = source_pin.dst_descriptors[index]
             if source is None:
-                break
+                continue
             if [descriptor.info for descriptor in source] != [
                 descriptor.info for descriptor in destination
             ]:
@@ -993,9 +1011,11 @@ class _RemoteFWDram:
                     source_pin.op_handle,
                     key,
                 )
-                break
-            completed_count += 1
-        completed_keys = source_pin.ordered_keys[:completed_count]
+                continue
+            completed_indices.append(index)
+        completed_keys = tuple(
+            source_pin.ordered_keys[index] for index in completed_indices
+        )
 
         kvcr._release_local_dram_sources(
             source_pin.op_id, local_sources.keys() - set(completed_keys)
@@ -1019,7 +1039,7 @@ class _RemoteFWDram:
         source_write = _SourceWriteOp(
             state=(
                 _SourceWriteState.READY_TO_WRITE
-                if completed_keys
+                if not force_failure
                 else _SourceWriteState.NOTIFY_FAILURE
             ),
             keys=set(completed_keys or source_pin.ordered_keys),
@@ -1028,13 +1048,14 @@ class _RemoteFWDram:
             op_id=source_pin.op_id,
             remote_agent=source_pin.remote_agent,
             op_handle=source_pin.op_handle,
-            ordered_keys=source_pin.ordered_keys,
-            dst_descriptors=source_pin.dst_descriptors,
+            dst_descriptors=tuple(
+                source_pin.dst_descriptors[index] for index in completed_indices
+            ),
             route=source_pin.route,
             _backend=self,
             framework_pins=framework_pins,
             src_descriptors=tuple(tuple(sources[key]) for key in completed_keys),
-            completed_count=len(completed_keys),
+            completed_indices=tuple(completed_indices),
         )
         kvcr._add_block_dependencies(source_write, new_operation=True)
         self._fw_pins_by_op[source_write.op_id] = set(source_write.framework_pins)
@@ -1635,29 +1656,33 @@ def _message_keys(payload: Mapping[str, Any]) -> tuple[BlockKey, ...]:
 def _write_done_notif(
     op_handle: OpHandle,
     success: bool,
-    completed_count: int | None = None,
+    completed_indices: tuple[int, ...] = (),
 ) -> bytes:
     payload: dict[str, Any] = {
         "type": "write_done",
         "op_handle": op_handle,
         "success": success,
     }
-    if completed_count is not None:
-        payload["completed_count"] = completed_count
+    if success:
+        payload["completed_indices"] = completed_indices
     return _NOTIF_PREFIX + msgspec.msgpack.encode(payload)
 
 
-def _notification_completed_count(
+def _notification_completed_indices(
     payload: Mapping[str, Any], requested_count: int
-) -> int:
-    completed_count = payload.get("completed_count")
+) -> list[int]:
+    indices = payload.get("completed_indices")
     if (
-        isinstance(completed_count, bool)
-        or not isinstance(completed_count, int)
-        or not 0 <= completed_count <= requested_count
+        not isinstance(indices, list)
+        or len(indices) > requested_count
+        or any(
+            type(index) is not int or not 0 <= index < requested_count
+            for index in indices
+        )
+        or len(set(indices)) != len(indices)
     ):
-        raise TypeError("invalid completed count")
-    return completed_count
+        raise TypeError("invalid completed indices")
+    return indices
 
 
 def _decode_notif(notif: bytes) -> dict[str, Any] | None:

--- a/src/kvcr/remote_fw_dram.py
+++ b/src/kvcr/remote_fw_dram.py
@@ -93,6 +93,7 @@ class _TargetPullOp(_RemoteOp):
     local_fill: bool
     remote_ctrl_ep: str
     _backend: "_RemoteFWDram" = field(repr=False, compare=False)
+    # Keys sent to the source; keys also includes remembered misses.
     ordered_keys: tuple[BlockKey, ...] = ()
     dst_descriptors: tuple[tuple[MemDescriptor, ...], ...] = ()
     request_id: str | None = None
@@ -134,7 +135,7 @@ class _TargetPullOp(_RemoteOp):
             _TargetPullState.WAITING_WRITE_DONE,
             _TargetPullState.WAITING_TERMINAL,
         ) and isinstance(event, Mapping):
-            success = bool(event.get("success")) and (
+            success = event.get("success") is True and (
                 not self.local_fill
                 or (
                     self.state is _TargetPullState.WAITING_WRITE_DONE
@@ -493,13 +494,12 @@ class _RemoteFWDram:
     ) -> bool:
         kvcr = self._kvcr
         started_at = kvcr._timer()
-        keys = tuple(blocks)
         scope = "remote_fetch" if local_fill else "remote_deliver"
         current_hint = (
             self._request_hints.get(request_id) if request_id is not None else None
         )
         if current_hint is not None and (
-            current_hint.failed or current_hint.missing_keys.issuperset(keys)
+            current_hint.failed or current_hint.missing_keys.issuperset(blocks)
         ):
             kvcr._record_duration(scope, started_at, "failed")
             return False
@@ -507,6 +507,7 @@ class _RemoteFWDram:
         if current_hint is None or current_hint.source is None:
             kvcr._record_duration(scope, started_at, "failed")
             return False
+        keys = tuple(key for key in blocks if key not in current_hint.missing_keys)
         kvcr._record_duration("hint_wait", current_hint.submitted_at, "complete")
         if request_id is not None:
             self._request_hints[request_id] = replace(current_hint, submitted_at=None)
@@ -514,7 +515,7 @@ class _RemoteFWDram:
         op = _TargetPullOp(
             state=_TargetPullState.START_WRITE,
             local_fill=local_fill,
-            keys=set(keys),
+            keys=set(blocks),
             started_at=started_at,
             deadline=deadline,
             op_id=("target", op_handle),
@@ -595,7 +596,7 @@ class _RemoteFWDram:
                         raise RuntimeError(
                             "non-local target pull is waiting for terminal state"
                         )
-                    self._kvcr._discard_local_dram_fill(item.ordered_keys)
+                    self._kvcr._discard_local_dram_fill(item.keys)
                 elif item.state is _TargetPullState.FINISHED:
                     self._finish_target_pull(item)
                 else:
@@ -681,7 +682,7 @@ class _RemoteFWDram:
                 )
             if completed_keys != op.keys:
                 kvcr._complete_local_dram_fill(
-                    tuple(key for key in op.ordered_keys if key not in completed_keys),
+                    op.keys - completed_keys,
                     success=False,
                 )
             return

--- a/tests/unit/_kvcr_test_utils.py
+++ b/tests/unit/_kvcr_test_utils.py
@@ -422,15 +422,15 @@ def _write_done_notification(
     op_handle: int,
     *,
     success: bool = True,
-    completed_count: int | None = None,
+    completed_indices: tuple[int, ...] = (0,),
 ) -> bytes:
     payload = {
         "type": "write_done",
         "op_handle": op_handle,
         "success": success,
     }
-    if completed_count is not None:
-        payload["completed_count"] = completed_count
+    if success:
+        payload["completed_indices"] = completed_indices
     return b"KVCR:" + msgspec.msgpack.encode(payload)
 
 

--- a/tests/unit/test_kvcr_remote_source.py
+++ b/tests/unit/test_kvcr_remote_source.py
@@ -556,7 +556,9 @@ def test_pending_pin_waiters_share_partial_results_and_request_uncovered_keys(
         assert (
             _poll_until(source, lambda _: not _has_outstanding_operations(source)) == []
         )
-        assert [xfer[2] for xfer in agent.xfers] == [[0]]
+        assert [xfer[2] for xfer in agent.xfers] == [[0]] * (
+            2 if second_has_uncovered_key else 1
+        )
         expected_unpins = (
             {"pin-ab", "pin-c"} if second_has_uncovered_key else {"pin-ab"}
         )

--- a/tests/unit/test_kvcr_remote_target.py
+++ b/tests/unit/test_kvcr_remote_target.py
@@ -366,8 +366,13 @@ def test_remote_staging_commits_available_keys() -> None:
     ]
 
 
-@pytest.mark.parametrize("completed_indices", [(-1,), (2,), (True,), (0, 0)])
-def test_remote_completion_rejects_invalid_indices(completed_indices) -> None:
+@pytest.mark.parametrize(
+    ("completed_indices", "success"),
+    [((-1,), True), ((2,), True), ((True,), True), ((0, 0), True), ((0, 1), "false")],
+)
+def test_remote_completion_rejects_invalid_notification(
+    completed_indices, success
+) -> None:
     agent = FakeNixlAgent()
     control = FakeBytesControl()
     target = _new_kvcr(
@@ -383,7 +388,9 @@ def test_remote_completion_rejects_invalid_indices(completed_indices) -> None:
     )
     _wait_until(lambda: bool(control.sent))
     agent.notifs["source"] = [
-        _write_done_notification(op_handle, completed_indices=completed_indices)
+        _write_done_notification(
+            op_handle, completed_indices=completed_indices, success=success
+        )
     ]
     assert _poll_until(target, bool) == [
         (op_handle, _op_entries(dict.fromkeys(keys, False)))
@@ -523,6 +530,22 @@ def test_kvcr_deliver_propagates_source_pin_miss():
     )
     assert list(target.poll_completed()) == [(retry_handle, _op_entries({key: False}))]
     assert target_control.sent == []
+
+    other_destination = [_mem_descriptor(addr=256)]
+    mixed_handle = target.deliver(
+        {key: [_mem_descriptor()], other_group: other_destination}, request_id="req"
+    )
+    _wait_until(lambda: bool(target_control.sent))
+    message = _decode_control_message(target_control.sent[0][1])
+    assert message["keys"] == [other_group]
+    assert message["dst_descriptors"] == msgspec.to_builtins([other_destination])
+    target_agent.notifs["source"] = [_write_done_notification(mixed_handle)]
+    assert _poll_until(target, bool) == [
+        (mixed_handle, _op_entries({key: False, other_group: True}))
+    ]
+    assert target.query((key,), "req") == [(QueryStatus.MISS, None)]
+    assert not _has_outstanding_operations(target)
+
     target.submit_hint(_router_hint("tcp://source:1"), request_id="other")
     assert target.query((key,), "other") == [
         (QueryStatus.FETCHABLE, CacheTier.REMOTE_G2)

--- a/tests/unit/test_kvcr_remote_target.py
+++ b/tests/unit/test_kvcr_remote_target.py
@@ -318,13 +318,13 @@ def test_remote_fetch_preserves_block_layout_and_bytes(
         assert {name: memory.raw for name, memory in target_local.items()} == pool_data
 
 
-def test_remote_staging_commits_available_prefix() -> None:
+def test_remote_staging_commits_available_keys() -> None:
     block_size = 16
-    local = ctypes.create_string_buffer(block_size * 2)
+    local = ctypes.create_string_buffer(block_size * 3)
     agent = FakeNixlAgent()
     control = FakeBytesControl()
     events: list[InventoryEvent] = []
-    keys = (BlockKey(b"k0"), BlockKey(b"k1"))
+    keys = tuple(BlockKey(f"k{i}".encode()) for i in range(3))
     target = _new_kvcr(
         agent,
         FakePrimaryPinning(),
@@ -339,23 +339,56 @@ def test_remote_staging_commits_available_prefix() -> None:
     _wait_until(lambda: bool(control.sent))
     message = _decode_control_message(control.sent[0][1])
     agent.notifs["source"] = [
-        _write_done_notification(message["op_handle"], completed_count=1)
+        _write_done_notification(message["op_handle"], completed_indices=(0, 2))
     ]
 
     completed = _poll_until(target, lambda results: bool(results))
     assert len(completed) == 1 and completed[0][0] == fetch
     results = completed[0][1]
-    assert results[keys[0]].success
-    assert results[keys[0]].descriptors is not None
-    release_handle = results[keys[0]].release_handle
-    assert release_handle is not None
-    assert results[keys[1]] == OpEntryResult(OpEntryStatus.FAILED)
+    available = (keys[0], keys[2])
+    release_handles = []
+    for key in keys:
+        if key in available:
+            assert results[key].success
+            assert results[key].descriptors is not None
+            assert results[key].release_handle is not None
+            release_handles.append(results[key].release_handle)
+        else:
+            assert results[key] == OpEntryResult(OpEntryStatus.FAILED)
     assert target.query(keys, "req") == [
         (QueryStatus.HIT, CacheTier.LOCAL_G2),
         (QueryStatus.MISS, None),
+        (QueryStatus.HIT, CacheTier.LOCAL_G2),
     ]
-    assert events == [InventoryEvent(keys[:1], CacheTier.LOCAL_G2, False)]
-    assert target.release((release_handle,)) == [(release_handle, True)]
+    assert events == [InventoryEvent(available, CacheTier.LOCAL_G2, False)]
+    assert target.release(release_handles) == [
+        (handle, True) for handle in release_handles
+    ]
+
+
+@pytest.mark.parametrize("completed_indices", [(-1,), (2,), (True,), (0, 0)])
+def test_remote_completion_rejects_invalid_indices(completed_indices) -> None:
+    agent = FakeNixlAgent()
+    control = FakeBytesControl()
+    target = _new_kvcr(
+        agent,
+        FakePrimaryPinning(),
+        control,
+        remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
+    )
+    keys = (BlockKey(b"k0"), BlockKey(b"k1"))
+    target.submit_hint(_router_hint("tcp://source:1"), request_id="req")
+    op_handle = target.deliver(
+        {key: [_mem_descriptor()] for key in keys}, request_id="req"
+    )
+    _wait_until(lambda: bool(control.sent))
+    agent.notifs["source"] = [
+        _write_done_notification(op_handle, completed_indices=completed_indices)
+    ]
+    assert _poll_until(target, bool) == [
+        (op_handle, _op_entries(dict.fromkeys(keys, False)))
+    ]
+    assert not _has_outstanding_operations(target)
 
 
 @pytest.mark.parametrize(
@@ -436,6 +469,7 @@ def test_kvcr_deliver_propagates_source_pin_miss():
         FakePrimaryPinning(),
         target_control,
         KVCRConfig(nixl_agent_name="target", pool_layouts=[("", 16)]),
+        key_adapter=_ConstantHashAdapter(),
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
     )
     source = _new_kvcr(
@@ -446,7 +480,8 @@ def test_kvcr_deliver_propagates_source_pin_miss():
         name="source",
         remote_options=RemoteFWDramOptions(eager_ctrl_connect=False),
     )
-    key = BlockKey(b"k0")
+    key = _make_block_key(b"k0", 0)
+    other_group = _make_block_key(b"k0", 1)
 
     target.submit_hint(_router_hint("tcp://source:1"), request_id="req")
     op_handle = target.deliver(
@@ -468,14 +503,18 @@ def test_kvcr_deliver_propagates_source_pin_miss():
     assert _decode_notif(source_agent.sent_notifs[0][1]) == {
         "type": "write_done",
         "op_handle": op_handle,
-        "success": False,
+        "success": True,
+        "completed_indices": [],
     }
 
     target_agent.notifs["source"] = [source_agent.sent_notifs[0][1]]
     assert _poll_until(target, lambda completed: bool(completed)) == [
         (op_handle, _op_entries({key: False}))
     ]
-    assert target._core._remote_fw_dram._request_hints["req"].failed
+    assert target.query((key, other_group), "req") == [
+        (QueryStatus.MISS, None),
+        (QueryStatus.FETCHABLE, CacheTier.REMOTE_G2),
+    ]
 
     target_control.sent = []
     retry_handle = target.deliver(
@@ -484,6 +523,12 @@ def test_kvcr_deliver_propagates_source_pin_miss():
     )
     assert list(target.poll_completed()) == [(retry_handle, _op_entries({key: False}))]
     assert target_control.sent == []
+    target.submit_hint(_router_hint("tcp://source:1"), request_id="other")
+    assert target.query((key,), "other") == [
+        (QueryStatus.FETCHABLE, CacheTier.REMOTE_G2)
+    ]
+    target.submit_hint(_router_hint("tcp://source:1"), request_id="req")
+    assert target.query((key,), "req") == [(QueryStatus.FETCHABLE, CacheTier.REMOTE_G2)]
 
 
 def _acked_deliver(control, kvcr, source, key):
@@ -761,17 +806,17 @@ def test_kvcr_request_scoped_sources_do_not_overwrite():
 
 
 @pytest.mark.parametrize(
-    ("eager_ctrl_connect", "missing_indices", "completed_count"),
+    ("eager_ctrl_connect", "missing_indices"),
     [
-        (False, (), 2),
-        (True, (), 2),
-        (False, (1,), 1),
+        (False, ()),
+        (True, ()),
+        (False, (1,)),
+        (False, (0,)),
     ],
 )
-def test_remote_framework_dram_transfers_available_prefix(
+def test_remote_framework_dram_transfers_available_keys(
     eager_ctrl_connect: bool,
     missing_indices: tuple[int, ...],
-    completed_count: int,
 ) -> None:
     target_agent = FakeNixlAgent(metadata=b"target-md")
     source_agent = FakeNixlAgent(metadata=b"source-md")
@@ -805,10 +850,14 @@ def test_remote_framework_dram_transfers_available_prefix(
         remote_options=RemoteFWDramOptions(backend="REMOTE"),
     )
     source._core._clock = lambda: 0.0
-    keys = (BlockKey(b"k0"), BlockKey(b"k1"))
+    keys = tuple(_make_block_key(b"k0", index) for index in range(3))
+    completed_indices = [
+        index for index in range(len(keys)) if index not in missing_indices
+    ]
 
     target.submit_hint(_router_hint("tcp://source:1"), request_id="req")
     assert target.query(keys, "req") == [
+        (QueryStatus.FETCHABLE, CacheTier.REMOTE_G2),
         (QueryStatus.FETCHABLE, CacheTier.REMOTE_G2),
         (QueryStatus.FETCHABLE, CacheTier.REMOTE_G2),
     ]
@@ -830,7 +879,9 @@ def test_remote_framework_dram_transfers_available_prefix(
 
     assert _poll_until(source, lambda _: bool(source_agent.xfers)) == []
     assert source_agent.xfer_backends == [["REMOTE"]]
-    assert source_agent.xfers[0][2] == list(range(completed_count))
+    assert source_agent.xfers[0][3] == [
+        (8192 + index * 16, 16, 0) for index in completed_indices
+    ]
     notification = source_agent.xfers[0][5]
     assert notification is not None
 
@@ -843,9 +894,15 @@ def test_remote_framework_dram_transfers_available_prefix(
         (
             op_handle,
             _op_entries(
-                {key: index < completed_count for index, key in enumerate(keys)}
+                {key: index in completed_indices for index, key in enumerate(keys)}
             ),
         )
+    ]
+    assert target.query(keys, "req") == [
+        (QueryStatus.MISS, None)
+        if index in missing_indices
+        else (QueryStatus.FETCHABLE, CacheTier.REMOTE_G2)
+        for index in range(len(keys))
     ]
 
     source_stats = source.get_stats()
@@ -861,6 +918,6 @@ def test_remote_framework_dram_transfers_available_prefix(
     assert (
         "counter",
         TRANSFER_BLOCKS_METRIC,
-        completed_count,
+        len(completed_indices),
         ("remote_deliver",),
     ) in target_stats.records


### PR DESCRIPTION
Remote G2 previously stopped at the first missing key and invalidated the entire request hint, hiding other available blocks when callers queried different key groups or boundaries.

Transfer all available requested keys and report completed indices so the destination can handle each key independently. Remember misses per exact key within each request to prevent repeated failed fetches. Discarding or resubmitting the same-source hint clears those misses.