### PR TITLE
Minor fixes to local DRAM operation handling and remote write validation

### DIFF
--- a/src/kvcr/local_dram.py
+++ b/src/kvcr/local_dram.py
@@ -543,6 +543,7 @@ class _LocalDram:
                 if (
                     residency_op is not None
                     and key in residency_op.keys
+                    and key not in residency_op.results
                     # Capacity waiters never owned this fill, and the slot it
                     # holds is exactly what they are queued for.
                     and key not in residency_op.capacity_waiters
@@ -550,7 +551,11 @@ class _LocalDram:
                     residency_op.results[key] = OpEntryResult(OpEntryStatus.FAILED)
                     residency_ops[op_id] = residency_op
                 deliver_op = self._pending_deliver_ops.get(op_id)
-                if deliver_op is not None and key in deliver_op.keys:
+                if (
+                    deliver_op is not None
+                    and key in deliver_op.keys
+                    and key not in deliver_op.results
+                ):
                     deliver_op.results[key] = OpEntryResult(OpEntryStatus.FAILED)
                     deliver_ops[op_id] = deliver_op
 
@@ -638,9 +643,14 @@ class _LocalDram:
                 self._free(residency.slots)
                 failed.append(key)
 
+            # A batch waiting on other keys may have already resolved this key.
             for op_id in record.active_op_ids:
                 residency_op = self._pending_residency_ops.get(op_id)
-                if residency_op is not None and key in residency_op.keys:
+                if (
+                    residency_op is not None
+                    and key in residency_op.keys
+                    and key not in residency_op.results
+                ):
                     if key_success and (
                         residency_op.op_id[0] == "deposit"
                         or now < residency_op.deadline
@@ -664,7 +674,11 @@ class _LocalDram:
                     # just freed; _resume_capacity_waiters retries it below.
 
                 deliver_op = self._pending_deliver_ops.get(op_id)
-                if deliver_op is not None and key in deliver_op.keys:
+                if (
+                    deliver_op is not None
+                    and key in deliver_op.keys
+                    and key not in deliver_op.results
+                ):
                     if key_success:
                         deliver_keys.setdefault(op_id, []).append(key)
                     else:
@@ -819,6 +833,9 @@ class _LocalDram:
 
     def _expire_pending_ops(self, now: float) -> None:
         for residency_op in list(self._pending_residency_ops.values()):
+            # discard_fill() can finish other operations from this snapshot.
+            if residency_op.op_id not in self._pending_residency_ops:
+                continue
             if now < residency_op.deadline:
                 continue
             if residency_op.op_id[0] == "deposit":

--- a/src/kvcr/remote_fw_dram.py
+++ b/src/kvcr/remote_fw_dram.py
@@ -1014,10 +1014,9 @@ class _RemoteFWDram:
     ) -> None:
         started_at = self._kvcr._timer()
         received_at = self._kvcr._clock()
-        try:
-            op_handle = int(payload["op_handle"])
-        except (KeyError, TypeError, ValueError):
-            logger.warning("KVCR malformed start_write: missing op_handle")
+        op_handle = payload.get("op_handle")
+        if type(op_handle) is not int:
+            logger.warning("KVCR malformed start_write: invalid op_handle")
             return
         try:
             remaining_timeout_ms = payload["remaining_timeout_ms"]

--- a/tests/unit/test_kvcr_local_dram.py
+++ b/tests/unit/test_kvcr_local_dram.py
@@ -211,7 +211,6 @@ def test_failed_group_reservation_does_not_evict_a_partial_group() -> None:
     pools = [ctypes.create_string_buffer(8), ctypes.create_string_buffer(8)]
     source = ctypes.create_string_buffer(16)
     agent = FakeNixlAgent()
-    agent.state = "DONE"
     kvcr = _two_pool_kvcr(agent, pools)
     full, swa, grouped = (BlockKey(name) for name in (b"full", b"swa", b"grouped"))
     descriptors = [
@@ -219,9 +218,17 @@ def test_failed_group_reservation_does_not_evict_a_partial_group() -> None:
         _mem_descriptor(ctypes.addressof(source) + 8, 8, info="swa"),
     ]
 
-    for key, descriptor in ((full, descriptors[0]), (swa, descriptors[1])):
-        operation = kvcr.deposit({key: [descriptor]}, no_evict=key == swa)
-        _poll_until(kvcr, lambda done: operation in dict(done))
+    kvcr.deposit({full: [descriptors[0]], swa: [descriptors[1]]})
+    # Both batches reject full; only swa should be claimed after the fill.
+    fetch = kvcr.fetch((full, swa), expected_layout=["swa"])
+    duplicate = kvcr.deposit({full: [descriptors[1]], swa: [descriptors[1]]})
+    assert list(kvcr.poll_completed()) == []
+    agent.state = "DONE"
+    completed = dict(_poll_until(kvcr, lambda results: len(results) == 3))
+    assert completed[duplicate] == _op_entries({full: False, swa: True})
+    assert completed[fetch][full].status is OpEntryStatus.FAILED
+    claim = completed[fetch][swa]
+    assert claim.success
 
     operation = kvcr.deposit({grouped: descriptors})
     result = dict(_poll_until(kvcr, lambda done: operation in dict(done)))[operation]
@@ -234,6 +241,7 @@ def test_failed_group_reservation_does_not_evict_a_partial_group() -> None:
     assert dict(_poll_until(kvcr, lambda done: retry in dict(done)))[retry][
         grouped
     ].success
+    kvcr.release([claim.release_handle])
 
 
 def test_group_allocation_evicts_enough_whole_keys(monkeypatch) -> None:

--- a/tests/unit/test_kvcr_remote_source.py
+++ b/tests/unit/test_kvcr_remote_source.py
@@ -348,14 +348,21 @@ def test_kvcr_source_ignores_malformed_control_messages():
     control.incoming.append(b"\xff\xff\xff not msgpack")
     control.incoming.append(msgspec.msgpack.encode(b"top-level-not-dict"))
     control.incoming.append(msgspec.msgpack.encode({"type": "unknown"}))
+    control.incoming.append(
+        msgspec.msgpack.encode({"type": "start_write", "op_handle": float("inf")})
+    )
+    key = BlockKey(b"valid")
+    control.incoming.append(_start_write_message(1, key))
     kvcr = _new_kvcr(source_agent, pinning, control, name="source")
 
-    time.sleep(0.01)
-    assert list(kvcr.poll_completed()) == []
-    kvcr._core._progress.raise_if_failed()
-    assert source_agent.xfers == []
+    assert _poll_until(kvcr, lambda _: bool(source_agent.xfers)) == []
+    assert pinning.searches == [(key,)]
+    assert len(source_agent.xfers) == 1
     assert source_agent.sent_notifs == []
     assert pinning.unpins == []
+    source_agent.state = "DONE"
+    assert _poll_until(kvcr, lambda _: bool(pinning.unpins)) == []
+    assert pinning.unpins == ["pin"]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_kvcr_remote_target.py
+++ b/tests/unit/test_kvcr_remote_target.py
@@ -433,6 +433,8 @@ def test_remote_fetch_timeout_keeps_slot_until_source_is_terminal(
     target._core._clock = lambda: now
     target.submit_hint(_router_hint("tcp://source:1"), request_id="req")
     fetch = target.fetch((key,), request_id="req")
+    # Both callers share the pending fill and must each complete once.
+    second_fetch = target.fetch((key,), request_id="req")
     _wait_until(lambda: bool(control.sent))
     message = _decode_control_message(control.sent[0][1])
 
@@ -461,9 +463,10 @@ def test_remote_fetch_timeout_keeps_slot_until_source_is_terminal(
         _wait_until(lambda: not target._core._progress._completed.empty())
 
     now = 1.5  # Past T, but still inside the destination's grace period.
-    assert _poll_until(target, lambda completed: bool(completed)) == [
-        (fetch, _op_entries({key: False}))
-    ]
+    assert dict(_poll_until(target, lambda completed: len(completed) == 2)) == {
+        fetch: _op_entries({key: False}),
+        second_fetch: _op_entries({key: False}),
+    }
     if resolution != "queued":
         assert target.query((key,), "req") == [
             (QueryStatus.FETCHABLE, CacheTier.REMOTE_G2)


### PR DESCRIPTION
- Preserve resolved per-key results and avoid duplicate completion during shared-fill timeouts.
- Keep fetch retries queued during fill cleanup without blocking unrelated work.
- Reject non-integer handles in start_write and write_done, preserving valid notifications in the same batch.
- Extend existing tests to cover these cases.